### PR TITLE
PTY thread for Goby3 middleware and Serial Mux app

### DIFF
--- a/src/apps/middleware/CMakeLists.txt
+++ b/src/apps/middleware/CMakeLists.txt
@@ -5,3 +5,5 @@ endif()
 add_subdirectory(log_tool)
 add_subdirectory(clang_tool)
 add_subdirectory(basic_frontseat_simulator)
+
+add_subdirectory(serial_mux)

--- a/src/apps/middleware/serial_mux/CMakeLists.txt
+++ b/src/apps/middleware/serial_mux/CMakeLists.txt
@@ -1,0 +1,4 @@
+protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS config.proto)
+
+add_executable(goby_serial_mux mux.cpp ${PROTO_SRCS} ${PROTO_HDRS})
+target_link_libraries(goby_serial_mux goby)

--- a/src/apps/middleware/serial_mux/config.proto
+++ b/src/apps/middleware/serial_mux/config.proto
@@ -1,0 +1,14 @@
+syntax = "proto2";
+
+import "goby/middleware/protobuf/app_config.proto";
+import "goby/middleware/protobuf/serial_config.proto";
+import "goby/middleware/protobuf/pty_config.proto";
+
+package goby.apps.middleware.protobuf;
+
+message SerialMuxConfig
+{
+    optional goby.middleware.protobuf.AppConfig app = 1;
+    required goby.middleware.protobuf.SerialConfig primary_serial = 2;
+    repeated goby.middleware.protobuf.PTYConfig secondary_pty = 3;
+}

--- a/src/apps/middleware/serial_mux/config.proto
+++ b/src/apps/middleware/serial_mux/config.proto
@@ -10,5 +10,12 @@ message SerialMuxConfig
 {
     optional goby.middleware.protobuf.AppConfig app = 1;
     required goby.middleware.protobuf.SerialConfig primary_serial = 2;
-    repeated goby.middleware.protobuf.PTYConfig secondary_pty = 3;
+
+    message SecondaryPTY
+    {
+        required goby.middleware.protobuf.PTYConfig pty = 1;
+        optional bool allow_write = 2 [default = true];
+    }
+    
+    repeated SecondaryPTY secondary = 3;
 }

--- a/src/apps/middleware/serial_mux/config.proto
+++ b/src/apps/middleware/serial_mux/config.proto
@@ -1,5 +1,7 @@
 syntax = "proto2";
 
+import "goby/protobuf/option_extensions.proto";
+
 import "goby/middleware/protobuf/app_config.proto";
 import "goby/middleware/protobuf/serial_config.proto";
 import "goby/middleware/protobuf/pty_config.proto";
@@ -9,13 +11,27 @@ package goby.apps.middleware.protobuf;
 message SerialMuxConfig
 {
     optional goby.middleware.protobuf.AppConfig app = 1;
-    required goby.middleware.protobuf.SerialConfig primary_serial = 2;
+    required goby.middleware.protobuf.SerialConfig primary_serial = 2
+        [(goby.field).description =
+             "Primary serial port to multiplex. This is typically a real "
+             "serial port (but could connect to a pty)"];
 
     message SecondaryPTY
     {
-        required goby.middleware.protobuf.PTYConfig pty = 1;
-        optional bool allow_write = 2 [default = true];
+        required goby.middleware.protobuf.PTYConfig pty = 1
+            [(goby.field).description = "Pseudoterminal (PTY) to create"];
+        optional bool allow_write = 2 [
+            default = true,
+            (goby.field).description =
+                "If true, sends data written to the PTY to the primary serial "
+                "port. If false, writes are discarded."
+        ];
     }
-    
-    repeated SecondaryPTY secondary = 3;
+
+    repeated SecondaryPTY secondary = 3
+        [(goby.field).description =
+             "Multiple secondary pseudoterminals (PTYs) to create. Each PTY "
+             "will receive a copy of all data read from the primary serial "
+             "port. All data written to PTYs where 'allow_write = true' will "
+             "be multiplexed and sent out the primary serial port."];
 }

--- a/src/apps/middleware/serial_mux/mux.cpp
+++ b/src/apps/middleware/serial_mux/mux.cpp
@@ -1,0 +1,62 @@
+#include "goby/middleware/marshalling/protobuf.h"
+
+#include "goby/middleware/application/multi_thread.h"
+#include "goby/middleware/io/line_based/pty.h"
+#include "goby/middleware/io/line_based/serial.h"
+
+#include "config.pb.h"
+
+namespace goby
+{
+namespace apps
+{
+namespace middleware
+{
+namespace groups
+{
+constexpr goby::middleware::Group serial_primary_in{"serial_primary_in"};
+constexpr goby::middleware::Group serial_primary_out{"serial_primary_out"};
+
+constexpr goby::middleware::Group pty_secondary_in{"pty_secondary_in"};
+
+} // namespace groups
+
+class SerialMux
+    : public goby::middleware::MultiThreadStandaloneApplication<protobuf::SerialMuxConfig>
+{
+  public:
+    SerialMux()
+    {
+        // input to primary serial -> directly to output of pty
+        using SerialThread = goby::middleware::io::SerialThreadLineBased<
+            groups::serial_primary_in, groups::serial_primary_out,
+            goby::middleware::io::PubSubLayer::INTERTHREAD,
+            goby::middleware::io::PubSubLayer::INTERTHREAD>;
+        using PTYThread = goby::middleware::io::PTYThreadLineBased<
+            groups::pty_secondary_in, groups::serial_primary_in,
+            goby::middleware::io::PubSubLayer::INTERTHREAD,
+            goby::middleware::io::PubSubLayer::INTERTHREAD>;
+
+        interthread().subscribe<groups::pty_secondary_in>(
+            [this](std::shared_ptr<const goby::middleware::protobuf::IOData> from_pty) {
+                auto to_serial = std::make_shared<goby::middleware::protobuf::IOData>(*from_pty);
+                to_serial->clear_index();
+                interthread().publish<groups::serial_primary_out>(to_serial);
+            });
+
+        launch_thread<SerialThread>(cfg().primary_serial());
+
+        int pty_index = 0;
+        for (const auto& pty_cfg : cfg().secondary_pty())
+            launch_thread<PTYThread>(pty_index++, pty_cfg);
+    }
+};
+
+} // namespace middleware
+} // namespace apps
+} // namespace goby
+
+int main(int argc, char* argv[])
+{
+    return goby::run<goby::apps::middleware::SerialMux>(argc, argv);
+}

--- a/src/middleware/ais.h
+++ b/src/middleware/ais.h
@@ -28,8 +28,10 @@
 
 #include <boost/algorithm/string.hpp>
 #include <boost/circular_buffer.hpp>
+#include <boost/units/cmath.hpp>
 
 #include "goby/middleware/protobuf/frontseat_data.pb.h"
+#include "goby/util/geodesy.h"
 #include "goby/util/protobuf/ais.pb.h"
 
 namespace goby

--- a/src/middleware/io/can.h
+++ b/src/middleware/io/can.h
@@ -146,10 +146,8 @@ void goby::middleware::io::CanThread<line_in_group, line_out_group, publish_laye
     addr_.can_family = AF_CAN;
     addr_.can_ifindex = ifr_.ifr_ifindex;
     if (bind(can_socket, (struct sockaddr*)&addr_, sizeof(addr_)) < 0)
-    {
-        glog.is_die() && glog << "Error in socket bind to interface " << this->cfg().interface()
-                              << ": " << std::strerror(errno) << std::endl;
-    }
+        throw(goby::Exception(std::string("Error in socket bind to interface ") +
+                              this->cfg().interface() + ": " + std::strerror(errno)));
 
     this->mutable_socket().assign(can_socket);
 

--- a/src/middleware/io/detail/io_interface.h
+++ b/src/middleware/io/detail/io_interface.h
@@ -123,7 +123,7 @@ class IOThread
     {
         auto data_out_callback =
             [this](std::shared_ptr<const goby::middleware::protobuf::IOData> io_msg) {
-                if (io_msg->index() == this->index())
+                if (!io_msg->has_index() || io_msg->index() == this->index())
                     write(io_msg);
             };
 

--- a/src/middleware/io/detail/io_interface.h
+++ b/src/middleware/io/detail/io_interface.h
@@ -307,7 +307,7 @@ void goby::middleware::io::detail::IOThread<line_in_group, line_out_group, publi
         goby::glog.is_debug2() && goby::glog << group(glog_group_) << "Successfully opened socket"
                                              << std::endl;
     }
-    catch (const boost::system::system_error& e)
+    catch (const std::exception& e)
     {
         protobuf::IOStatus status;
         status.set_state(protobuf::IO__CRITICAL_FAILURE);

--- a/src/middleware/io/detail/io_interface.h
+++ b/src/middleware/io/detail/io_interface.h
@@ -160,11 +160,16 @@ class IOThread
             this->interthread().cv()->notify_all();
         }
         incoming_mail_notify_thread_->join();
+        incoming_mail_notify_thread_.reset();
     }
 
     ~IOThread()
     {
         socket_.reset();
+
+        // for non clean shutdown, avoid abort
+        if (incoming_mail_notify_thread_)
+            incoming_mail_notify_thread_->detach();
 
         protobuf::IOStatus status;
         status.set_state(protobuf::IO__LINK_CLOSED);

--- a/src/middleware/io/detail/pty_interface.h
+++ b/src/middleware/io/detail/pty_interface.h
@@ -1,0 +1,143 @@
+// Copyright 2020:
+//   GobySoft, LLC (2013-)
+//   Community contributors (see AUTHORS file)
+// File authors:
+//   Toby Schneider <toby@gobysoft.org>
+//
+//
+// This file is part of the Goby Underwater Autonomy Project Libraries
+// ("The Goby Libraries").
+//
+// The Goby Libraries are free software: you can redistribute them and/or modify
+// them under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// The Goby Libraries are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Goby.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <boost/asio/posix/stream_descriptor.hpp>
+#include <boost/asio/streambuf.hpp>
+#include <boost/asio/write.hpp>
+#include <boost/units/systems/si/prefixes.hpp>
+
+#include "goby/middleware/io/detail/io_interface.h"
+#include "goby/middleware/protobuf/pty_config.pb.h"
+
+#include <sys/stat.h>
+
+namespace goby
+{
+namespace middleware
+{
+namespace io
+{
+namespace detail
+{
+template <const goby::middleware::Group& line_in_group,
+          const goby::middleware::Group& line_out_group,
+          // by default publish all incoming traffic to interprocess for logging
+          PubSubLayer publish_layer = PubSubLayer::INTERPROCESS,
+          // but only subscribe on interthread for outgoing traffic
+          PubSubLayer subscribe_layer = PubSubLayer::INTERTHREAD>
+class PTYThread : public detail::IOThread<line_in_group, line_out_group, publish_layer,
+                                          subscribe_layer, goby::middleware::protobuf::PTYConfig,
+                                          boost::asio::posix::stream_descriptor>
+{
+    using Base = detail::IOThread<line_in_group, line_out_group, publish_layer, subscribe_layer,
+                                  goby::middleware::protobuf::PTYConfig,
+                                  boost::asio::posix::stream_descriptor>;
+
+  public:
+    /// \brief Constructs the thread.
+    /// \param config A reference to the Protocol Buffers config read by the main application at launch
+    /// \param index Thread index for multiple instances in a given application (-1 indicates a single instance)
+    PTYThread(const goby::middleware::protobuf::PTYConfig& config, int index = -1)
+        : Base(config, index, std::string("pty: ") + config.name())
+    {
+    }
+
+    ~PTYThread() {}
+
+  protected:
+    virtual void async_write(const std::string& bytes) override;
+
+  private:
+    void open_socket() override;
+};
+} // namespace detail
+} // namespace io
+} // namespace middleware
+} // namespace goby
+
+template <const goby::middleware::Group& line_in_group,
+          const goby::middleware::Group& line_out_group,
+          goby::middleware::io::PubSubLayer publish_layer,
+          goby::middleware::io::PubSubLayer subscribe_layer>
+void goby::middleware::io::detail::PTYThread<line_in_group, line_out_group, publish_layer,
+                                             subscribe_layer>::open_socket()
+{
+    int pty_internal = posix_openpt(O_RDWR | O_NOCTTY);
+
+    if (pty_internal == -1)
+        throw(goby::Exception(std::string("Error in posix_openpt: ") + std::strerror(errno)));
+    if (grantpt(pty_internal) == -1)
+        throw(goby::Exception(std::string("Error in grantpt: ") + std::strerror(errno)));
+    if (unlockpt(pty_internal) == -1)
+        throw(goby::Exception(std::string("Error in unlockpt: ") + std::strerror(errno)));
+
+    char pty_external_path[256];
+    ptsname_r(pty_internal, pty_external_path, sizeof(pty_external_path));
+    const char* pty_external_symlink = this->cfg().name().c_str();
+
+    struct stat stat_buffer;
+    // file exists
+    if (lstat(pty_external_symlink, &stat_buffer) == 0)
+    {
+        if (S_ISLNK(stat_buffer.st_mode) == 1)
+        {
+            if (remove(pty_external_symlink) == -1)
+                throw(goby::Exception(std::string("Could not remove existing symlink: ") +
+                                      pty_external_symlink));
+        }
+        else
+        {
+            throw(goby::Exception(std::string("File exists and is not symlink: ") +
+                                  pty_external_symlink));
+        }
+    }
+
+    if (symlink(pty_external_path, pty_external_symlink) == -1)
+        throw(goby::Exception(std::string("Could not create symlink: ") + pty_external_symlink));
+
+    this->mutable_socket().assign(pty_internal);
+    this->mutable_socket().non_blocking(true);
+}
+
+template <const goby::middleware::Group& line_in_group,
+          const goby::middleware::Group& line_out_group,
+          goby::middleware::io::PubSubLayer publish_layer,
+          goby::middleware::io::PubSubLayer subscribe_layer>
+void goby::middleware::io::detail::PTYThread<line_in_group, line_out_group, publish_layer,
+                                             subscribe_layer>::async_write(const std::string& bytes)
+{
+    boost::asio::async_write(
+        this->mutable_socket(), boost::asio::buffer(bytes),
+        [this](const boost::system::error_code& ec, std::size_t bytes_transferred) {
+            if (!ec && bytes_transferred > 0)
+            {
+                this->handle_write_success(bytes_transferred);
+            }
+            else
+            {
+                this->handle_write_error(ec);
+            }
+        });
+}

--- a/src/middleware/io/line_based/common.h
+++ b/src/middleware/io/line_based/common.h
@@ -23,6 +23,8 @@
 
 #pragma once
 
+#include <regex>
+
 namespace goby
 {
 namespace middleware

--- a/src/middleware/io/line_based/pty.h
+++ b/src/middleware/io/line_based/pty.h
@@ -77,18 +77,17 @@ void goby::middleware::io::PTYThreadLineBased<line_in_group, line_out_group, pub
     boost::asio::async_read_until(
         this->mutable_socket(), buffer_, eol_matcher_,
         [this](const boost::system::error_code& ec, std::size_t bytes_transferred) {
-            if (/*!ec && */ bytes_transferred > 0)
+            if (!ec && bytes_transferred > 0)
             {
                 std::string bytes(bytes_transferred, 0);
                 std::istream is(&buffer_);
                 is.read(&bytes[0], bytes_transferred);
                 this->handle_read_success(bytes_transferred, bytes);
-                //    this->async_read();
+                this->async_read();
             }
-            this->async_read();
-            //            else
-            //            {
-            //                this->handle_read_error(ec);
-            //            }
+            else
+            {
+                this->handle_read_error(ec);
+            }
         });
 }

--- a/src/middleware/io/line_based/pty.h
+++ b/src/middleware/io/line_based/pty.h
@@ -1,0 +1,94 @@
+// Copyright 2019-2020:
+//   GobySoft, LLC (2013-)
+//   Community contributors (see AUTHORS file)
+// File authors:
+//   Toby Schneider <toby@gobysoft.org>
+//
+//
+// This file is part of the Goby Underwater Autonomy Project Libraries
+// ("The Goby Libraries").
+//
+// The Goby Libraries are free software: you can redistribute them and/or modify
+// them under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// The Goby Libraries are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Goby.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include "goby/middleware/io/detail/pty_interface.h"
+#include "goby/middleware/io/line_based/common.h"
+
+namespace goby
+{
+namespace middleware
+{
+namespace io
+{
+/// \brief Reads/Writes strings from/to serial port using a line-based (typically ASCII) protocol with a defined end-of-line regex.
+/// \tparam line_in_group goby::middleware::Group to publish to after receiving data from the serial port
+/// \tparam line_out_group goby::middleware::Group to subcribe to for data to send to the serial port
+template <const goby::middleware::Group& line_in_group,
+          const goby::middleware::Group& line_out_group,
+          PubSubLayer publish_layer = PubSubLayer::INTERPROCESS,
+          PubSubLayer subscribe_layer = PubSubLayer::INTERTHREAD>
+class PTYThreadLineBased
+    : public detail::PTYThread<line_in_group, line_out_group, publish_layer, subscribe_layer>
+{
+    using Base = detail::PTYThread<line_in_group, line_out_group, publish_layer, subscribe_layer>;
+
+  public:
+    /// \brief Constructs the thread.
+    /// \param config A reference to the Protocol Buffers config read by the main application at launch
+    /// \param index Thread index for multiple instances in a given application (-1 indicates a single instance)
+    PTYThreadLineBased(const goby::middleware::protobuf::PTYConfig& config, int index = -1)
+        : Base(config, index), eol_matcher_(this->cfg().end_of_line())
+    {
+    }
+
+    ~PTYThreadLineBased() {}
+
+  private:
+    /// \brief Starts an asynchronous read on the serial port until the end-of-line string is reached. When the read completes, a lambda is called that publishes the received line.
+    void async_read() override;
+
+  private:
+    match_regex eol_matcher_;
+    boost::asio::streambuf buffer_;
+};
+} // namespace io
+} // namespace middleware
+} // namespace goby
+
+template <const goby::middleware::Group& line_in_group,
+          const goby::middleware::Group& line_out_group,
+          goby::middleware::io::PubSubLayer publish_layer,
+          goby::middleware::io::PubSubLayer subscribe_layer>
+void goby::middleware::io::PTYThreadLineBased<line_in_group, line_out_group, publish_layer,
+                                              subscribe_layer>::async_read()
+{
+    boost::asio::async_read_until(
+        this->mutable_socket(), buffer_, eol_matcher_,
+        [this](const boost::system::error_code& ec, std::size_t bytes_transferred) {
+            if (/*!ec && */ bytes_transferred > 0)
+            {
+                std::string bytes(bytes_transferred, 0);
+                std::istream is(&buffer_);
+                is.read(&bytes[0], bytes_transferred);
+                this->handle_read_success(bytes_transferred, bytes);
+                //    this->async_read();
+            }
+            this->async_read();
+            //            else
+            //            {
+            //                this->handle_read_error(ec);
+            //            }
+        });
+}

--- a/src/middleware/io/line_based/tcp_server.h
+++ b/src/middleware/io/line_based/tcp_server.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include "goby/middleware/io/detail/tcp_server_interface.h"
+#include "goby/middleware/io/line_based/common.h"
 
 namespace goby
 {

--- a/src/middleware/marshalling/detail/dccl_serializer_parser.h
+++ b/src/middleware/marshalling/detail/dccl_serializer_parser.h
@@ -97,15 +97,11 @@ struct DCCLSerializerParserHelperBase
                 std::make_pair(desc, std::unique_ptr<LoaderBase>(new LoaderDynamic(desc))));
     }
 
-    static void setup_dlog();
 
     static dccl::Codec& codec()
     {
         if (!codec_)
-        {
             codec_.reset(new dccl::Codec);
-            setup_dlog();
-        }
         return *codec_;
     }
 
@@ -113,7 +109,6 @@ struct DCCLSerializerParserHelperBase
     {
         codec_.reset(new_codec);
         loader_map_.clear();
-        setup_dlog();
         return *new_codec;
     }
 
@@ -154,6 +149,9 @@ struct DCCLSerializerParserHelperBase
         std::lock_guard<std::mutex> lock(dccl_mutex_);
         codec().load_library(library);
     }
+
+    /// \brief Enable dlog output to glog using same verbosity settings as glog.
+    static void setup_dlog();
 };
 } // namespace detail
 

--- a/src/middleware/protobuf/pty_config.proto
+++ b/src/middleware/protobuf/pty_config.proto
@@ -1,0 +1,19 @@
+syntax = "proto2";
+import "goby/protobuf/option_extensions.proto";
+import "dccl/option_extensions.proto";
+
+package goby.middleware.protobuf;
+
+message PTYConfig
+{
+    required string name = 1
+        [(goby.field) = {example: "/tmp/ttytest0" description: "Name for created PTY device symlink."}];
+
+    optional string end_of_line = 2 [
+        default = "\n",
+        (goby.field) = {
+            description: "End of line string. Can also be a std::regex"
+        }
+    ];
+
+}

--- a/src/middleware/protobuf/pty_config.proto
+++ b/src/middleware/protobuf/pty_config.proto
@@ -6,14 +6,18 @@ package goby.middleware.protobuf;
 
 message PTYConfig
 {
-    required string name = 1
-        [(goby.field) = {example: "/tmp/ttytest0" description: "Name for created PTY device symlink."}];
-
-    optional string end_of_line = 2 [
+    required string port = 1 [(goby.field) = {
+        example: "/tmp/ttytest0"
+        description: "Name for created PTY device symlink."
+    }];
+    optional uint32 baud = 2 [
+        default = 115200,
+        (goby.field) = {description: "Serial baud for PTY device"}
+    ];
+    optional string end_of_line = 3 [
         default = "\n",
         (goby.field) = {
             description: "End of line string. Can also be a std::regex"
         }
     ];
-
 }

--- a/src/middleware/src.cmake
+++ b/src/middleware/src.cmake
@@ -18,6 +18,7 @@ protobuf_generate_cpp(MIDDLEWARE_PROTO_SRCS MIDDLEWARE_PROTO_HDRS
   middleware/protobuf/frontseat_data.proto
   middleware/protobuf/frontseat_config.proto
   middleware/protobuf/tcp_config.proto
+  middleware/protobuf/pty_config.proto
   )
 
 set(MIDDLEWARE_SRC

--- a/src/util/protobuf/debug_logger.proto
+++ b/src/util/protobuf/debug_logger.proto
@@ -26,12 +26,22 @@ message GLogConfig
 
     message FileLog
     {
-        required string file_name = 1
-            [(goby.field).description =
-                 "Full path to the debug file to write. If present, the string "
-                 "'%1%' will be replaced by the current UTC date and time, and "
-                 "'%2%' will be replaced by the application name."];
-        optional Verbosity verbosity = 2 [
+        optional string file_name = 1 [
+            (goby.field).description =
+                "Path to the debug file to write. If 'file_dir' is set, this "
+                "field is the path relative to 'file_dir', otherwise it is an "
+                "absolute path. The string '%1%' must be present, which will "
+                "be replaced by the current UTC date and time. Optionally, "
+                "'%2%' will be replaced by the application name.",
+            default = "%2%_%1%.txt"
+        ];
+        optional string file_dir = 2 [
+            (goby.field).description =
+                "Directory to store log file in. If not specified, 'file_name' "
+                "will be assumed to be an full path to the log file"
+        ];
+
+        optional Verbosity verbosity = 3 [
             default = VERBOSE,
             (goby.field).description = "Verbosity for this file log"
         ];
@@ -39,4 +49,7 @@ message GLogConfig
     repeated FileLog file_log = 3
         [(goby.field).description =
              "Open one or more files for (debug) logging."];
+
+    
+    optional bool show_dccl_log = 4 [default = false];
 }


### PR DESCRIPTION
- Created `PTYThreadLineBased` that acts just like the `SerialThreadLineBased` except instead of connecting to a serial port, it creates a pseudoterminal (pty) and connects the Goby publish/subscribe to the "master" end. This allows Goby to directly create pty files and eliminates the need for `socat` in some virtual serial port cases.
- Created `goby_serial_mux` which is designed to connect to a single "primary" serial port and one or more "secondary" pty devices. All messages coming into the serial port are sent to all the secondary ptys, and all messages from the ptys are multiplexed into the "primary" serial port output. By using "allow_write: false", some or all of the ptys can be excluded from writing the serial port.
   - An example use case is several users of a single NMEA-0183 GPS feed. 


Invocation of `goby_serial_mux` connecting to a real serial port `/dev/ttyUSB0` and three PTYs: `/tmp/pty[1,2,3]`:
```
goby_serial_mux --primary_serial 'port: "/dev/ttyUSB0" baud: 19200' --secondary 'pty { port: "/tmp/pty1" baud: 19200 } allow_write: true' --secondary 'pty { port: "/tmp/pty2" baud: 19200 } allow_write: true ' --secondary 'pty { port: "/tmp/pty3" baud: 19200 } allow_write: false' -n -vvv
```