### PR TITLE
Fix compiler errors from ToT Clang

### DIFF
--- a/src/middleware/poller.h
+++ b/src/middleware/poller.h
@@ -52,7 +52,7 @@ template <typename Transporter> class Poller : public PollerInterface
 
         int poll_items = 0;
         if (!inner_poll_items)
-            poll_items += static_cast<Transporter*>(this)->template _poll(lock);
+            poll_items += static_cast<Transporter*>(this)->_poll(lock);
 
         //            goby::glog.is(goby::common::logger::DEBUG3) && goby::glog << "Poller::transporter_poll(): " << typeid(*this).name() << " this: " << this << " (" << poll_items << " items) "<< " inner_poller_: " << inner_poller_ << " (" << inner_poll_items << " items) " << std::endl;
 

--- a/src/middleware/transport-interprocess.h
+++ b/src/middleware/transport-interprocess.h
@@ -112,7 +112,7 @@ class InterProcessTransporterBase
         static_cast<Derived*>(this)->template _unsubscribe<Data, scheme>(group);
     }
 
-    void unsubscribe_all() { static_cast<Derived*>(this)->template _unsubscribe_all(); }
+    void unsubscribe_all() { static_cast<Derived*>(this)->_unsubscribe_all(); }
 
     // Wildcards
     void subscribe_regex(std::function<void(const std::vector<unsigned char>&, int scheme,
@@ -121,7 +121,7 @@ class InterProcessTransporterBase
                          const std::set<int>& schemes, const std::string& type_regex = ".*",
                          const std::string& group_regex = ".*")
     {
-        static_cast<Derived*>(this)->template _subscribe_regex(f, schemes, type_regex, group_regex);
+        static_cast<Derived*>(this)->_subscribe_regex(f, schemes, type_regex, group_regex);
     }
 
     std::unique_ptr<InnerTransporter> own_inner_;


### PR DESCRIPTION
I tried building Goby3 with top-of-tree Clang (which will be Clang 8.0.0 eventually) and there were a few misuses of the `template` keyword I had to remove.