### PR TITLE
queue_manager: fix uninitialised warning

### DIFF
--- a/src/acomms/queue/queue_manager.cpp
+++ b/src/acomms/queue/queue_manager.cpp
@@ -521,7 +521,7 @@ goby::acomms::QueueManager::find_next_sender(const protobuf::ModemTransmission& 
                                              const std::string& data, bool first_user_frame)
 {
     // competition between variable about who gets to send
-    double winning_priority;
+    double winning_priority = 0;
     boost::posix_time::ptime winning_last_send_time;
 
     Queue* winning_queue = 0;


### PR DESCRIPTION
Fixes this warning:
```
[55/126] Building CXX object src/CMakeFiles/goby.dir/acomms/queue/queue_manager.cpp.o
FAILED: src/CMakeFiles/goby.dir/acomms/queue/queue_manager.cpp.o 
/usr/bin/c++  -DACCEPT_USE_OF_DEPRECATED_PROJ_API_H -DBOOST_ALL_NO_LIB -DBOOST_DATE_TIME_DYN_LINK -DBOOST_FILESYSTEM_DYN_LINK -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_SYSTEM_DYN_LINK -DHAS_GMP -DHAS_NCURSES -DSHARED_LIBRARY_SUFFIX=\".so\" -Dgoby_EXPORTS -Iinclude -Iinclude/goby/protobuf -Iinclude/goby/acomms/protobuf -Iinclude/goby/util/protobuf -Iinclude/goby/middleware/protobuf -Os -fomit-frame-pointer -g -fPIC   -Wall -Werror -Wno-misleading-indentation -std=gnu++14 -MD -MT src/CMakeFiles/goby.dir/acomms/queue/queue_manager.cpp.o -MF src/CMakeFiles/goby.dir/acomms/queue/queue_manager.cpp.o.d -o src/CMakeFiles/goby.dir/acomms/queue/queue_manager.cpp.o -c ../src/acomms/queue/queue_manager.cpp
../src/acomms/queue/queue_manager.cpp: In member function 'goby::acomms::Queue* goby::acomms::QueueManager::find_next_sender(const goby::acomms::protobuf::ModemTransmission&, const string&, bool)':
../src/acomms/queue/queue_manager.cpp:559:64: error: 'winning_priority' may be used uninitialized in this function [-Werror=maybe-uninitialized]
  559 |             if ((!winning_queue || priority > winning_priority ||
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
  560 |                  (priority == winning_priority && last_send_time < winning_last_send_time)))
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
```