### PR TITLE
cmake: don't build moos middleware if no zeromq

### DIFF
--- a/src/moos/CMakeLists.txt
+++ b/src/moos/CMakeLists.txt
@@ -55,4 +55,7 @@ endif()
 set_target_properties(goby_moos PROPERTIES VERSION "${GOBY_VERSION}" SOVERSION "${GOBY_SOVERSION}")
 
 add_subdirectory(frontseat)
-add_subdirectory(middleware)
+
+if(build_zeromq)
+  add_subdirectory(middleware)
+endif()


### PR DESCRIPTION
This fixes an error in the compile process when building with out the zeromq dependency.