### PR TITLE
replace canonicalize_file_name with realpath

### DIFF
--- a/src/common/application_base3.h
+++ b/src/common/application_base3.h
@@ -177,7 +177,7 @@ template <typename Config> goby::common::ApplicationBase3<Config>::ApplicationBa
                                  << std::endl;
 
         remove(file_symlink.c_str());
-        int result = symlink(canonicalize_file_name(file_name.c_str()), file_symlink.c_str());
+        int result = symlink(realpath(file_name.c_str(), NULL), file_symlink.c_str());
         if (result != 0)
             glog.is(WARN) &&
                 glog << "Cannot create symlink to latest file. Continuing onwards anyway"


### PR DESCRIPTION
canonicalize_file_name does not exist in musl libc (and OSX by looking at issue history), stdlib doc says this is equivalent. fixes #84

e.g. https://www.smartmontools.org/ticket/921