### PR TITLE
Improvements for Can IO thread

### DIFF
--- a/src/middleware/protobuf/can_config.proto
+++ b/src/middleware/protobuf/can_config.proto
@@ -10,20 +10,25 @@ message CanConfig
         unit_system: "si"
     };
 
-    required  string interface = 1  [(goby.field) = {
-        example: "can0"
-        description: "Can interface"
-    }];
+    required string interface = 1
+        [(goby.field) = {example: "can0" description: "Can interface"}];
 
-    message CanFilter {
-      enum CanMask {
-        StandardFrameFormat = 0x000007FF;
-        ExtendedFrameFormat = 0x1FFFFFFF;
-      };
-      required uint32 can_id = 1;
-      //  Should we have a default?
-      optional CanMask can_mask = 2 [default = ExtendedFrameFormat];
+    message CanFilter
+    {
+        enum CanMask
+        {
+            StandardFrameFormat = 0x000007FF;
+            ExtendedFrameFormat = 0x1FFFFFFF;
+            PGNOnly = 0x01FFFF00;
+        };
+        required uint32 can_id = 1;
+        oneof mask
+        {
+            CanMask can_mask = 2 [default = ExtendedFrameFormat];
+            uint32 can_mask_custom = 3;
+        }
     }
 
     repeated CanFilter filter = 2;
+    repeated uint32 pgn_filter = 3;
 }


### PR DESCRIPTION
- For outgoing data on the CANBus: Add interthread subscription to the can_frame type directly (provides symmetry with the publication already there).
- Can specify filter mask directly as bitmask or using enum as before. 
```
filter { can_id: 0xFF0400 can_mask_custom: 0xFF0000 }
filter { can_id: 0xFF0400 can_mask: ExtendendFrameFormat }
```

- Added PGNOnly to filter mask enums to filter on a specific J1939/NMEA2000 PGN. 
- Added pgn_filter for a shorthand for defining these filters:
```
pgn_filter: 65284
```
is a shorthand for
```
filter { can_id: 0xFF0400 can_mask: PGNOnly } 
```
(where `0xFF0400` is `65284 << 8`)
- Added `make_extended_format_can_id` free function for easily making an EFF can_id out of a common set of parameters (PGN and priority).