### PR TITLE
acomms, linebasedcomms: remove deprecated boost io_service code

### DIFF
--- a/src/acomms/modemdriver/iridium_shore_rudics.h
+++ b/src/acomms/modemdriver/iridium_shore_rudics.h
@@ -37,9 +37,9 @@ namespace acomms
 class RUDICSConnection : public std::enable_shared_from_this<RUDICSConnection>
 {
   public:
-    static std::shared_ptr<RUDICSConnection> create(boost::asio::io_service& io_service)
+    static std::shared_ptr<RUDICSConnection> create(boost::asio::executor executor)
     {
-        return std::shared_ptr<RUDICSConnection>(new RUDICSConnection(io_service));
+        return std::shared_ptr<RUDICSConnection>(new RUDICSConnection(executor));
     }
 
     boost::asio::ip::tcp::socket& socket() { return socket_; }
@@ -96,8 +96,8 @@ class RUDICSConnection : public std::enable_shared_from_this<RUDICSConnection>
     const std::string& remote_endpoint_str() { return remote_endpoint_str_; }
 
   private:
-    RUDICSConnection(boost::asio::io_service& io_service)
-        : socket_(io_service), remote_endpoint_str_("Unknown"), packet_failures_(0)
+    RUDICSConnection(boost::asio::executor& executor)
+        : socket_(executor), remote_endpoint_str_("Unknown"), packet_failures_(0)
     {
     }
 
@@ -171,7 +171,7 @@ class RUDICSServer
     void start_accept()
     {
         std::shared_ptr<RUDICSConnection> new_connection =
-            RUDICSConnection::create(acceptor_.get_io_service());
+            RUDICSConnection::create(acceptor_.get_executor());
         acceptor_.async_accept(new_connection->socket(),
                                boost::bind(&RUDICSServer::handle_accept, this, new_connection,
                                            boost::asio::placeholders::error));

--- a/src/acomms/modemdriver/iridium_shore_sbd.h
+++ b/src/acomms/modemdriver/iridium_shore_sbd.h
@@ -201,9 +201,9 @@ class SBDMTConfirmationMessageReader : public SBDMessageReader
 class SBDConnection : public boost::enable_shared_from_this<SBDConnection>
 {
   public:
-    static std::shared_ptr<SBDConnection> create(boost::asio::io_service& io_service)
+    static std::shared_ptr<SBDConnection> create(boost::asio::executor executor)
     {
-        return std::shared_ptr<SBDConnection>(new SBDConnection(io_service));
+        return std::shared_ptr<SBDConnection>(new SBDConnection(executor));
     }
 
     boost::asio::ip::tcp::socket& socket() { return socket_; }
@@ -227,8 +227,8 @@ class SBDConnection : public boost::enable_shared_from_this<SBDConnection>
     const std::string& remote_endpoint_str() { return remote_endpoint_str_; }
 
   private:
-    SBDConnection(boost::asio::io_service& io_service)
-        : socket_(io_service), connect_time_(-1), message_(socket_), remote_endpoint_str_("Unknown")
+    SBDConnection(boost::asio::executor executor)
+        : socket_(executor), connect_time_(-1), message_(socket_), remote_endpoint_str_("Unknown")
     {
     }
 
@@ -253,7 +253,7 @@ class SBDServer
     void start_accept()
     {
         std::shared_ptr<SBDConnection> new_connection =
-            SBDConnection::create(acceptor_.get_io_service());
+            SBDConnection::create(acceptor_.get_executor());
 
         connections_.insert(new_connection);
 

--- a/src/util/linebasedcomms/tcp_server.h
+++ b/src/util/linebasedcomms/tcp_server.h
@@ -105,16 +105,16 @@ class TCPConnection : public boost::enable_shared_from_this<TCPConnection>,
 
     boost::asio::ip::tcp::socket& socket() { return socket_; }
 
-    void start() { socket_.get_io_service().post(boost::bind(&TCPConnection::read_start, this)); }
+    void start() { boost::asio::post(socket_.get_executor(), boost::bind(&TCPConnection::read_start, this)); }
 
     void write(const protobuf::Datagram& msg)
     {
-        socket_.get_io_service().post(boost::bind(&TCPConnection::socket_write, this, msg));
+        boost::asio::post(socket_.get_executor(), boost::bind(&TCPConnection::socket_write, this, msg));
     }
 
     void close(const boost::system::error_code& error)
     {
-        socket_.get_io_service().post(boost::bind(&TCPConnection::socket_close, this, error));
+        boost::asio::post(socket_.get_executor(), boost::bind(&TCPConnection::socket_close, this, error));
     }
 
     std::string local_endpoint() { return goby::util::as<std::string>(socket_.local_endpoint()); }


### PR DESCRIPTION
Please note this is entirely untested code. This now compiles (at least on Alpine Linux edge) with latest version of boost (1.71).

Fixes #103 .