### PR TITLE
3.0 app lifecycle

### DIFF
--- a/src/apps/middleware/logger/logger.cpp
+++ b/src/apps/middleware/logger/logger.cpp
@@ -88,7 +88,7 @@ int main(int argc, char* argv[])
     sigset_t old_mask;
     pthread_sigmask(SIG_BLOCK, &new_mask, &old_mask);
 
-    std::thread t(std::bind(goby::run<goby::Logger>, argc, argv));
+    std::thread t([&argc, &argv]() { goby::run<goby::Logger>(argc, argv); });
 
     // unblock signals
     sigset_t empty_mask;

--- a/src/common/application_base.cpp
+++ b/src/common/application_base.cpp
@@ -80,11 +80,8 @@ goby::common::ApplicationBase::ApplicationBase(google::protobuf::Message* cfg /*
     catch (common::ConfigException& e)
     {
         // output all the available command line options
-        if (e.error())
-        {
-            std::cerr << od << "\n";
-            std::cerr << "Problem parsing command-line configuration: \n" << e.what() << "\n";
-        }
+        std::cerr << od << "\n";
+        std::cerr << "Problem parsing command-line configuration: \n" << e.what() << "\n";
         throw;
     }
 

--- a/src/common/configuration_reader.cpp
+++ b/src/common/configuration_reader.cpp
@@ -108,22 +108,16 @@ void goby::common::ConfigReader::read_cfg(int argc, char* argv[],
 
     if (var_map->count("help"))
     {
-        ConfigException e("");
-        e.set_error(false);
         std::cerr << *od_all << "\n";
         exit(EXIT_SUCCESS);
     }
     else if (var_map->count("example_config"))
     {
-        ConfigException e("");
-        e.set_error(false);
         get_example_cfg_file(message, &std::cout);
         exit(EXIT_SUCCESS);
     }
     else if (var_map->count("version"))
     {
-        ConfigException e("");
-        e.set_error(false);
         std::cout << goby::version_message() << std::endl;
         exit(EXIT_SUCCESS);
     }

--- a/src/common/configuration_reader.cpp
+++ b/src/common/configuration_reader.cpp
@@ -208,19 +208,8 @@ void goby::common::ConfigReader::read_cfg(int argc, char* argv[],
         }
 
         // now the proto message must have all required fields
-        if (check_required_configuration && !message->IsInitialized())
-        {
-            std::vector<std::string> errors;
-            message->FindInitializationErrors(&errors);
-
-            std::stringstream err_msg;
-            err_msg << "Configuration is missing required parameters: \n";
-            for (const std::string& s : errors)
-                err_msg << common::esc_red << s << "\n" << common::esc_nocolor;
-
-            err_msg << "Make sure you specified a proper `cfg_path` to the configuration file.";
-            throw(ConfigException(err_msg.str()));
-        }
+        if (check_required_configuration)
+            check_required_cfg(*message);
     }
 }
 
@@ -700,4 +689,21 @@ void goby::common::ConfigReader::wrap_description(std::string* description, int 
     std::string spaces(num_blanks, ' ');
     spaces += "# ";
     boost::replace_all(*description, "\n", "\n" + spaces);
+}
+
+void goby::common::ConfigReader::check_required_cfg(const google::protobuf::Message& message)
+{
+    if (!message.IsInitialized())
+    {
+        std::vector<std::string> errors;
+        message.FindInitializationErrors(&errors);
+
+        std::stringstream err_msg;
+        err_msg << "Configuration is missing required parameters: \n";
+        for (const std::string& s : errors)
+            err_msg << common::esc_red << s << "\n" << common::esc_nocolor;
+
+        err_msg << "Make sure you specified a proper `cfg_path` to the configuration file.";
+        throw(ConfigException(err_msg.str()));
+    }
 }

--- a/src/common/configuration_reader.cpp
+++ b/src/common/configuration_reader.cpp
@@ -111,21 +111,21 @@ void goby::common::ConfigReader::read_cfg(int argc, char* argv[],
         ConfigException e("");
         e.set_error(false);
         std::cerr << *od_all << "\n";
-        throw(e);
+        exit(EXIT_SUCCESS);
     }
     else if (var_map->count("example_config"))
     {
         ConfigException e("");
         e.set_error(false);
         get_example_cfg_file(message, &std::cout);
-        throw(e);
+        exit(EXIT_SUCCESS);
     }
     else if (var_map->count("version"))
     {
         ConfigException e("");
         e.set_error(false);
         std::cout << goby::version_message() << std::endl;
-        throw(e);
+        exit(EXIT_SUCCESS);
     }
 
     if (var_map->count("app_name"))

--- a/src/common/configuration_reader.h
+++ b/src/common/configuration_reader.h
@@ -53,13 +53,9 @@ namespace common
 class ConfigException : public Exception
 {
   public:
-    ConfigException(const std::string& s) : Exception(s), error_(true) {}
-
-    void set_error(bool b) { error_ = b; }
-    bool error() { return error_; }
+    ConfigException(const std::string& s) : Exception(s) {}
 
   private:
-    bool error_;
 };
 
 class ConfigReader

--- a/src/common/configuration_reader.h
+++ b/src/common/configuration_reader.h
@@ -71,6 +71,8 @@ class ConfigReader
                          boost::program_options::variables_map* var_map,
                          bool check_required_configuration = true);
 
+    static void check_required_cfg(const google::protobuf::Message& message);
+
     static void get_protobuf_program_options(boost::program_options::options_description& po_desc,
                                              const google::protobuf::Descriptor* desc);
 

--- a/src/common/configuration_reader.h
+++ b/src/common/configuration_reader.h
@@ -147,6 +147,25 @@ class ConfigReader
             }
         }
     }
+
+    // special case for bool presence/absence when default is false
+    // for example, for the bool field "foo", "--foo" is true and omitting "--foo" is false, rather than --foo=true/false
+    static void set_single_option(boost::program_options::options_description& po_desc,
+                                  const google::protobuf::FieldDescriptor* field_desc,
+                                  bool default_value, const std::string& name,
+                                  const std::string& description)
+    {
+        if (!field_desc->is_repeated() && field_desc->has_default_value() && default_value == false)
+        {
+            po_desc.add_options()(
+                name.c_str(), boost::program_options::bool_switch()->default_value(default_value),
+                description.c_str());
+        }
+        else
+        {
+            set_single_option<bool>(po_desc, field_desc, default_value, name, description);
+        }
+    }
 };
 } // namespace common
 } // namespace goby

--- a/src/common/configurator.h
+++ b/src/common/configurator.h
@@ -1,0 +1,104 @@
+// Copyright 2009-2018 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (2013-)
+//                     Massachusetts Institute of Technology (2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Goby Underwater Autonomy Project Libraries
+// ("The Goby Libraries").
+//
+// The Goby Libraries are free software: you can redistribute them and/or modify
+// them under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// The Goby Libraries are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Goby.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef CONFIGURATOR_20181205H
+#define CONFIGURATOR_20181205H
+
+#include "goby/common/configuration_reader.h"
+#include "goby/common/core_helpers.h"
+#include "goby/common/protobuf/app3.pb.h"
+
+namespace goby
+{
+namespace common
+{
+template <typename Config> class ProtobufConfigurator
+{
+  public:
+    ProtobufConfigurator(int argc, char* argv[]);
+
+    const Config& cfg()
+    {
+        if (!config_finalized_)
+        {
+            finalize_configuration(cfg_);
+            common::ConfigReader::check_required_cfg(cfg_);
+            config_finalized_ = true;
+        }
+
+        return cfg_;
+    }
+    const goby::protobuf::App3Config& app3_config() { return cfg().app(); }
+
+  protected:
+    // override to finalize the configuration at runtime
+    virtual void finalize_configuration(Config& cfg) {}
+
+  private:
+    bool config_finalized_{false};
+    Config cfg_;
+};
+
+template <typename Config>
+ProtobufConfigurator<Config>::ProtobufConfigurator(int argc, char* argv[])
+{
+    //
+    // read the configuration
+    //
+    boost::program_options::options_description od("Allowed options");
+    boost::program_options::variables_map var_map;
+    try
+    {
+        std::string application_name;
+
+        // we will check it later
+        bool check_required_cfg = false;
+        common::ConfigReader::read_cfg(argc, argv, &cfg_, &application_name, &od, &var_map,
+                                       check_required_cfg);
+
+        cfg_.mutable_app()->set_name(application_name);
+        // incorporate some parts of the AppBaseConfig that are common
+        // with gobyd (e.g. Verbosity)
+        merge_app_base_cfg(cfg_.mutable_app(), var_map);
+
+        if (cfg_.app().debug_cfg())
+        {
+            std::cout << cfg_.DebugString() << std::endl;
+            exit(EXIT_SUCCESS);
+        }
+    }
+    catch (common::ConfigException& e)
+    {
+        // output all the available command line options
+        if (e.error())
+        {
+            std::cerr << od << "\n";
+            std::cerr << "Problem parsing command-line configuration: \n" << e.what() << "\n";
+        }
+        throw;
+    }
+}
+
+} // namespace common
+} // namespace goby
+
+#endif

--- a/src/common/core_helpers.h
+++ b/src/common/core_helpers.h
@@ -59,7 +59,8 @@ void merge_app_base_cfg(AppBaseConfig* base_cfg,
     {
         base_cfg->mutable_glog_config()->set_show_gui(true);
     }
-    else if (var_map.count("verbose"))
+
+    if (var_map.count("verbose"))
     {
         switch (var_map["verbose"].as<std::string>().size())
         {
@@ -83,8 +84,6 @@ void merge_app_base_cfg(AppBaseConfig* base_cfg,
         }
     }
 
-    //            if(var_map.count("no_db"))
-    //                base_cfg->mutable_database_config()->set_using_database(false);
 }
 
 } // namespace common

--- a/src/middleware/multi-thread-application.h
+++ b/src/middleware/multi-thread-application.h
@@ -114,8 +114,8 @@ class MultiThreadApplicationBase : public goby::common::ApplicationBase3<Config,
     }
 
     MultiThreadApplicationBase(boost::units::quantity<boost::units::si::frequency> loop_freq,
-                               Transporter* transporter, bool check_required_configuration = true)
-        : goby::common::ApplicationBase3<Config, StateMachine>(check_required_configuration),
+                               Transporter* transporter)
+        : goby::common::ApplicationBase3<Config, StateMachine>(),
           MainThreadBase(this->app_cfg(), transporter, loop_freq)
     {
         goby::glog.set_lock_action(goby::common::logger_lock::lock);
@@ -245,9 +245,8 @@ class MultiThreadStandaloneApplication
     {
     }
 
-    MultiThreadStandaloneApplication(boost::units::quantity<boost::units::si::frequency> loop_freq,
-                                     bool check_required_configuration = true)
-        : Base(loop_freq, &Base::interthread(), check_required_configuration)
+    MultiThreadStandaloneApplication(boost::units::quantity<boost::units::si::frequency> loop_freq)
+        : Base(loop_freq, &Base::interthread())
     {
     }
     virtual ~MultiThreadStandaloneApplication() {}

--- a/src/middleware/multi-thread-application.h
+++ b/src/middleware/multi-thread-application.h
@@ -262,7 +262,7 @@ template <class Config> class MultiThreadTest : public MultiThreadStandaloneAppl
   public:
     MultiThreadTest(
         boost::units::quantity<boost::units::si::frequency> loop_freq = 0 * boost::units::si::hertz)
-        : Base(loop_freq, false)
+        : Base(loop_freq)
     {
     }
     virtual ~MultiThreadTest() {}

--- a/src/middleware/multi-thread-application.h
+++ b/src/middleware/multi-thread-application.h
@@ -87,8 +87,8 @@ class SimpleThread
         intervehicle_;
 };
 
-template <class Config, class Transporter, class StateMachine>
-class MultiThreadApplicationBase : public goby::common::ApplicationBase3<Config, StateMachine>,
+template <class Config, class Transporter>
+class MultiThreadApplicationBase : public goby::common::ApplicationBase3<Config>,
                                    public goby::Thread<Config, Transporter>
 {
   private:
@@ -115,7 +115,7 @@ class MultiThreadApplicationBase : public goby::common::ApplicationBase3<Config,
 
     MultiThreadApplicationBase(boost::units::quantity<boost::units::si::frequency> loop_freq,
                                Transporter* transporter)
-        : goby::common::ApplicationBase3<Config, StateMachine>(),
+        : goby::common::ApplicationBase3<Config>(),
           MainThreadBase(this->app_cfg(), transporter, loop_freq)
     {
         goby::glog.set_lock_action(goby::common::logger_lock::lock);
@@ -183,16 +183,16 @@ class MultiThreadApplicationBase : public goby::common::ApplicationBase3<Config,
     void _join_thread(const std::type_index& type_i, int index);
 };
 
-template <class Config, class StateMachine = goby::common::NullStateMachine>
+template <class Config>
 class MultiThreadApplication
     : public MultiThreadApplicationBase<
-          Config, InterVehicleForwarder<InterProcessPortal<InterThreadTransporter> >, StateMachine>
+          Config, InterVehicleForwarder<InterProcessPortal<InterThreadTransporter> > >
 {
   private:
     InterProcessPortal<InterThreadTransporter> interprocess_;
     InterVehicleForwarder<InterProcessPortal<InterThreadTransporter> > intervehicle_;
     using Base = MultiThreadApplicationBase<
-        Config, InterVehicleForwarder<InterProcessPortal<InterThreadTransporter> >, StateMachine>;
+        Config, InterVehicleForwarder<InterProcessPortal<InterThreadTransporter> > >;
 
   public:
     MultiThreadApplication(double loop_freq_hertz = 0)
@@ -232,12 +232,12 @@ class MultiThreadApplication
     }
 };
 
-template <class Config, class StateMachine = goby::common::NullStateMachine>
+template <class Config>
 class MultiThreadStandaloneApplication
-    : public MultiThreadApplicationBase<Config, InterThreadTransporter, StateMachine>
+    : public MultiThreadApplicationBase<Config, InterThreadTransporter>
 {
   private:
-    using Base = MultiThreadApplicationBase<Config, InterThreadTransporter, StateMachine>;
+    using Base = MultiThreadApplicationBase<Config, InterThreadTransporter>;
 
   public:
     MultiThreadStandaloneApplication(double loop_freq_hertz = 0)
@@ -295,14 +295,14 @@ struct ThreadTypeSelector<ThreadType, ThreadConfig, true>
 };
 } // namespace goby
 
-template <class Config, class Transporter, class StateMachine>
+template <class Config, class Transporter>
 std::exception_ptr
-    goby::MultiThreadApplicationBase<Config, Transporter, StateMachine>::thread_exception_(nullptr);
+    goby::MultiThreadApplicationBase<Config, Transporter>::thread_exception_(nullptr);
 
-template <class Config, class Transporter, class StateMachine>
+template <class Config, class Transporter>
 template <typename ThreadType, typename ThreadConfig, bool has_index>
-void goby::MultiThreadApplicationBase<Config, Transporter, StateMachine>::_launch_thread(
-    int index, const ThreadConfig& cfg)
+void goby::MultiThreadApplicationBase<Config, Transporter>::_launch_thread(int index,
+                                                                           const ThreadConfig& cfg)
 {
     std::type_index type_i = std::type_index(typeid(ThreadType));
 
@@ -334,8 +334,8 @@ void goby::MultiThreadApplicationBase<Config, Transporter, StateMachine>::_launc
     ++running_thread_count_;
 }
 
-template <class Config, class Transporter, class StateMachine>
-void goby::MultiThreadApplicationBase<Config, Transporter, StateMachine>::_join_thread(
+template <class Config, class Transporter>
+void goby::MultiThreadApplicationBase<Config, Transporter>::_join_thread(
     const std::type_index& type_i, int index)
 {
     if (!threads_.count(type_i) || !threads_[type_i].count(index))
@@ -368,8 +368,8 @@ void goby::MultiThreadApplicationBase<Config, Transporter, StateMachine>::_join_
     }
 }
 
-template <class Config, class Transporter, class StateMachine>
-void goby::MultiThreadApplicationBase<Config, Transporter, StateMachine>::quit(int return_value)
+template <class Config, class Transporter>
+void goby::MultiThreadApplicationBase<Config, Transporter>::quit(int return_value)
 {
     goby::glog.is(goby::common::logger::DEBUG1) &&
         goby::glog << "Requesting all threads shutdown cleanly..." << std::endl;
@@ -385,7 +385,7 @@ void goby::MultiThreadApplicationBase<Config, Transporter, StateMachine>::quit(i
         MainThreadBase::transporter().poll();
     }
 
-    goby::common::ApplicationBase3<Config, StateMachine>::quit(return_value);
+    goby::common::ApplicationBase3<Config>::quit(return_value);
 }
 
 #endif

--- a/src/middleware/single-thread-application.h
+++ b/src/middleware/single-thread-application.h
@@ -34,8 +34,8 @@
 
 namespace goby
 {
-template <class Config, class StateMachine = goby::common::NullStateMachine>
-class SingleThreadApplication : public goby::common::ApplicationBase3<Config, StateMachine>,
+template <class Config>
+class SingleThreadApplication : public goby::common::ApplicationBase3<Config>,
                                 public Thread<Config, InterVehicleForwarder<InterProcessPortal<> > >
 {
   private:

--- a/src/moos/goby_moos_app.h
+++ b/src/moos/goby_moos_app.h
@@ -762,9 +762,8 @@ void GobyMOOSAppSelector<MOOSAppType>::read_configuration(google::protobuf::Mess
 
         if (var_map.count("help"))
         {
-            goby::common::ConfigException e("");
-            e.set_error(false);
-            throw(e);
+            std::cerr << od_all << "\n";
+            exit(EXIT_SUCCESS);
         }
         else if (var_map.count("example_config"))
         {
@@ -873,8 +872,7 @@ void GobyMOOSAppSelector<MOOSAppType>::read_configuration(google::protobuf::Mess
     {
         // output all the available command line options
         std::cerr << od_all << "\n";
-        if (e.error())
-            std::cerr << "Problem parsing command-line configuration: \n" << e.what() << "\n";
+        std::cerr << "Problem parsing command-line configuration: \n" << e.what() << "\n";
 
         throw;
     }


### PR DESCRIPTION
As noted in #45 it is not practical for the ApplicationBase3::app_cfg() to be mutable as this requires thread synchronization, etc.

However, it is often useful to allow the Application to set or modify various configuration values as part of it's launch procedure.

Furthermore, we would like to go away from Protobuf as the only configuration option for goby applications.

In addition, it's desirable to preserve the existing functionality, namely that the configuration is available to the ApplicationBase3's subclass constructors.

Given these, this pull request implements the Configurator concept, which is an (optional, defaults to ProtobufConfigurator which provides fully backwards-compatible behavior) additional template parameter for goby::run. 

The Configurator must provide two methods at a minimum

```
// the application's configuration
const Config& cfg()
// the ApplicationBase3 configuration, which will probably move from Protobuf to a plain C++ struct in the future.
const goby::protobuf::App3Config& app3_config() { return cfg().app(); }
```

In this PR is the ProtobufConfigurator implementation of the Configurator concept, which provides the existing functionality for reading Protobuf TextFormat configuration files, merging them with the command line flags, etc. It provides a virtual method `finalize_configuration` for subclasses to do whatever work they need to at runtime to finalize the configuration.

This PR fixes #41, fixes #14 and fixes #45