### PR TITLE
Use std::cerr until glog is configured.

### DIFF
--- a/src/apps/moos/goby_moos_gateway/goby_moos_gateway.cpp
+++ b/src/apps/moos/goby_moos_gateway/goby_moos_gateway.cpp
@@ -70,15 +70,20 @@ int main(int argc, char* argv[])
             glog.is(VERBOSE) && glog << "Loading plugin library: " << plugin << std::endl;
             void* handle = dlopen(plugin.c_str(), RTLD_LAZY);
             if (handle)
+            { 
                 goby::moos::GobyMOOSGateway::dl_handles_.push_back(handle);
+            }
             else
-                glog.is(DIE) && glog << "Failed to open library: " << plugin
-                                     << ", reason: " << dlerror() << std::endl;
-
+            {
+                std::cerr << "Failed to open library: " << plugin << ", reason: " << dlerror()
+                          << std::endl;
+                exit(EXIT_FAILURE);
+            }
             if (!dlsym(handle, "goby3_moos_gateway_load"))
             {
-                glog.is(DIE) && glog << "Function goby3_moos_gateway_load in library: " << plugin
-                                     << " does not exist." << std::endl;
+                std::cerr << "Function goby3_moos_gateway_load in library: " << plugin
+                          << " does not exist." << std::endl;
+                exit(EXIT_FAILURE);
             }
         }
     }


### PR DESCRIPTION
When trying to load a plugin the application would just exit with no output at all. If I unset the GOBY_MOOS_GATEWAY_PLUGINS variable I would see  "Must define at least one plugin library in GOBY_MOOS_GATEWAY_PLUGINS environmental variable".  I am guessing that message uses std::cerr for the same reason. 

Turns out I had a typo in my plugin name, but this fix should make figuring that out easier in the future. 