### PR TITLE
changes native to native_handle for boost 1.67

### DIFF
--- a/src/acomms/modemdriver/iridium_driver.cpp
+++ b/src/acomms/modemdriver/iridium_driver.cpp
@@ -94,7 +94,7 @@ void goby::acomms::IridiumDriver::modem_init()
 
         if (driver_cfg_.GetExtension(IridiumDriverConfig::use_dtr) && modem().active() && !dtr_set)
         {
-            serial_fd_ = dynamic_cast<util::SerialClient&>(modem()).socket().native();
+            serial_fd_ = dynamic_cast<util::SerialClient&>(modem()).socket().native_handle();
             set_dtr(true);
             glog.is(DEBUG1) && glog << group(glog_out_group()) << "DTR is: " << query_dtr()
                                     << std::endl;

--- a/src/acomms/modemdriver/mm_driver.cpp
+++ b/src/acomms/modemdriver/mm_driver.cpp
@@ -111,7 +111,7 @@ void goby::acomms::MMDriver::startup(const protobuf::DriverConfig& cfg)
         // Grab our native file descrpitor for the serial port.  Only works for linux.
         // Used to change control lines (e.g. RTS) w/ linux through IOCTL calls.
         // Would need #ifdef's for conditional compling if other platforms become desired.
-        serial_fd_ = dynamic_cast<util::SerialClient&>(modem()).socket().native();
+        serial_fd_ = dynamic_cast<util::SerialClient&>(modem()).socket().native_handle();
 
         // The MM2 (at least, possibly MM1 as well) has an issue where serial comms are
         // garbled when RTS is asserted and hardware flow control is disabled (HFC0).


### PR DESCRIPTION
native was deprecated in boost 1.47, this is the replacement function.

This is mentioned in my second comment in https://github.com/GobySoft/goby3/issues/72#issuecomment-488561191

Please note this is untested beyond compiling.