### PR TITLE
Move thread cleanup in MultiThreadApplication to finalize() method

### DIFF
--- a/src/common/application_base3.h
+++ b/src/common/application_base3.h
@@ -93,7 +93,7 @@ template <typename Config> class ApplicationBase3
     /// \brief Requests a clean exit.
     ///
     /// \param return_value The request return value
-    virtual void quit(int return_value = 0)
+    void quit(int return_value = 0)
     {
         alive_ = false;
         return_value_ = return_value;

--- a/src/middleware/transport-interprocess-zeromq.h
+++ b/src/middleware/transport-interprocess-zeromq.h
@@ -370,8 +370,6 @@ class InterProcessPortal
         auto it = forwarder_subscription_identifiers_[thread_id].find(identifier);
         if (it != forwarder_subscription_identifiers_[thread_id].end())
         {
-            forwarder_subscription_identifiers_[thread_id].erase(it);
-
             bool no_forwarder_subscribers = true;
             for (const auto& p : forwarder_subscription_identifiers_)
             {
@@ -392,6 +390,8 @@ class InterProcessPortal
                 if (portal_subscriptions_.count(identifier) == 0)
                     zmq_main_.unsubscribe(identifier);
             }
+
+            forwarder_subscription_identifiers_[thread_id].erase(it);
         }
     }
 

--- a/src/test/moos/translator1/test.cpp
+++ b/src/test/moos/translator1/test.cpp
@@ -456,6 +456,8 @@ int main(int argc, char* argv[])
            embedded_test.SerializePartialAsString());
 
     std::cout << "all tests passed" << std::endl;
+
+    dccl::DynamicProtobufManager::protobuf_shutdown();
 }
 
 void run_one_in_one_out_test(MOOSTranslator& translator, int i, bool hex_encode)


### PR DESCRIPTION
This allows subclasses to still override `finalize()` and do their own thread cleanup instead that requires synchronization outside of the usual Goby3 interthread pub/sub.

