### PR TITLE
External data in Liaison Commander and other improvements

### DIFF
--- a/src/apps/zeromq/liaison/liaison_commander.cpp
+++ b/src/apps/zeromq/liaison/liaison_commander.cpp
@@ -828,7 +828,7 @@ void goby::apps::zeromq::LiaisonCommander::ControlsContainer::CommandContainer::
 void goby::apps::zeromq::LiaisonCommander::ControlsContainer::CommandContainer::
     set_external_data_table_params(Wt::WTreeView* external_data_table)
 {
-    //   external_data_table->resize(WLength::Auto, pb_commander_config_.database_view_height());
+    external_data_table->resize(WLength::Auto, pb_commander_config_.database_view_height());
     external_data_table->sortByColumn(protobuf::ProtobufCommanderConfig::EXTERNAL_DATA_COLUMN_TIME,
                                       DescendingOrder);
     external_data_table->setMinimumSize(

--- a/src/apps/zeromq/liaison/liaison_commander.cpp
+++ b/src/apps/zeromq/liaison/liaison_commander.cpp
@@ -450,9 +450,12 @@ void goby::apps::zeromq::LiaisonCommander::ControlsContainer::send_message()
                 break;
             case goby::middleware::protobuf::LAYER_INTERVEHICLE:
                 commander_->post_to_comms([=]() {
-                    commander_->goby_thread()->intervehicle().publish_dynamic_introspection(
-                        current_command->message_,
-                        goby::middleware::DynamicGroup(grouplayer.group()));
+                    commander_->goby_thread()
+                        ->intervehicle()
+                        .publish_dynamic<google::protobuf::Message,
+                                         goby::middleware::MarshallingScheme::DCCL>(
+                            current_command->message_,
+                            goby::middleware::DynamicGroup(grouplayer.group()));
                 });
                 break;
         }

--- a/src/apps/zeromq/liaison/liaison_commander.h
+++ b/src/apps/zeromq/liaison/liaison_commander.h
@@ -318,6 +318,7 @@ class CommanderCommsThread : public goby::zeromq::LiaisonCommsThread<LiaisonComm
             using std::placeholders::_2;
             command_publisher_ = {
                 {},
+                std::bind(&CommanderCommsThread::set_command_group, this, _1, _2),
                 std::bind(&CommanderCommsThread::handle_command_ack, this, _1, _2),
                 std::bind(&CommanderCommsThread::handle_command_expired, this, _1, _2)};
         }
@@ -348,6 +349,10 @@ class CommanderCommsThread : public goby::zeromq::LiaisonCommsThread<LiaisonComm
     ~CommanderCommsThread() {}
 
   private:
+    void set_command_group(google::protobuf::Message& command, const goby::middleware::Group& group)
+    {
+    }
+
     void handle_command_ack(const google::protobuf::Message& command,
                             const goby::middleware::intervehicle::protobuf::AckData& ack)
     {

--- a/src/apps/zeromq/liaison/liaison_commander.h
+++ b/src/apps/zeromq/liaison/liaison_commander.h
@@ -87,6 +87,7 @@ struct CommandEntry
 {
     std::string protobuf_name;
     std::string group;
+    std::string layer;
     std::vector<unsigned char> bytes;
     long long utime;
     Wt::WDateTime time;
@@ -100,6 +101,7 @@ struct CommandEntry
     {
         Wt::Dbo::field(a, protobuf_name, "protobuf_name");
         Wt::Dbo::field(a, group, "group");
+        Wt::Dbo::field(a, layer, "layer");
         Wt::Dbo::field(a, bytes, "bytes");
         Wt::Dbo::field(a, utime, "utime");
         Wt::Dbo::field(a, time, "time");
@@ -230,7 +232,7 @@ class LiaisonCommander
 
             void handle_database_dialog(DatabaseDialogResponse response,
                                         std::shared_ptr<google::protobuf::Message> message,
-                                        std::string group);
+                                        std::string group, std::string layer);
 
             std::shared_ptr<google::protobuf::Message> message_;
 
@@ -240,6 +242,10 @@ class LiaisonCommander
             Wt::WContainerWidget* group_div_;
             Wt::WLabel* group_label_;
             Wt::WComboBox* group_selection_;
+
+            std::vector<
+                goby::apps::zeromq::protobuf::ProtobufCommanderConfig::LoadProtobuf::GroupLayer>
+                publish_to_;
 
             Wt::WGroupBox* tree_box_;
             Wt::WTreeTable* tree_table_;

--- a/src/apps/zeromq/liaison/liaison_commander.h
+++ b/src/apps/zeromq/liaison/liaison_commander.h
@@ -83,6 +83,24 @@ class LiaisonTreeTableNode : public Wt::WTreeTableNode
     }
 };
 
+struct ExternalData
+{
+    std::string affiliated_protobuf_name;
+    std::string protobuf_name;
+    Wt::WDateTime time;
+    std::string group;
+    std::string value;
+
+    template <class Action> void persist(Action& a)
+    {
+        Wt::Dbo::field(a, affiliated_protobuf_name, "affiliated_protobuf_name");
+        Wt::Dbo::field(a, protobuf_name, "protobuf_name");
+        Wt::Dbo::field(a, time, "time");
+        Wt::Dbo::field(a, group, "group");
+        Wt::Dbo::field(a, value, "value");
+    }
+};
+
 struct CommandEntry
 {
     std::string protobuf_name;
@@ -143,8 +161,16 @@ class LiaisonCommander
 
     struct ControlsContainer : Wt::WGroupBox
     {
+        struct CommandContainer;
+
         ControlsContainer(const protobuf::ProtobufCommanderConfig& pb_commander_config,
                           Wt::WStackedWidget* commands_div, LiaisonCommander* parent);
+
+        void load_groups(const google::protobuf::Descriptor* desc, int load_protobuf_index,
+                         CommandContainer* new_command);
+        void load_external_data(const google::protobuf::Descriptor* desc, int load_protobuf_index,
+                                CommandContainer* new_command);
+
         void switch_command(int selection_index);
 
         void clear_message();
@@ -251,17 +277,20 @@ class LiaisonCommander
                 goby::apps::zeromq::protobuf::ProtobufCommanderConfig::LoadProtobuf::GroupLayer>
                 publish_to_;
 
-            Wt::WGroupBox* tree_box_;
-            Wt::WTreeTable* tree_table_;
+            Wt::WGroupBox* message_tree_box_;
+            Wt::WTreeTable* message_tree_table_;
 
             //                    Wt::WStackedWidget* field_info_stack_;
             //                    std::map<const google::protobuf::FieldDescriptor*, int> field_info_map_;
 
             Wt::Dbo::Session* session_;
-            Wt::Dbo::QueryModel<Wt::Dbo::ptr<CommandEntry>>* query_model_;
+            Wt::Dbo::QueryModel<Wt::Dbo::ptr<CommandEntry>>* sent_model_;
+            Wt::WGroupBox* sent_box_;
+            Wt::WTreeView* sent_table_;
 
-            Wt::WGroupBox* query_box_;
-            Wt::WTreeView* query_table_;
+            Wt::Dbo::QueryModel<Wt::Dbo::ptr<ExternalData>>* external_data_model_;
+            Wt::WGroupBox* external_data_box_;
+            Wt::WTreeView* external_data_table_;
 
             boost::posix_time::ptime last_reload_time_;
 

--- a/src/apps/zeromq/liaison/liaison_commander.h
+++ b/src/apps/zeromq/liaison/liaison_commander.h
@@ -176,6 +176,7 @@ class LiaisonCommander
         void increment_incoming_messages(const Wt::WMouseEvent& event);
         void decrement_incoming_messages(const Wt::WMouseEvent& event);
         void remove_incoming_message(const Wt::WMouseEvent& event);
+        void clear_incoming_messages(const Wt::WMouseEvent& event);
 
         struct CommandContainer : Wt::WGroupBox
         {
@@ -320,6 +321,8 @@ class LiaisonCommander
             std::map<std::string, std::map<std::string, ExternalDataMeta>>
                 externally_loadable_fields_;
 
+            std::set<const google::protobuf::Descriptor*> external_types_;
+
             Wt::WGroupBox* message_tree_box_;
             Wt::WTreeTable* message_tree_table_;
 
@@ -329,10 +332,12 @@ class LiaisonCommander
             Wt::Dbo::Session* session_;
             Wt::Dbo::QueryModel<Wt::Dbo::ptr<CommandEntry>>* sent_model_;
             Wt::WGroupBox* sent_box_;
+            Wt::WPushButton* sent_clear_;
             Wt::WTreeView* sent_table_;
 
             Wt::Dbo::QueryModel<Wt::Dbo::ptr<ExternalData>>* external_data_model_;
             Wt::WGroupBox* external_data_box_;
+            Wt::WPushButton* external_data_clear_;
             Wt::WTreeView* external_data_table_;
 
             boost::posix_time::ptime last_reload_time_;

--- a/src/middleware/common.h
+++ b/src/middleware/common.h
@@ -1,0 +1,43 @@
+// Copyright 2017-2020:
+//   GobySoft, LLC (2013-)
+//   Community contributors (see AUTHORS file)
+// File authors:
+//   Toby Schneider <toby@gobysoft.org>
+//
+//
+// This file is part of the Goby Underwater Autonomy Project Libraries
+// ("The Goby Libraries").
+//
+// The Goby Libraries are free software: you can redistribute them and/or modify
+// them under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// The Goby Libraries are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Goby.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef Common20200603H
+#define Common20200603H
+
+#include "goby/middleware/protobuf/layer.pb.h"
+
+namespace goby
+{
+namespace middleware
+{
+inline std::string to_string(goby::middleware::protobuf::Layer layer)
+{
+    const int underscore_pos = 5; // underscore position in: "LAYER_"
+    std::string name = goby::middleware::protobuf::Layer_Name(layer).substr(underscore_pos + 1);
+    boost::to_lower(name);
+    return name;
+}
+} // namespace middleware
+} // namespace goby
+
+#endif

--- a/src/middleware/log/protobuf_log_plugin.h
+++ b/src/middleware/log/protobuf_log_plugin.h
@@ -105,7 +105,7 @@ template <int scheme> class ProtobufPluginBase : public LogPlugin
         {
             try
             {
-                auto msg = SerializerParserHelper<google::protobuf::Message, scheme>::parse_dynamic(
+                auto msg = SerializerParserHelper<google::protobuf::Message, scheme>::parse(
                     bytes_begin, bytes_end, actual_end, log_entry.type());
                 msgs.push_back(msg);
             }

--- a/src/middleware/marshalling/cstr.h
+++ b/src/middleware/marshalling/cstr.h
@@ -46,7 +46,8 @@ template <> struct SerializerParserHelper<std::string, MarshallingScheme::CSTR>
 
     template <typename CharIterator>
     static std::shared_ptr<std::string> parse(CharIterator bytes_begin, CharIterator bytes_end,
-                                              CharIterator& actual_end)
+                                              CharIterator& actual_end,
+                                              const std::string& type = type_name())
     {
         actual_end = bytes_end;
         if (bytes_begin != bytes_end)

--- a/src/middleware/marshalling/dccl.h
+++ b/src/middleware/marshalling/dccl.h
@@ -72,7 +72,8 @@ struct SerializerParserHelper<DataType, MarshallingScheme::DCCL>
     /// If DCCL messages are concatentated, you can pass "actual_end" back into parse() as the new "bytes_begin" until it reaches "bytes_end"
     template <typename CharIterator>
     static std::shared_ptr<DataType> parse(CharIterator bytes_begin, CharIterator bytes_end,
-                                           CharIterator& actual_end)
+                                           CharIterator& actual_end,
+                                           const std::string& type = type_name())
     {
         std::lock_guard<std::mutex> lock(dccl_mutex_);
         check_load<DataType>();
@@ -96,6 +97,8 @@ struct SerializerParserHelper<DataType, MarshallingScheme::DCCL>
         check_load<DataType>();
         return codec().template id<DataType>();
     }
+
+    static unsigned id(const google::protobuf::Message& d) { return id(); }
 
   private:
 };
@@ -141,8 +144,8 @@ struct SerializerParserHelper<google::protobuf::Message, MarshallingScheme::DCCL
     /// \return Parsed Protobuf message
     template <typename CharIterator>
     static std::shared_ptr<google::protobuf::Message>
-    parse_dynamic(CharIterator bytes_begin, CharIterator bytes_end, CharIterator& actual_end,
-                  const std::string& type)
+    parse(CharIterator bytes_begin, CharIterator bytes_end, CharIterator& actual_end,
+          const std::string& type)
     {
         std::lock_guard<std::mutex> lock(dccl_mutex_);
 

--- a/src/middleware/marshalling/detail/dccl_serializer_parser.cpp
+++ b/src/middleware/marshalling/detail/dccl_serializer_parser.cpp
@@ -96,3 +96,70 @@ goby::middleware::detail::DCCLSerializerParserHelperBase::unpack(const std::stri
 
     return packets;
 }
+
+void goby::middleware::detail::DCCLSerializerParserHelperBase::setup_dlog()
+{
+    static bool setup_complete = false;
+
+    if (!setup_complete)
+    {
+        std::string glog_dccl_group = "dccl";
+
+        glog.add_group(glog_dccl_group, util::Colors::lt_magenta);
+
+        auto dlog_lambda = [=](const std::string& msg, dccl::logger::Verbosity vrb,
+                               dccl::logger::Group grp) {
+            switch (vrb)
+            {
+                case dccl::logger::WARN:
+                    goby::glog.is_warn() && goby::glog << group(glog_dccl_group) << msg
+                                                       << std::endl;
+                    break;
+
+                case dccl::logger::INFO:
+                    goby::glog.is_verbose() && goby::glog << group(glog_dccl_group) << msg
+                                                          << std::endl;
+                    break;
+
+                default:
+                case dccl::logger::DEBUG1:
+                    goby::glog.is_debug1() && goby::glog << group(glog_dccl_group) << msg
+                                                         << std::endl;
+                    break;
+
+                case dccl::logger::DEBUG2:
+                    goby::glog.is_debug2() && goby::glog << group(glog_dccl_group) << msg
+                                                         << std::endl;
+                    break;
+
+                case dccl::logger::DEBUG3:
+                    goby::glog.is_debug3() && goby::glog << group(glog_dccl_group) << msg
+                                                         << std::endl;
+                    break;
+            }
+        };
+
+        switch (goby::glog.buf().highest_verbosity())
+        {
+            default:
+            case goby::util::logger::QUIET: break;
+            case goby::util::logger::WARN:
+                dccl::dlog.connect(dccl::logger::WARN_PLUS, dlog_lambda);
+                break;
+            case goby::util::logger::VERBOSE:
+                dccl::dlog.connect(dccl::logger::INFO_PLUS, dlog_lambda);
+                break;
+            case goby::util::logger::DEBUG1:
+                dccl::dlog.connect(dccl::logger::DEBUG1_PLUS, dlog_lambda);
+                break;
+            case goby::util::logger::DEBUG2:
+                dccl::dlog.connect(dccl::logger::DEBUG2_PLUS, dlog_lambda);
+                break;
+            case goby::util::logger::DEBUG3:
+                dccl::dlog.connect(dccl::logger::DEBUG3_PLUS, dlog_lambda);
+                break;
+        }
+
+        setup_complete = true;
+    }
+}

--- a/src/middleware/marshalling/detail/dccl_serializer_parser.h
+++ b/src/middleware/marshalling/detail/dccl_serializer_parser.h
@@ -97,10 +97,15 @@ struct DCCLSerializerParserHelperBase
                 std::make_pair(desc, std::unique_ptr<LoaderBase>(new LoaderDynamic(desc))));
     }
 
+    static void setup_dlog();
+
     static dccl::Codec& codec()
     {
         if (!codec_)
+        {
             codec_.reset(new dccl::Codec);
+            setup_dlog();
+        }
         return *codec_;
     }
 
@@ -108,6 +113,7 @@ struct DCCLSerializerParserHelperBase
     {
         codec_.reset(new_codec);
         loader_map_.clear();
+        setup_dlog();
         return *new_codec;
     }
 

--- a/src/middleware/marshalling/interface.h
+++ b/src/middleware/marshalling/interface.h
@@ -121,30 +121,17 @@ template <typename DataType, int scheme, class Enable = void> struct SerializerP
     /// \param bytes_begin Iterator to the beginning of a container of bytes
     /// \param bytes_end Iterator to the end of a container of bytes
     /// \param actual_end Will be set to the actual end of parsing by this specialization (useful for byte streams that are concatenated, e.g. DCCL)
+    /// \param type Type name as string. If type_name() can be defined without parameters, the default value should be set, otherwise omit it (for dynamic types like google::protobuf::Message)
     /// \return shared pointer to the parsed message
     template <typename CharIterator>
     static std::shared_ptr<DataType> parse(CharIterator bytes_begin, CharIterator bytes_end,
-                                           CharIterator& actual_end)
+                                           CharIterator& actual_end,
+                                           const std::string& type = type_name())
     {
         static_assert(std::is_void<Enable>::value, "SerializerParserHelper must be specialized");
         return std::shared_ptr<DataType>();
     }
 
-    /// \brief alternative to the parse method for SerializerParserHelper specializations that can handle multiple types using runtime introspection
-    ///
-    /// \param bytes_begin Iterator to the beginning of a container of bytes
-    /// \param bytes_end Iterator to the end of a container of bytes
-    /// \param actual_end Will be set to the actual end of parsing by this specialization (useful for byte streams that are concatenated, e.g. DCCL)
-    /// \param type the type to parse as a marshalling scheme specific string
-    /// \return shared pointer to the parsed message
-    template <typename CharIterator>
-    static std::shared_ptr<DataType> parse_dynamic(CharIterator bytes_begin, CharIterator bytes_end,
-                                                   CharIterator& actual_end,
-                                                   const std::string& type)
-    {
-        static_assert(std::is_void<Enable>::value, "SerializerParserHelper must be specialized");
-        return std::shared_ptr<DataType>();
-    }
 };
 
 //

--- a/src/middleware/marshalling/mavlink.h
+++ b/src/middleware/marshalling/mavlink.h
@@ -91,8 +91,8 @@ template <> struct SerializerParserHelper<mavlink::mavlink_message_t, Marshallin
 
     template <typename CharIterator>
     static std::shared_ptr<mavlink::mavlink_message_t>
-    parse_dynamic(CharIterator bytes_begin, CharIterator bytes_end, CharIterator& actual_end,
-                  const std::string& type)
+    parse(CharIterator bytes_begin, CharIterator bytes_end, CharIterator& actual_end,
+          const std::string& type)
     {
         CharIterator c = bytes_begin;
         auto msg = std::make_shared<mavlink::mavlink_message_t>();
@@ -187,13 +187,12 @@ struct SerializerParserHelper<std::tuple<Integer, Integer, DataType>, Marshallin
 
     template <typename CharIterator>
     static std::shared_ptr<std::tuple<Integer, Integer, DataType>>
-    parse(CharIterator bytes_begin, CharIterator bytes_end, CharIterator& actual_end)
+    parse(CharIterator bytes_begin, CharIterator bytes_end, CharIterator& actual_end,
+          const std::string& type = type_name())
     {
         auto msg =
-            SerializerParserHelper<mavlink::mavlink_message_t,
-                                   MarshallingScheme::MAVLINK>::parse_dynamic(bytes_begin,
-                                                                              bytes_end, actual_end,
-                                                                              type_name());
+            SerializerParserHelper<mavlink::mavlink_message_t, MarshallingScheme::MAVLINK>::parse(
+                bytes_begin, bytes_end, actual_end, type_name());
         auto packet_with_metadata = std::make_shared<std::tuple<Integer, Integer, DataType>>();
         DataType* packet = &std::get<MAVLinkTupleIndices::PACKET_INDEX>(*packet_with_metadata);
         mavlink::MsgMap map(msg.get());
@@ -222,7 +221,8 @@ template <typename DataType> struct SerializerParserHelper<DataType, Marshalling
 
     template <typename CharIterator>
     static std::shared_ptr<DataType> parse(CharIterator bytes_begin, CharIterator bytes_end,
-                                           CharIterator& actual_end)
+                                           CharIterator& actual_end,
+                                           const std::string& type = type_name())
     {
         auto packet_with_metadata =
             SerializerParserHelper<std::tuple<int, int, DataType>,

--- a/src/middleware/marshalling/protobuf.h
+++ b/src/middleware/marshalling/protobuf.h
@@ -65,7 +65,8 @@ struct SerializerParserHelper<
     /// \brief Parse Protobuf message (using standard Protobuf decoding)
     template <typename CharIterator>
     static std::shared_ptr<DataType> parse(CharIterator bytes_begin, CharIterator bytes_end,
-                                           CharIterator& actual_end)
+                                           CharIterator& actual_end,
+                                           const std::string& type = type_name())
     {
         auto msg = std::make_shared<DataType>();
         msg->ParseFromArray(&*bytes_begin, bytes_end - bytes_begin);
@@ -110,8 +111,8 @@ template <> struct SerializerParserHelper<google::protobuf::Message, Marshalling
     /// \return Parsed Protobuf message
     template <typename CharIterator>
     static std::shared_ptr<google::protobuf::Message>
-    parse_dynamic(CharIterator bytes_begin, CharIterator bytes_end, CharIterator& actual_end,
-                  const std::string& type)
+    parse(CharIterator bytes_begin, CharIterator bytes_end, CharIterator& actual_end,
+          const std::string& type)
     {
         std::shared_ptr<google::protobuf::Message> msg;
 

--- a/src/middleware/protobuf/geographic.proto
+++ b/src/middleware/protobuf/geographic.proto
@@ -1,0 +1,35 @@
+syntax = "proto2";
+
+import "dccl/option_extensions.proto";
+
+package goby.middleware.protobuf;
+
+message LatLonPoint
+{
+    option (dccl.msg).unit_system = "si";
+    required double lat = 1 [(dccl.field) = {units {
+                                 derived_dimensions: "plane_angle"
+                                 system: "angle::degree"
+                             }}];
+    required double lon = 2 [(dccl.field) = {units {
+                                 derived_dimensions: "plane_angle"
+                                 system: "angle::degree"
+                             }}];
+
+    optional double depth = 3
+        [default = 0, (dccl.field) = {units {derived_dimensions: "length"}}];
+}
+
+// protobuf contents of $GPWPL message
+message Waypoint
+{
+    optional string name = 1;
+    required LatLonPoint location = 2;
+}
+
+// protobuf contents of $GPRTE message
+message Route
+{
+    optional string name = 1;
+    repeated Waypoint point = 2;
+}

--- a/src/middleware/protobuf/layer.proto
+++ b/src/middleware/protobuf/layer.proto
@@ -1,0 +1,11 @@
+package goby.middleware.protobuf;
+
+enum Layer
+{
+    LAYER_INTERTHREAD = 0;
+    LAYER_INTERPROCESS = 1;
+    LAYER_INTERVEHICLE = 2;
+}
+
+
+                            

--- a/src/middleware/protobuf/layer.proto
+++ b/src/middleware/protobuf/layer.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 package goby.middleware.protobuf;
 
 enum Layer

--- a/src/middleware/src.cmake
+++ b/src/middleware/src.cmake
@@ -12,6 +12,8 @@ protobuf_generate_cpp(MIDDLEWARE_PROTO_SRCS MIDDLEWARE_PROTO_HDRS
   middleware/protobuf/can_config.proto
   middleware/protobuf/udp_config.proto
   middleware/protobuf/coroner.proto
+  middleware/protobuf/layer.proto
+  middleware/protobuf/geographic.proto
   )
 
 set(MIDDLEWARE_SRC

--- a/src/middleware/transport/interprocess.h
+++ b/src/middleware/transport/interprocess.h
@@ -180,15 +180,15 @@ class InterProcessTransporterBase
     /// \brief Subscribe to a number of types within a given group and scheme using a regular expression
     ///
     /// The marshalling scheme must implement SerializerParserHelper::parse() to use this method.
-    /// \tparam group group to publish this message to (reference to constexpr Group)
     /// \tparam Data data type to publish. Can usually be inferred from the \c data parameter.
     /// \tparam scheme Marshalling scheme id (typically MarshallingScheme::MarshallingSchemeEnum). Can usually be inferred from the Data type.
+    /// \param group group to subscribe to (typically a DynamicGroup)
     /// \param f Callback function or lambda that is called upon receipt of any messages matching the given group and type regex
     /// \param type_regex C++ regex to match type names (within the given scheme)
-    template <const Group& group, typename Data, int scheme = scheme<Data>()>
+    template <typename Data, int scheme = scheme<Data>()>
     void subscribe_type_regex(
         std::function<void(std::shared_ptr<const Data>, const std::string& type)> f,
-        const std::string& type_regex = ".*")
+        const Group& group, const std::string& type_regex = ".*")
     {
         std::regex special_chars{R"([-[\]{}()*+?.,\^$|#\s])"};
         std::string sanitized_group =
@@ -204,6 +204,22 @@ class InterProcessTransporterBase
 
         static_cast<Derived*>(this)->_subscribe_regex(regex_lambda, {scheme}, type_regex,
                                                       "^" + sanitized_group + "$");
+    }
+
+    /// \brief Subscribe to a number of types within a given group and scheme using a regular expression
+    ///
+    /// The marshalling scheme must implement SerializerParserHelper::parse() to use this method.
+    /// \tparam group group to publish this message to (reference to constexpr Group)
+    /// \tparam Data data type to publish. Can usually be inferred from the \c data parameter.
+    /// \tparam scheme Marshalling scheme id (typically MarshallingScheme::MarshallingSchemeEnum). Can usually be inferred from the Data type.
+    /// \param f Callback function or lambda that is called upon receipt of any messages matching the given group and type regex
+    /// \param type_regex C++ regex to match type names (within the given scheme)
+    template <const Group& group, typename Data, int scheme = scheme<Data>()>
+    void subscribe_type_regex(
+        std::function<void(std::shared_ptr<const Data>, const std::string& type)> f,
+        const std::string& type_regex = ".*")
+    {
+        subscribe_type_regex(f, group, type_regex);
     }
 
     /// \brief returns the marshalling scheme id for a given data type on this layer

--- a/src/middleware/transport/interprocess.h
+++ b/src/middleware/transport/interprocess.h
@@ -179,7 +179,7 @@ class InterProcessTransporterBase
 
     /// \brief Subscribe to a number of types within a given group and scheme using a regular expression
     ///
-    /// The marshalling scheme must implement SerializerParserHelper::parse_dynamic() to use this method.
+    /// The marshalling scheme must implement SerializerParserHelper::parse() to use this method.
     /// \tparam group group to publish this message to (reference to constexpr Group)
     /// \tparam Data data type to publish. Can usually be inferred from the \c data parameter.
     /// \tparam scheme Marshalling scheme id (typically MarshallingScheme::MarshallingSchemeEnum). Can usually be inferred from the Data type.
@@ -197,8 +197,8 @@ class InterProcessTransporterBase
         auto regex_lambda = [=](const std::vector<unsigned char>& data, int schm,
                                 const std::string& type, const Group& grp) {
             auto data_begin = data.begin(), data_end = data.end(), actual_end = data.end();
-            auto msg = SerializerParserHelper<Data, scheme>::parse_dynamic(data_begin, data_end,
-                                                                           actual_end, type);
+            auto msg =
+                SerializerParserHelper<Data, scheme>::parse(data_begin, data_end, actual_end, type);
             f(msg, type);
         };
 

--- a/src/middleware/transport/intervehicle.h
+++ b/src/middleware/transport/intervehicle.h
@@ -139,7 +139,10 @@ class InterVehicleTransporterBase
                       "Can only use DCCL messages with InterVehicleTransporters");
         if (data)
         {
-            std::shared_ptr<Data> data_with_group = std::make_shared<Data>(*data);
+            // copy this way as it allows us to copy Data == google::protobuf::Message abstract base class
+            std::shared_ptr<Data> data_with_group(data->New());
+            data_with_group->CopyFrom(*data);
+
             publisher.set_group(*data_with_group, group);
 
             static_cast<Derived*>(this)->template _publish<Data>(*data_with_group, group,
@@ -150,32 +153,6 @@ class InterVehicleTransporterBase
                                                                                   group, publisher);
             this->inner().template publish_dynamic<Data, MarshallingScheme::PROTOBUF>(
                 data_with_group, group, publisher);
-        }
-    }
-
-    void publish_dynamic_introspection(std::shared_ptr<const google::protobuf::Message> data,
-                                       const Group& group = Group(),
-                                       const Publisher<google::protobuf::Message>& publisher =
-                                           Publisher<google::protobuf::Message>())
-    {
-        if (data)
-        {
-            std::shared_ptr<google::protobuf::Message> data_with_group(data->New());
-            data_with_group->CopyFrom(*data);
-
-            //            publisher.set_group(*data_with_group, group);
-
-
-            static_cast<Derived*>(this)->template _publish<google::protobuf::Message>(
-                *data_with_group, group, publisher);
-
-            // publish to interprocess as both DCCL and Protobuf
-            this->inner()
-                .template publish_dynamic<google::protobuf::Message, MarshallingScheme::DCCL>(
-                    data_with_group, group, publisher);
-            this->inner()
-                .template publish_dynamic<google::protobuf::Message, MarshallingScheme::PROTOBUF>(
-                    data_with_group, group, publisher);
         }
     }
 

--- a/src/middleware/transport/intervehicle.h
+++ b/src/middleware/transport/intervehicle.h
@@ -160,10 +160,11 @@ class InterVehicleTransporterBase
     {
         if (data)
         {
-            //            std::shared_ptr<Data> data_with_group = std::make_shared<Data>(*data);
+            std::shared_ptr<google::protobuf::Message> data_with_group(data->New());
+            data_with_group->CopyFrom(*data);
+
             //            publisher.set_group(*data_with_group, group);
 
-            auto data_with_group = data;
 
             static_cast<Derived*>(this)->template _publish<google::protobuf::Message>(
                 *data_with_group, group, publisher);

--- a/src/middleware/transport/intervehicle/driver_thread.h
+++ b/src/middleware/transport/intervehicle/driver_thread.h
@@ -85,7 +85,7 @@ serialize_publication(const Data& d, const Group& group, const Publisher<Data>& 
 
     auto* key = msg->mutable_key();
     key->set_marshalling_scheme(MarshallingScheme::DCCL);
-    key->set_type(SerializerParserHelper<Data, MarshallingScheme::DCCL>::type_name());
+    key->set_type(SerializerParserHelper<Data, MarshallingScheme::DCCL>::type_name(d));
     key->set_group(std::string(group));
     key->set_group_numeric(group.numeric());
     auto now = goby::time::SystemClock::now<goby::time::MicroTime>();

--- a/src/middleware/transport/serialization_handlers.h
+++ b/src/middleware/transport/serialization_handlers.h
@@ -168,8 +168,8 @@ class SerializationSubscription : public SerializationHandlerBase<>
     CharIterator _post(CharIterator bytes_begin, CharIterator bytes_end) const
     {
         CharIterator actual_end;
-        auto msg =
-            SerializerParserHelper<Data, scheme_id>::parse(bytes_begin, bytes_end, actual_end);
+        auto msg = SerializerParserHelper<Data, scheme_id>::parse(bytes_begin, bytes_end,
+                                                                  actual_end, type_name_);
 
         if (subscribed_group() == subscriber_.group(*msg) && handler_)
             handler_(msg);
@@ -193,6 +193,11 @@ class PublisherCallback : public SerializationHandlerBase<Metadata>
 
     PublisherCallback(HandlerType handler)
         : handler_(handler), type_name_(SerializerParserHelper<Data, scheme_id>::type_name())
+    {
+    }
+
+    PublisherCallback(HandlerType handler, const Data& data)
+        : handler_(handler), type_name_(SerializerParserHelper<Data, scheme_id>::type_name(data))
     {
     }
 
@@ -230,8 +235,8 @@ class PublisherCallback : public SerializationHandlerBase<Metadata>
     CharIterator _post(CharIterator bytes_begin, CharIterator bytes_end, const Metadata& md) const
     {
         CharIterator actual_end;
-        auto msg =
-            SerializerParserHelper<Data, scheme_id>::parse(bytes_begin, bytes_end, actual_end);
+        auto msg = SerializerParserHelper<Data, scheme_id>::parse(bytes_begin, bytes_end,
+                                                                  actual_end, type_name_);
 
         if (handler_)
             handler_(*msg, md);

--- a/src/moos/ais.h
+++ b/src/moos/ais.h
@@ -85,13 +85,21 @@ class AISConverter
 
         auto ninety_degrees(90. * boost::units::degree::degrees);
 
+        // convert to local projection to perform cog and sog calculations
+        goby::util::UTMGeodesy geo({status_reports_.front().global_fix().lat_with_units(),
+                                    status_reports_.front().global_fix().lon_with_units()});
         for (int i = 1, n = status_reports_.size(); i < n; ++i)
         {
             auto& status0 = status_reports_[i - 1];
             auto& status1 = status_reports_[i];
 
-            auto dy = status1.local_fix().y_with_units() - status0.local_fix().y_with_units();
-            auto dx = status1.local_fix().x_with_units() - status0.local_fix().x_with_units();
+            auto xy0 = geo.convert(
+                {status0.global_fix().lat_with_units(), status0.global_fix().lon_with_units()});
+            auto xy1 = geo.convert(
+                {status1.global_fix().lat_with_units(), status1.global_fix().lon_with_units()});
+
+            auto dy = xy1.y - xy0.y;
+            auto dx = xy1.x - xy0.x;
             auto dt = status1.time_with_units() - status0.time_with_units();
 
             decltype(ninety_degrees) cog_angle(boost::units::atan2(dy, dx));

--- a/src/protobuf/option_extensions.proto
+++ b/src/protobuf/option_extensions.proto
@@ -41,8 +41,10 @@ message GobyFieldOptions
         optional ConfigAction action = 2 [default = ALWAYS];
     }
     optional ConfigurationOptions cfg = 200;
+
 }
 
 message GobyMessageOptions
 {
+    optional string convertible_from = 100; // tags this message as convertible from another existing message type based on field names
 }

--- a/src/zeromq/liaison/liaison_container.h
+++ b/src/zeromq/liaison/liaison_container.h
@@ -206,8 +206,8 @@ class LiaisonCommsThread
 
     void loop() override
     {
-        goby::glog.is_debug3() && goby::glog << "LiaisonCommsThread " << this->index() << " loop()"
-                                             << std::endl;
+        //        goby::glog.is_debug3() && goby::glog << "LiaisonCommsThread " << this->index() << " loop()"
+        //                                             << std::endl;
         container_->process_from_wt();
     }
 

--- a/src/zeromq/protobuf/liaison_config.proto
+++ b/src/zeromq/protobuf/liaison_config.proto
@@ -96,6 +96,7 @@ message ProtobufCommanderConfig
 
     optional int32 value_width_pixels = 10 [default = 500];
     optional int32 modify_width_pixels = 11 [default = 100];
+    optional int32 external_data_width_pixels = 12 [default = 100];
 
     optional string sqlite3_database = 20
         [default = "/tmp/liaison_commander_autosave.db"];

--- a/src/zeromq/protobuf/liaison_config.proto
+++ b/src/zeromq/protobuf/liaison_config.proto
@@ -1,4 +1,5 @@
 syntax = "proto2";
+
 import "goby/protobuf/option_extensions.proto";
 import "goby/middleware/protobuf/app_config.proto";
 import "goby/middleware/protobuf/layer.proto";
@@ -77,6 +78,19 @@ message ProtobufCommanderConfig
                 [default = LAYER_INTERPROCESS];
         }
         repeated GroupLayer publish_to = 2;
+
+        message ExternalData
+        {
+            required string name = 1;
+            required string group = 2;
+            message Translation
+            {
+                required string from = 1;
+                required string to = 2;
+            }
+            repeated Translation translate = 3;
+        }
+        repeated ExternalData external_data = 3;
     }
     repeated LoadProtobuf load_protobuf = 1;
 
@@ -138,6 +152,26 @@ message ProtobufCommanderConfig
     }
 
     repeated NotificationSubscription notify_subscribe = 30;
+
+    enum ExternalDataColumn
+    {
+        option allow_alias = true;
+
+        EXTERNAL_DATA_COLUMN_NAME = 0;
+        EXTERNAL_DATA_COLUMN_GROUP = 1;
+        EXTERNAL_DATA_COLUMN_TIME = 2;
+        EXTERNAL_DATA_COLUMN_VALUE = 3;
+        EXTERNAL_DATA_COLUMN_MAX = 3;
+    }
+
+    message DatabaseExternalDataColumnWidthPixels
+    {
+        optional int32 name_width = 1 [default = 180];
+        optional int32 group_width = 2 [default = 120];
+        optional int32 time_width = 3 [default = 120];
+        optional int32 value_width = 4 [default = 400];
+    }
+    optional DatabaseExternalDataColumnWidthPixels external_database_width = 40;
 
     // optional string time_source_var = 40;
 

--- a/src/zeromq/protobuf/liaison_config.proto
+++ b/src/zeromq/protobuf/liaison_config.proto
@@ -1,6 +1,7 @@
 syntax = "proto2";
 import "goby/protobuf/option_extensions.proto";
 import "goby/middleware/protobuf/app_config.proto";
+import "goby/middleware/protobuf/layer.proto";
 import "goby/zeromq/protobuf/interprocess_config.proto";
 import "goby/acomms/protobuf/network_ack.proto";
 
@@ -66,7 +67,13 @@ message ProtobufCommanderConfig
     message LoadProtobuf
     {
         required string name = 1;
-        repeated string group = 2;
+
+        message GroupLayer
+        {
+            required string group = 1;
+            optional goby.middleware.protobuf.Layer layer = 2 [default = LAYER_INTERPROCESS];
+        }
+        repeated GroupLayer publish_to = 2;
     }
     repeated LoadProtobuf load_protobuf = 1;
 
@@ -85,20 +92,22 @@ message ProtobufCommanderConfig
         COLUMN_COMMENT = 0;
         COLUMN_NAME = 1;
         COLUMN_GROUP = 2;
-        COLUMN_IP = 3;
-        COLUMN_TIME = 4;
-        COLUMN_LAST_ACK = 5;
-        COLUMN_MAX = 5;
+        COLUMN_LAYER = 3;
+        COLUMN_IP = 4;
+        COLUMN_TIME = 5;
+        COLUMN_LAST_ACK = 6;
+        COLUMN_MAX = 6;
     }
 
     message DatabaseColumnWidthPixels
     {
         optional int32 comment_width = 1 [default = 180];
         optional int32 name_width = 2 [default = 180];
-        optional int32 group_width = 3 [default = 180];
-        optional int32 ip_width = 4 [default = 120];
-        optional int32 time_width = 5 [default = 120];
-        optional int32 last_ack_width = 6 [default = 120];
+        optional int32 group_width = 3 [default = 120];
+        optional int32 layer_width = 4 [default = 120];
+        optional int32 ip_width = 5 [default = 120];
+        optional int32 time_width = 6 [default = 120];
+        optional int32 last_ack_width = 7 [default = 120];
     }
     optional DatabaseColumnWidthPixels database_width = 22;
 

--- a/src/zeromq/protobuf/liaison_config.proto
+++ b/src/zeromq/protobuf/liaison_config.proto
@@ -71,7 +71,10 @@ message ProtobufCommanderConfig
         message GroupLayer
         {
             required string group = 1;
-            optional goby.middleware.protobuf.Layer layer = 2 [default = LAYER_INTERPROCESS];
+            optional uint32 group_numeric = 2 [default = 0];
+            optional string group_numeric_field_name = 3;
+            optional goby.middleware.protobuf.Layer layer = 4
+                [default = LAYER_INTERPROCESS];
         }
         repeated GroupLayer publish_to = 2;
     }


### PR DESCRIPTION
- Added layer (interprocess, intervehicle) for Liaison Commander publications.
- Add ability to receive and store data from external publications in Liaison Commander than can be copied directly (loaded) into fields of the message ("external data").
- Improve goby_clang_tool to attribute pub/sub to most derived class.
- Support dynamic (i.e. google::protobuf::Message) publication of DCCL messages on the intervehicle layer (for use by Liaison initially).