### PR TITLE
fixes error caused by use of deprecated PROJ4 API

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,6 +38,8 @@ endif()
 
 # proj
 goby_find_required_package(Proj)
+# goby and MOOS make use of deprecated PROJ4 API
+add_definitions(-DACCEPT_USE_OF_DEPRECATED_PROJ_API_H)
 
 # GMP
 goby_find_required_package(GMP)


### PR DESCRIPTION
As of PROJ4 6.0 "To use the proj_api.h you must define the macro ACCEPT_USE_OF_DEPRECATED_PROJ_API_H".

Fixes error: 
```
In file included from /apk_src/goby/src/goby3-3.0/src/util/geodesy.h:32,
                 from /apk_src/goby/src/goby3-3.0/src/util/geodesy.cpp:32:
/usr/include/proj_api.h:37:2: error: #error 'To use the proj_api.h you must define the macro ACCEPT_USE_OF_DEPRECATED_PROJ_API_H'
 #error 'To use the proj_api.h you must define the macro ACCEPT_USE_OF_DEPRECATED_PROJ_API_H'
  ^~~~~
```