### PR TITLE
cmake: remove not required zeromq component from being added

### DIFF
--- a/src/goby-config.cmake.in
+++ b/src/goby-config.cmake.in
@@ -5,12 +5,6 @@ else()
   set(GOBY_FOUND 0)
 endif()
 
-# moos requires zeromq
-if("moos" IN_LIST GOBY_FIND_COMPONENTS)
-  list(INSERT GOBY_FIND_COMPONENTS 0 "zeromq")
-endif()
-
-
 foreach(component ${GOBY_FIND_COMPONENTS})
   if(EXISTS ${CMAKE_CURRENT_LIST_DIR}/goby_${component}-config.cmake)
     include(${CMAKE_CURRENT_LIST_DIR}/goby_${component}-config.cmake)


### PR DESCRIPTION
Currently it forces the zeromq component to be added which I don't believe this is true any more due to https://github.com/GobySoft/goby3/blob/3.0/src/moos/CMakeLists.txt#L52 

