### PR TITLE
3.0 fix io write buffer

### DIFF
--- a/src/middleware/io/detail/tcp_client_interface.h
+++ b/src/middleware/io/detail/tcp_client_interface.h
@@ -75,21 +75,9 @@ class TCPClientThread : public IOThread<line_in_group, line_out_group, publish_l
     }
 
   private:
-    /// \brief Starts an asynchronous write from data published
-    void async_write(const std::string& bytes) override
+    void async_write(std::shared_ptr<const goby::middleware::protobuf::IOData> io_msg) override
     {
-        boost::asio::async_write(
-            this->mutable_socket(), boost::asio::buffer(bytes),
-            [this](const boost::system::error_code& ec, std::size_t bytes_transferred) {
-                if (!ec && bytes_transferred > 0)
-                {
-                    this->handle_write_success(bytes_transferred);
-                }
-                else
-                {
-                    this->handle_write_error(ec);
-                }
-            });
+        basic_async_write(this, io_msg);
     }
 
     /// \brief Tries to open the tcp client socket, and if fails publishes an error

--- a/src/middleware/io/detail/tcp_server_interface.h
+++ b/src/middleware/io/detail/tcp_server_interface.h
@@ -81,12 +81,12 @@ class TCPSession : public std::enable_shared_from_this<TCPSession<TCPServerThrea
     const boost::asio::ip::tcp::endpoint& local_endpoint() { return local_endpoint_; }
 
     // public so TCPServer can call this
-    virtual void async_write(const std::string& bytes)
+    virtual void async_write(std::shared_ptr<const goby::middleware::protobuf::IOData> io_msg)
     {
         auto self(this->shared_from_this());
         boost::asio::async_write(
-            socket_, boost::asio::buffer(bytes),
-            [this, self](boost::system::error_code ec, std::size_t bytes_transferred) {
+            socket_, boost::asio::buffer(io_msg->data()),
+            [this, self, io_msg](boost::system::error_code ec, std::size_t bytes_transferred) {
                 if (!ec)
                 {
                     server_.handle_write_success(bytes_transferred);
@@ -265,7 +265,7 @@ void goby::middleware::io::detail::TCPServerThread<
             (io_msg->tcp_dest() ==
              endpoint_convert<protobuf::TCPEndPoint>(client->remote_endpoint())))
         {
-            client->async_write(io_msg->data());
+            client->async_write(io_msg);
         }
     }
 }

--- a/src/middleware/io/udp_one_to_many.h
+++ b/src/middleware/io/udp_one_to_many.h
@@ -157,7 +157,7 @@ void goby::middleware::io::UDPOneToManyThread<
 
     this->mutable_socket().async_send_to(
         boost::asio::buffer(io_msg->data()), remote_endpoint,
-        [this](const boost::system::error_code& ec, std::size_t bytes_transferred) {
+        [this, io_msg](const boost::system::error_code& ec, std::size_t bytes_transferred) {
             if (!ec && bytes_transferred > 0)
             {
                 this->handle_write_success(bytes_transferred);

--- a/src/middleware/io/udp_point_to_point.h
+++ b/src/middleware/io/udp_point_to_point.h
@@ -80,7 +80,7 @@ void goby::middleware::io::UDPPointToPointThread<
 {
     this->mutable_socket().async_send_to(
         boost::asio::buffer(io_msg->data()), remote_endpoint_,
-        [this](const boost::system::error_code& ec, std::size_t bytes_transferred) {
+        [this, io_msg](const boost::system::error_code& ec, std::size_t bytes_transferred) {
             if (!ec && bytes_transferred > 0)
             {
                 this->handle_write_success(bytes_transferred);


### PR DESCRIPTION
Fixes #176 by removing the `async_write(const std::string& )` overload, and then having all threads capture the io_msg shared pointer in their completion handler lambdas, thus ensuring that a least one copy of the io_msg shared pointer (which includes the data buffer string) exists until the completion handler is called.

Added common "basic_async_write" function to reduce duplicated code for this common scenario (calling the boost::asio::async_write free function).

It's unclear if this is a real problem, but to avoid ThreadSanitizer complaints, I also added a workaround for this GCC bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?format=multiple&id=77704