### PR TITLE
cmake: only add include dir if it exists

### DIFF
--- a/cmake_modules/FindProtobufGoby.cmake
+++ b/cmake_modules/FindProtobufGoby.cmake
@@ -132,9 +132,6 @@ find_path(PROTOBUF_INCLUDE_DIR google/protobuf/service.h)
 # so that we can use Google's included descriptor.proto
 list(APPEND ALL_PROTOBUF_INCLUDE_DIRS "-I${PROTOBUF_INCLUDE_DIR}")
 
-list(APPEND ALL_PROTOBUF_INCLUDE_DIRS "-I/usr/include")
-list(APPEND ALL_PROTOBUF_INCLUDE_DIRS "-I/usr/local/include")
-
 
 # Google's provided vcproj files generate libraries with a "lib"
 # prefix on Windows


### PR DESCRIPTION
This folder doesn't exist on my machine and I get a lot of warnings from it.

Alternatively, is there any particular include directories that are required apart from google protobuf includes? Is this actually needed?