### PR TITLE
Disable goby_test_single_thread_app1 under ThreadSanitizer

### DIFF
--- a/src/test/middleware/single_thread_app1/CMakeLists.txt
+++ b/src/test/middleware/single_thread_app1/CMakeLists.txt
@@ -5,3 +5,8 @@ target_link_libraries(goby_test_single_thread_app1 goby_middleware goby_common d
 
 add_test(goby_test_single_thread_app1 ${goby_BIN_DIR}/goby_test_single_thread_app1)
 
+# Disable the test when building with ThreadSanitizer
+# https://github.com/GobySoft/goby3/issues/68
+if(CMAKE_CXX_FLAGS MATCHES "(^| )-fsanitize=thread( |$)")
+  set_tests_properties(goby_test_single_thread_app1 PROPERTIES DISABLED true)
+endif()


### PR DESCRIPTION
This works around #68 by detecting when we are running under TSAN and disabling the test in that instance.

I have another workaround in the cgsn-mooring project but it is hacky because CMake doesn't allow us to disable tests defined in subdirectories. https://bitbucket.org/ooicgsn/cgsn-mooring/commits/326cc0d5718b7e97cd9cbd9bf01236b88ed798da?at=goby_asan_test