### PR TITLE
moos: fix maybe uninitialised warning

### DIFF
--- a/src/moos/moos_protobuf_helpers.h
+++ b/src/moos/moos_protobuf_helpers.h
@@ -394,7 +394,7 @@ class MOOSTranslation<protobuf::TranslatorEntry::TECHNIQUE_COMMA_SEPARATED_KEY_E
                 protobuf::TranslatorEntry::PublishSerializer::Algorithm>::const_iterator
                 const_iterator;
 
-            int primary_field;
+            int primary_field = 0;
             for (const_iterator alg_it = algorithms.begin(), alg_n = algorithms.end();
                  alg_it != alg_n; ++alg_it)
             {


### PR DESCRIPTION
```
FAILED: src/apps/moos/pAcommsHandler/CMakeFiles/pAcommsHandler.dir/pAcommsHandler.cpp.o 
/usr/bin/c++  -DACCEPT_USE_OF_DEPRECATED_PROJ_API_H -DHAS_GMP -DHAS_NCURSES -DSHARED_LIBRARY_SUFFIX=\".so\" -Iinclude -Iinclude/goby/protobuf -Iinclude/goby/acomms/protobuf -Iinclude/goby/util/protobuf -Iinclude/goby/middleware/protobuf -I/usr/lib/cmake/MOOS/../../../include -Os -fomit-frame-pointer -g   -Wall -Werror -Wno-misleading-indentation -std=gnu++14 -MD -MT src/apps/moos/pAcommsHandler/CMakeFiles/pAcommsHandler.dir/pAcommsHandler.cpp.o -MF src/apps/moos/pAcommsHandler/CMakeFiles/pAcommsHandler.dir/pAcommsHandler.cpp.o.d -o src/apps/moos/pAcommsHandler/CMakeFiles/pAcommsHandler.dir/pAcommsHandler.cpp.o -c ../src/apps/moos/pAcommsHandler/pAcommsHandler.cpp
In file included from ../src/apps/moos/pAcommsHandler/pAcommsHandler.cpp:36:
include/goby/moos/moos_protobuf_helpers.h: In static member function 'static void goby::moos::MOOSTranslation<(goby::moos::protobuf::TranslatorEntry_ParserSerializerTechnique)3>::serialize(std::__cxx11::string*, const google::protobuf::Message&, const google::protobuf::RepeatedPtrField<goby::moos::protobuf::TranslatorEntry_PublishSerializer_Algorithm>&, bool)':
include/goby/moos/moos_protobuf_helpers.h:410:71: error: 'primary_field' may be used uninitialized in this function [-Werror=maybe-uninitialized]
             key += "(" + desc->FindFieldByNumber(primary_field)->name() + ")";
                                                                       ^
cc1plus: all warnings being treated as errors
```