### PR TITLE
3.0 intervehicle subscription improvements

### DIFF
--- a/src/acomms/protobuf/buffer.proto
+++ b/src/acomms/protobuf/buffer.proto
@@ -17,7 +17,8 @@ message DynamicBufferConfig
     // lowest value takes precedence
     optional double blackout_time = 3 [
         default = 0,
-        (dccl.field) = {min: 0 max: 3600 precision: 0 units {base_dimensions: "T"}}
+        (dccl.field) =
+            {min: 0 max: 3600 precision: 0 units {base_dimensions: "T"}}
     ];
     // larger value takes precedence
     optional uint32 max_queue = 4
@@ -31,6 +32,6 @@ message DynamicBufferConfig
             {min: 1 max: 86400 precision: 0 units {base_dimensions: "T"}}
     ];
     // use average of values
-    optional int32 value_base = 7
-        [default = 100, (dccl.field) = {min: 1 max: 1000}];
+    optional double value_base = 7
+        [default = 100, (dccl.field) = {min: 1 max: 1000 precision: 0}];
 }

--- a/src/apps/zeromq/gobyd/CMakeLists.txt
+++ b/src/apps/zeromq/gobyd/CMakeLists.txt
@@ -1,2 +1,4 @@
 add_executable(gobyd gobyd.cpp)
 target_link_libraries(gobyd goby goby_zeromq)
+
+generate_middleware_interfaces(gobyd)

--- a/src/middleware/protobuf/intervehicle.proto
+++ b/src/middleware/protobuf/intervehicle.proto
@@ -152,3 +152,11 @@ message ExpireMessagePair
         1;
     required ExpireData data = 2;
 }
+
+
+message SubscriptionReport
+{
+    required uint32 link_modem_id = 1;
+    repeated Subscription subscription = 2;
+    optional Subscription changed = 3;
+}

--- a/src/middleware/protobuf/intervehicle.proto
+++ b/src/middleware/protobuf/intervehicle.proto
@@ -19,7 +19,7 @@ message PortalConfig
     {
         required uint32 modem_id = 1;
         optional uint32 subnet_mask = 2 [default = 0xFFF0];
-        
+
         required goby.acomms.protobuf.DriverConfig driver = 11
             [(goby.field).description =
                  "Configure the modem driver(s) in use by this portal"];
@@ -41,6 +41,23 @@ message PortalConfig
     }
 
     repeated LinkConfig link = 1;
+
+    message PersistSubscriptions
+    {
+        required string name = 1
+            [(goby.field).description =
+                 "Name to use when persisting subscriptions (must be unique "
+                 "for each InterVehiclePortal on this machine)"];
+        required string dir = 2
+            [(goby.field).description =
+                 "Directory to write subscription data file"];
+    }
+    optional PersistSubscriptions persist_subscriptions = 10
+        [(goby.field).description =
+             "Configuration for persisting intervehicle subscriptions between "
+             "restarts. If omitted, subscriptions will not be persisted, and "
+             "all remote subscribers will need to resubscribe when this Portal "
+             "restarts."];
 }
 
 message Status
@@ -69,7 +86,7 @@ message Subscription
         UNSUBSCRIBE = 2;
     }
     required Action action = 3;
-    
+
     required uint32 dccl_id = 5 [(dccl.field) = {min: 1 max: 32767}];
     required uint32 group = 6 [(dccl.field) = {min: 0 max: 255}];
     optional TransporterConfig intervehicle = 10;
@@ -153,10 +170,22 @@ message ExpireMessagePair
     required ExpireData data = 2;
 }
 
-
 message SubscriptionReport
 {
     required uint32 link_modem_id = 1;
     repeated Subscription subscription = 2;
     optional Subscription changed = 3;
+}
+
+message SubscriptionPersistCollection
+{
+    option (dccl.msg) = {
+        unit_system: "si"
+    };
+
+    required uint64 time = 1 [(dccl.field) = {
+        omit: true
+        units {prefix: "micro" base_dimensions: "T"}
+    }];
+    repeated Subscription subscription = 2;
 }

--- a/src/middleware/transport/intervehicle.h
+++ b/src/middleware/transport/intervehicle.h
@@ -284,7 +284,7 @@ class InterVehicleTransporterBase
                     std::make_shared<SerializationSubscription<Data, MarshallingScheme::DCCL>>(
                         func, group, subscriber);
 
-                this->subscriptions_[dccl_id].insert(std::make_pair(group, subscription));
+                this->subscriptions_[dccl_id][group] = subscription;
             }
             break;
             case SubscriptionAction::UNSUBSCRIBE:
@@ -429,8 +429,9 @@ class InterVehicleTransporterBase
 
   protected:
     // maps DCCL ID to map of Group->subscription
-    std::unordered_map<int, std::unordered_multimap<
-                                std::string, std::shared_ptr<const SerializationHandlerBase<>>>>
+    // only one subscription allowed per IntervehicleForwarder/Portal (new subscription overwrites old one)
+    std::unordered_map<
+        int, std::unordered_map<std::string, std::shared_ptr<const SerializationHandlerBase<>>>>
         subscriptions_;
 
   private:
@@ -698,7 +699,7 @@ class InterVehiclePortal
                     received_.push_back(msg);
                 });
 
-        // a message required ack can be disposed by either [1] ack, [2] expire (TTL exceeded), [3] having no subscribers, [4] queue size exceeded.
+        // a message requiring ack can be disposed by either [1] ack, [2] expire (TTL exceeded), [3] having no subscribers, [4] queue size exceeded.
         // post the correct callback (ack for [1] and expire for [2-4])
         // and remove the pending ack message
         using ack_pair_type = intervehicle::protobuf::AckMessagePair;

--- a/src/middleware/transport/intervehicle/driver_thread.h
+++ b/src/middleware/transport/intervehicle/driver_thread.h
@@ -35,6 +35,8 @@
 #include "goby/middleware/transport/interprocess.h"
 #include "goby/middleware/transport/interthread.h"
 
+#include "goby/middleware/transport/intervehicle/groups.h"
+
 namespace goby
 {
 namespace acomms
@@ -104,26 +106,6 @@ serialize_publication(const Data& d, const Group& group, const Publisher<Data>& 
     return msg;
 }
 
-namespace groups
-{
-constexpr Group subscription_forward{"goby::middleware::intervehicle::subscription_forward",
-                                     Group::broadcast_group};
-
-constexpr Group modem_data_out{"goby::middleware::intervehicle::modem_data_out"};
-constexpr Group modem_data_in{"goby::middleware::intervehicle::modem_data_in"};
-constexpr Group modem_ack_in{"goby::middleware::intervehicle::modem_ack_in"};
-constexpr Group modem_expire_in{"goby::middleware::intervehicle::modem_expire_in"};
-
-constexpr Group modem_subscription_forward_tx{
-    "goby::middleware::intervehicle::modem_subscription_forward_tx"};
-constexpr Group modem_subscription_forward_rx{
-    "goby::middleware::intervehicle::modem_subscription_forward_rx"};
-constexpr Group modem_driver_ready{"goby::middleware::intervehicle::modem_driver_ready"};
-
-constexpr Group metadata_request{"goby::middleware::intervehicle::metadata_request"};
-
-} // namespace groups
-
 class ModemDriverThread
     : public goby::middleware::Thread<intervehicle::protobuf::PortalConfig::LinkConfig,
                                       InterProcessForwarder<InterThreadTransporter>>
@@ -176,6 +158,8 @@ class ModemDriverThread
 
         return dest_in_subnet;
     }
+
+    void _publish_subscription_report(const intervehicle::protobuf::Subscription& changed);
 
   private:
     std::unique_ptr<InterThreadTransporter> interthread_;

--- a/src/middleware/transport/intervehicle/groups.h
+++ b/src/middleware/transport/intervehicle/groups.h
@@ -1,0 +1,55 @@
+// Copyright 2020:
+//   GobySoft, LLC (2013-)
+//   Community contributors (see AUTHORS file)
+// File authors:
+//   Toby Schneider <toby@gobysoft.org>
+//
+//
+// This file is part of the Goby Underwater Autonomy Project Libraries
+// ("The Goby Libraries").
+//
+// The Goby Libraries are free software: you can redistribute them and/or modify
+// them under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// The Goby Libraries are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Goby.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+namespace goby
+{
+namespace middleware
+{
+namespace intervehicle
+{
+namespace groups
+{
+constexpr Group subscription_forward{"goby::middleware::intervehicle::subscription_forward",
+                                     Group::broadcast_group};
+
+constexpr Group modem_data_out{"goby::middleware::intervehicle::modem_data_out"};
+constexpr Group modem_data_in{"goby::middleware::intervehicle::modem_data_in"};
+constexpr Group modem_ack_in{"goby::middleware::intervehicle::modem_ack_in"};
+constexpr Group modem_expire_in{"goby::middleware::intervehicle::modem_expire_in"};
+
+constexpr Group modem_subscription_forward_tx{
+    "goby::middleware::intervehicle::modem_subscription_forward_tx"};
+constexpr Group modem_subscription_forward_rx{
+    "goby::middleware::intervehicle::modem_subscription_forward_rx"};
+constexpr Group modem_driver_ready{"goby::middleware::intervehicle::modem_driver_ready"};
+
+constexpr Group metadata_request{"goby::middleware::intervehicle::metadata_request"};
+
+constexpr Group subscription_report{"goby::middleware::intervehicle::subscription_report"};
+
+} // namespace groups
+} // namespace intervehicle
+} // namespace middleware
+} // namespace goby


### PR DESCRIPTION
Add:
- SubscriptionReport for all intervehicle subscriptions
- ability for `gobyd` to persist subscriptions to disk and then re-read them upon the next launch. This is valuable to allow gobyd to restart (or the system running it) while not requiring all remote intervehicle subscribers to re-subscribe.