### PR TITLE
Micromodem 2 improvements - multi-message reply support and optional query all cfg

### DIFF
--- a/src/acomms/modemdriver/mm_driver.cpp
+++ b/src/acomms/modemdriver/mm_driver.cpp
@@ -165,8 +165,11 @@ void goby::acomms::MMDriver::startup(const protobuf::DriverConfig& cfg)
         usleep(100000); // 10 Hz
     }
 
-    // so that we know what the Micro-Modem has for all the NVRAM values, not just the ones we set
-    query_all_cfg();
+    if (mm_driver_cfg().query_cfg_on_startup())
+    {
+        // so that we know what the Micro-Modem has for all the NVRAM values, not just the ones we set
+        query_all_cfg();
+    }
 
     startup_done_ = true;
 }

--- a/src/acomms/modemdriver/mm_driver.h
+++ b/src/acomms/modemdriver/mm_driver.h
@@ -247,6 +247,9 @@ class MMDriver : public ModemDriverBase
     static const boost::posix_time::time_duration WAIT_AFTER_REBOOT;
     // allowed time diff in millisecs between our clock and the modem clock
     static const int ALLOWED_MS_DIFF;
+    // seconds to wait for modem to respond
+    static const goby::time::SystemClock::duration MULTI_REPLY_WAIT;
+
 
     static const std::string SERIAL_DELIMITER;
     // number of frames for a given packet type
@@ -266,6 +269,9 @@ class MMDriver : public ModemDriverBase
 
     // are we waiting for a command ack (CA) from the modem or can we send another output?
     bool waiting_for_modem_;
+
+    // are we waiting for a multi-message reply
+    bool waiting_for_multimsg_;
 
     // set after the startup routines finish once. we can't startup on instantiation because
     // the base class sets some of our references (from the MOOS file)
@@ -343,6 +349,9 @@ class MMDriver : public ModemDriverBase
     micromodem::protobuf::TransmissionType last_lbl_type_;
 
     goby::time::SITime last_keep_alive_time_;
+
+    // time of the last multi-message reply received. we timeout and pop after MULTI_REPLY_WAIT seconds
+    goby::time::SystemClock::time_point last_multimsg_rx_time_;
 
     struct MMRevision
     {

--- a/src/acomms/modemdriver/mm_driver.h
+++ b/src/acomms/modemdriver/mm_driver.h
@@ -241,15 +241,12 @@ class MMDriver : public ModemDriverBase
         ROUGH_SPEED_OF_SOUND = 1500
     }; // m/s
 
-    // seconds to wait for modem to respond
-    static const boost::posix_time::time_duration MODEM_WAIT;
-    // seconds to wait after modem reboot
-    static const boost::posix_time::time_duration WAIT_AFTER_REBOOT;
-    // allowed time diff in millisecs between our clock and the modem clock
-    static const int ALLOWED_MS_DIFF;
-    // seconds to wait for modem to respond
+    // time to wait for modem to respond
+    static const goby::time::SystemClock::duration MODEM_WAIT;
+    // time to wait for modem to respond
     static const goby::time::SystemClock::duration MULTI_REPLY_WAIT;
-
+    // time to wait after modem reboot
+    static const goby::time::SystemClock::duration WAIT_AFTER_REBOOT;
 
     static const std::string SERIAL_DELIMITER;
     // number of frames for a given packet type
@@ -265,7 +262,7 @@ class MMDriver : public ModemDriverBase
     std::deque<util::NMEASentence> out_;
 
     // time of the last message written. we timeout and resend after MODEM_WAIT seconds
-    boost::posix_time::ptime last_write_time_;
+    goby::time::SystemClock::time_point last_write_time_;
 
     // are we waiting for a command ack (CA) from the modem or can we send another output?
     bool waiting_for_modem_;
@@ -314,8 +311,8 @@ class MMDriver : public ModemDriverBase
         HYDROID_GATEWAY_PREFIX_LENGTH = 3
     };
     // time between requests to the hydroid gateway buoy gps
-    static const boost::posix_time::time_duration HYDROID_GATEWAY_GPS_REQUEST_INTERVAL;
-    boost::posix_time::ptime last_hydroid_gateway_gps_request_;
+    static const goby::time::SystemClock::duration HYDROID_GATEWAY_GPS_REQUEST_INTERVAL;
+    goby::time::SystemClock::time_point last_hydroid_gateway_gps_request_;
     bool is_hydroid_gateway_;
     std::string hydroid_gateway_modem_prefix_;
     std::string hydroid_gateway_gps_request_;
@@ -348,7 +345,7 @@ class MMDriver : public ModemDriverBase
 
     micromodem::protobuf::TransmissionType last_lbl_type_;
 
-    goby::time::SITime last_keep_alive_time_;
+    goby::time::SystemClock::time_point last_keep_alive_time_;
 
     // time of the last multi-message reply received. we timeout and pop after MULTI_REPLY_WAIT seconds
     goby::time::SystemClock::time_point last_multimsg_rx_time_;

--- a/src/acomms/protobuf/mm_driver.proto
+++ b/src/acomms/protobuf/mm_driver.proto
@@ -111,6 +111,8 @@ message Config
 
     optional bool use_application_acks = 20 [default = false];
     repeated uint32 additional_application_ack_modem_id = 21;
+    
+    optional bool query_cfg_on_startup = 22 [default = true];
 }
 
 extend goby.acomms.protobuf.DriverConfig

--- a/src/test/acomms/driver_tester/driver_tester.cpp
+++ b/src/test/acomms/driver_tester/driver_tester.cpp
@@ -221,7 +221,8 @@ void goby::test::acomms::DriverTester::handle_data_receive1(const protobuf::Mode
 
             auto now = goby::time::SystemClock::now();
             auto reported = goby::time::convert<decltype(now)>(msg.time_with_units());
-            assert(reported < now && reported > now - std::chrono::seconds(2));
+            assert(std::abs(std::chrono::duration_cast<std::chrono::milliseconds>(reported - now)
+                                .count()) < 2000);
             ++check_count_;
         }
         break;
@@ -237,7 +238,8 @@ void goby::test::acomms::DriverTester::handle_data_receive1(const protobuf::Mode
 
             auto now = goby::time::SystemClock::now();
             auto reported = goby::time::convert<decltype(now)>(msg.time_with_units());
-            assert(reported < now && reported > now - std::chrono::seconds(2));
+            assert(std::abs(std::chrono::duration_cast<std::chrono::milliseconds>(reported - now)
+                                .count()) < 2000);
             ++check_count_;
         }
         break;


### PR DESCRIPTION
Fixes the issues I ran into in #126 

- Added a configuration parameter to make query_all optional, set to default true
- I added state and timeout when receiving a multi message reply.

Our utilities now work well with MM2 firmware, and are well behaved and wait for all the CFG messages to come in before carrying on.

Something things to note:
- I added a last_keepalive_received to the receive handler. I noticed the keepalive messages were being sent at inopportune times and this would prevent this from happening.