### PR TITLE
Added --exec_cfg_path to Goby apps

### DIFF
--- a/src/version.h
+++ b/src/version.h
@@ -41,7 +41,7 @@ namespace goby
         ss << "This is Version " << goby::VERSION_STRING
            << " of the Goby Underwater Autonomy Project released on "
            << goby::VERSION_DATE
-           <<".\n See https://launchpad.net/goby to search for updates.";
+           <<".\n See https://github.com/GobySoft/goby3 to search for updates.";
         return ss.str();
     }
 }


### PR DESCRIPTION
This is to allow Goby apps to read their configuration from the output (pipe) of another binary/shell script, so that an arbitrary amount of preprocessing can be done to create the actual configuration used by the Goby application.