### PR TITLE
Wait Until Triggered

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,19 +216,23 @@ workflows:
   version: 2
   commit:
     jobs:
-      - amd64-stretch-build:
+# To keep basic builds to a minimum, remove Xenial and Stretch
+#      - amd64-xenial-build:
+#          <<: *filter-template-non-master
+#      - amd64-stretch-build:
+#          <<: *filter-template-non-master
+
+      - amd64+tsan-build:
           <<: *filter-template-non-master
       - amd64-buster-build:
           <<: *filter-template-non-master
-# To keep basic builds to a minimum, remove Xenial
-#      - amd64-xenial-build:
-#          <<: *filter-template-non-master
       - amd64-bionic-build:
           <<: *filter-template-non-master
       - amd64-focal-build:
           <<: *filter-template-non-master
+
       - amd64-focal-minimal-build:
-          <<: *filter-template-non-master          
+          <<: *filter-template-master-only
       
       - get-orig-source:
           <<: *filter-template-master-only
@@ -327,9 +331,6 @@ workflows:
       - amd64+asan-build:
           <<: *filter-template-master-only
 
-# problem running unit test on CircleCI executors
-#      - amd64+tsan-build:
-#          <<: *filter-template-master-only
 
 # problem running this using clang with libcrypto++-dev 
 #      - amd64+ubsan-build:

--- a/src/apps/zeromq/gobyd/gobyd.cpp
+++ b/src/apps/zeromq/gobyd/gobyd.cpp
@@ -80,6 +80,8 @@ class DaemonConfigurator : public goby::middleware::ProtobufConfigurator<protobu
     {
         protobuf::GobyDaemonConfig& cfg = mutable_cfg();
 
+        cfg.mutable_interprocess()->set_client_name(cfg.app().name());
+
         if (cfg.has_intervehicle())
         {
             auto& intervehicle = *cfg.mutable_intervehicle();
@@ -138,6 +140,8 @@ goby::apps::zeromq::Daemon::Daemon()
                 quit();
             }
         });
+
+    interprocess_.ready();
 }
 
 goby::apps::zeromq::Daemon::~Daemon()

--- a/src/apps/zeromq/gobyd/gobyd.cpp
+++ b/src/apps/zeromq/gobyd/gobyd.cpp
@@ -49,6 +49,14 @@ class Daemon : public goby::middleware::Application<protobuf::GobyDaemonConfig>
   private:
     void run() override;
 
+    goby::zeromq::Manager make_manager()
+    {
+        return app_cfg().has_hold()
+                   ? goby::zeromq::Manager(*manager_context_, app_cfg().interprocess(), router_,
+                                           app_cfg().hold())
+                   : goby::zeromq::Manager(*manager_context_, app_cfg().interprocess(), router_);
+    }
+
   private:
     // for handling ZMQ Interprocess Communications
     std::unique_ptr<zmq::context_t> router_context_;
@@ -99,7 +107,7 @@ goby::apps::zeromq::Daemon::Daemon()
     : router_context_(new zmq::context_t(app_cfg().router_threads())),
       manager_context_(new zmq::context_t(1)),
       router_(*router_context_, app_cfg().interprocess()),
-      manager_(*manager_context_, app_cfg().interprocess(), router_),
+      manager_(make_manager()),
       router_thread_(new std::thread([&] { router_.run(); })),
       manager_thread_(new std::thread([&] { manager_.run(); })),
       interprocess_(app_cfg().interprocess())

--- a/src/middleware/application/configurator.h
+++ b/src/middleware/application/configurator.h
@@ -43,7 +43,7 @@ template <typename Config> class ConfiguratorInterface
 
     /// \brief Subset of the configuration used to configure the Application itself
     /// \todo Change AppConfig to a C++ struct (not a Protobuf message)
-    const protobuf::AppConfig& app_configuration() const { return app_configuration_; }
+    virtual const protobuf::AppConfig& app_configuration() const { return app_configuration_; }
 
     /// \brief Override to validate the configuration
     ///
@@ -64,7 +64,7 @@ template <typename Config> class ConfiguratorInterface
     Config& mutable_cfg() { return cfg_; }
 
     /// \brief Derived classes can modify the application configuration as needed in their constructor
-    protobuf::AppConfig& mutable_app_configuration() { return app_configuration_; }
+    virtual protobuf::AppConfig& mutable_app_configuration() { return app_configuration_; }
 
   private:
     Config cfg_;
@@ -83,6 +83,8 @@ template <typename Config> class ProtobufConfigurator : public ConfiguratorInter
     /// \param argv Command line parameters
     ProtobufConfigurator(int argc, char* argv[]);
 
+    const protobuf::AppConfig& app_configuration() const override { return this->cfg().app(); }
+
   protected:
     virtual void validate() const override
     {
@@ -96,6 +98,11 @@ template <typename Config> class ProtobufConfigurator : public ConfiguratorInter
     {
         std::cerr << "Invalid configuration: use --help and/or --example_config for more help: "
                   << e.what() << std::endl;
+    }
+
+    protobuf::AppConfig& mutable_app_configuration() override
+    {
+        return *this->mutable_cfg().mutable_app();
     }
 
     void merge_app_base_cfg(protobuf::AppConfig* base_cfg,

--- a/src/middleware/application/detail/interprocess_common.h
+++ b/src/middleware/application/detail/interprocess_common.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "goby/zeromq/protobuf/interprocess_config.pb.h"
+
+namespace goby
+{
+namespace middleware
+{
+namespace detail
+{
+inline goby::zeromq::protobuf::InterProcessPortalConfig
+make_interprocess_config(goby::zeromq::protobuf::InterProcessPortalConfig cfg, std::string app_name)
+{
+    cfg.set_client_name(app_name);
+    return cfg;
+}
+} // namespace detail
+} // namespace middleware
+} // namespace goby

--- a/src/middleware/application/detail/interprocess_common.h
+++ b/src/middleware/application/detail/interprocess_common.h
@@ -14,6 +14,7 @@ make_interprocess_config(goby::zeromq::protobuf::InterProcessPortalConfig cfg, s
     cfg.set_client_name(app_name);
     return cfg;
 }
+
 } // namespace detail
 } // namespace middleware
 } // namespace goby

--- a/src/middleware/application/interface.h
+++ b/src/middleware/application/interface.h
@@ -32,9 +32,9 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#include "goby/exception.h"
 #include <boost/format.hpp>
 
+#include "goby/exception.h"
 #include "goby/middleware/application/configurator.h"
 #include "goby/middleware/marshalling/detail/dccl_serializer_parser.h"
 #include "goby/middleware/protobuf/app_config.pb.h"

--- a/src/middleware/application/interface.h
+++ b/src/middleware/application/interface.h
@@ -81,14 +81,26 @@ template <typename Config> class Application
     using ConfigType = Config;
 
   protected:
+    /// \brief Called just before initialize
+    virtual void pre_initialize(){};
+
     /// \brief Perform any initialize tasks that couldn't be done in the constructor
     virtual void initialize(){};
+
+    /// \brief Called just after initialize
+    virtual void post_initialize(){};
 
     /// \brief Runs continuously until quit() is called
     virtual void run() = 0;
 
+    /// \brief Called just before finalize
+    virtual void pre_finalize(){};
+
     /// \brief Perform any final cleanup actions just before the destructor is called
     virtual void finalize(){};
+
+    /// \brief Called just after finalize
+    virtual void post_finalize(){};
 
     /// \brief Requests a clean exit.
     ///
@@ -250,11 +262,14 @@ template <typename Config> int goby::middleware::Application<Config>::__run()
     sigaddset(&signal_mask, SIGWINCH);
     pthread_sigmask(SIG_BLOCK, &signal_mask, NULL);
 
-    // continue to run while we are alive (quit() has not been called)
-
+    this->pre_initialize();
     this->initialize();
+    this->post_initialize();
+    // continue to run while we are alive (quit() has not been called)
     while (alive_) { this->run(); }
+    this->pre_finalize();
     this->finalize();
+    this->post_finalize();
     return return_value_;
 }
 

--- a/src/middleware/application/multi_thread.h
+++ b/src/middleware/application/multi_thread.h
@@ -27,6 +27,7 @@
 #include <boost/units/systems/si.hpp>
 
 #include "goby/exception.h"
+#include "goby/middleware/application/detail/interprocess_common.h"
 #include "goby/middleware/application/detail/thread_type_selector.h"
 #include "goby/middleware/application/interface.h"
 #include "goby/middleware/application/thread.h"
@@ -313,7 +314,8 @@ class MultiThreadApplication
     /// \param loop_freq The frequency at which to attempt to call loop(), assuming the main thread isn't blocked handling transporter callbacks (e.g. subscribe callbacks). Zero or negative indicates loop() will never be called.
     MultiThreadApplication(boost::units::quantity<boost::units::si::frequency> loop_freq)
         : Base(loop_freq, &intervehicle_),
-          interprocess_(Base::interthread(), this->app_cfg().interprocess()),
+          interprocess_(Base::interthread(), detail::make_interprocess_config(
+                                                 this->app_cfg().interprocess(), this->app_name())),
           intervehicle_(interprocess_)
     {
         // handle goby_terminate request

--- a/src/middleware/application/multi_thread.h
+++ b/src/middleware/application/multi_thread.h
@@ -234,7 +234,7 @@ class MultiThreadApplicationBase : public goby::middleware::Application<Config>,
     virtual ~MultiThreadApplicationBase() {}
 
     InterThreadTransporter& interthread() { return interthread_; }
-    virtual void finalize() override { join_all_threads(); }
+    virtual void post_finalize() override { join_all_threads(); }
 
     void join_all_threads()
     {
@@ -359,6 +359,9 @@ class MultiThreadApplication
         health.set_name(this->app_name());
         health.set_state(goby::middleware::protobuf::HEALTH__OK);
     }
+
+    /// \brief Assume all required subscriptions are done in the Constructor or in initialize(). If this isn't the case, this method can be overridden
+    virtual void post_initialize() override { interprocess().ready(); };
 };
 
 /// \brief Base class for building multithreaded Goby applications that do not have perform any interprocess (or outer) communications, but only communicate internally via the InterThreadTransporter

--- a/src/middleware/application/single_thread.h
+++ b/src/middleware/application/single_thread.h
@@ -26,8 +26,10 @@
 
 #include <boost/units/systems/si.hpp>
 
+#include "goby/middleware/application/detail/interprocess_common.h"
 #include "goby/middleware/application/interface.h"
 #include "goby/middleware/application/thread.h"
+
 #include "goby/middleware/transport/interprocess.h"
 #include "goby/middleware/transport/intervehicle.h"
 
@@ -66,7 +68,8 @@ class SingleThreadApplication : public goby::middleware::Application<Config>,
     /// \param loop_freq The frequency at which to attempt to call loop(), assuming the main thread isn't blocked handling transporter callbacks (e.g. subscribe callbacks). Zero or negative indicates loop() will never be called.
     SingleThreadApplication(boost::units::quantity<boost::units::si::frequency> loop_freq)
         : MainThread(this->app_cfg(), loop_freq),
-          interprocess_(this->app_cfg().interprocess()),
+          interprocess_(
+              detail::make_interprocess_config(this->app_cfg().interprocess(), this->app_name())),
           intervehicle_(interprocess_)
     {
         this->set_transporter(&intervehicle_);

--- a/src/middleware/application/single_thread.h
+++ b/src/middleware/application/single_thread.h
@@ -112,6 +112,9 @@ class SingleThreadApplication : public goby::middleware::Application<Config>,
         health.set_state(goby::middleware::protobuf::HEALTH__OK);
     }
 
+    /// \brief Assume all required subscriptions are done in the Constructor or in initialize(). If this isn't the case, this method can be overridden
+    virtual void post_initialize() override { interprocess().ready(); };
+
   private:
     void run() override { MainThread::run_once(); }
 };

--- a/src/middleware/io/detail/io_interface.h
+++ b/src/middleware/io/detail/io_interface.h
@@ -373,7 +373,7 @@ void goby::middleware::io::detail::IOThread<line_in_group, line_out_group, publi
         if (now > next_open_attempt_)
             try_open();
         else
-            usleep(10000); // avoid pegging CPU while waiting to attempt reopening socket
+            usleep(100000); // avoid pegging CPU while waiting to attempt reopening socket
     }
 }
 

--- a/src/middleware/protobuf/terminate.proto
+++ b/src/middleware/protobuf/terminate.proto
@@ -12,3 +12,20 @@ message TerminateResponse
     optional string target_name = 1;
     optional uint32 target_pid = 2;
 }
+
+
+message TerminateResult
+{        
+    optional string target_name = 1;
+    optional uint32 target_pid = 2;
+
+    enum Result
+    {
+        PROCESS_RESPONDED = 1;
+        PROCESS_CLEANLY_QUIT = 2;
+        TIMEOUT_RESPONSE = 3;
+        TIMEOUT_RUNNING = 4;
+    }
+    required Result result = 3;
+
+}

--- a/src/middleware/terminate/groups.h
+++ b/src/middleware/terminate/groups.h
@@ -36,6 +36,7 @@ namespace groups
 {
 constexpr goby::middleware::Group terminate_request{"goby::terminate::request"};
 constexpr goby::middleware::Group terminate_response{"goby::terminate::response"};
+constexpr goby::middleware::Group terminate_result{"goby::terminate::result"};
 } // namespace groups
 } // namespace goby
 } // namespace goby

--- a/src/middleware/transport/detail/subscription_store.h
+++ b/src/middleware/transport/detail/subscription_store.h
@@ -200,8 +200,7 @@ template <typename Data> class SubscriptionStore : public SubscriptionStoreBase
                 if (thread_id != std::this_thread::get_id() || publisher.cfg().echo())
                 {
                     // protect the DataQueue we are writing to
-                    std::unique_lock<std::mutex> lock(
-                        *(data_protection_.find(thread_id)->second.data_mutex));
+                    std::unique_lock<std::mutex> lock(*(data_protection_.at(thread_id).data_mutex));
                     auto queue_it = data_.find(thread_id);
                     queue_it->second.insert(group, data);
                     cv_to_notify.push_back(data_protection_.at(thread_id));

--- a/src/middleware/transport/interface.h
+++ b/src/middleware/transport/interface.h
@@ -379,7 +379,7 @@ int goby::middleware::PollerInterface::_poll_all(
 
             if (poll_items == 0)
                 goby::glog.is(goby::util::logger::DEBUG3) &&
-                    goby::glog << "PollerInterface condition_variable: spurious wakeup"
+                    goby::glog << "PollerInterface condition_variable: no data (spurious?) wakeup"
                                << std::endl;
         }
         else

--- a/src/middleware/transport/intervehicle/driver_thread.h
+++ b/src/middleware/transport/intervehicle/driver_thread.h
@@ -154,7 +154,7 @@ class ModemDriverThread
             goby::glog.is_debug3() && goby::glog
                                           << "Dest: " << dest_id
                                           << " is not in subnet (our id: " << cfg().modem_id()
-                                          << ", mask: " << cfg().subnet_mask();
+                                          << ", mask: " << cfg().subnet_mask() << std::endl;
 
         return dest_in_subnet;
     }

--- a/src/test/zeromq/single_thread_app1/CMakeLists.txt
+++ b/src/test/zeromq/single_thread_app1/CMakeLists.txt
@@ -3,5 +3,5 @@ protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS test.proto)
 add_executable(goby_test_zeromq_single_thread_app1 test.cpp  ${PROTO_SRCS} ${PROTO_HDRS})
 target_link_libraries(goby_test_zeromq_single_thread_app1 goby goby_zeromq)
 
-add_test(goby_test_zeromq_single_thread_app1 ${goby_BIN_DIR}/goby_test_zeromq_single_thread_app1)
+add_test(goby_test_zeromq_single_thread_app1 ${goby_BIN_DIR}/goby_test_zeromq_single_thread_app1 -vvvv) 
 

--- a/src/test/zeromq/single_thread_app1/test.cpp
+++ b/src/test/zeromq/single_thread_app1/test.cpp
@@ -54,7 +54,9 @@ class TestConfigurator : public goby::middleware::ProtobufConfigurator<TestConfi
         : goby::middleware::ProtobufConfigurator<TestConfig>(argc, argv)
     {
         TestConfig& cfg = mutable_cfg();
+        cfg.mutable_app()->set_name("TestApp");
         cfg.mutable_interprocess()->set_platform(platform_name);
+        cfg.mutable_interprocess()->set_manager_timeout_seconds(5);
     }
 };
 
@@ -64,22 +66,18 @@ class TestApp : public Base
     TestApp() : Base(10)
     {
         interprocess().subscribe<widget1, Widget>([this](const Widget& w) { post(w); });
+        interprocess().ready();
     }
 
     void loop() override
     {
         static int i = 0;
         ++i;
-        // wait for zeromq pub/sub setup
-        if (i < 1 * loop_frequency_hertz())
-        {
-            return;
-        }
-        else if (i > (10 + 1 * loop_frequency_hertz()))
+        if (i > (10 + 1 * loop_frequency_hertz()))
         {
             quit();
         }
-        else
+        else if (!interprocess().hold_state())
         {
             assert(rx_count_ == tx_count_);
             std::cout << goby::time::SystemClock::now() << std::endl;
@@ -117,11 +115,14 @@ int main(int argc, char* argv[])
     {
         goby::zeromq::protobuf::InterProcessPortalConfig cfg;
         cfg.set_platform(platform_name);
+        goby::zeromq::protobuf::InterProcessManagerHold hold;
+        hold.add_required_client("TestApp");
+
         manager_context.reset(new zmq::context_t(1));
         router_context.reset(new zmq::context_t(1));
         goby::zeromq::Router router(*router_context, cfg);
         t2.reset(new std::thread([&] { router.run(); }));
-        goby::zeromq::Manager manager(*manager_context, cfg, router);
+        goby::zeromq::Manager manager(*manager_context, cfg, router, hold);
         t3.reset(new std::thread([&] { manager.run(); }));
         int wstatus;
         wait(&wstatus);
@@ -134,8 +135,8 @@ int main(int argc, char* argv[])
     }
     else
     {
-        // wait for router to set up
-        sleep(1);
+        // let manager and router start up
+        //      sleep(1);
         return goby::run<goby::test::zeromq::TestApp>(
             goby::test::zeromq::TestConfigurator(argc, argv));
     }

--- a/src/test/zeromq/single_thread_app1/test.cpp
+++ b/src/test/zeromq/single_thread_app1/test.cpp
@@ -71,15 +71,12 @@ class TestApp : public Base
 
     void loop() override
     {
-        static int i = 0;
-        ++i;
-        if (i > (10 + 1 * loop_frequency_hertz()))
+        if (rx_count_ == 10)
         {
             quit();
         }
-        else if (!interprocess().hold_state())
+        else if (!interprocess().hold_state() && rx_count_ == tx_count_)
         {
-            assert(rx_count_ == tx_count_);
             std::cout << goby::time::SystemClock::now() << std::endl;
             Widget w;
             w.set_b(++tx_count_);
@@ -93,6 +90,7 @@ class TestApp : public Base
         std::cout << "Rx: " << widget.DebugString() << std::flush;
         assert(widget.b() == tx_count_);
         ++rx_count_;
+        assert(rx_count_ == tx_count_);
     }
 
   private:

--- a/src/test/zeromq/zeromq_portal_without_interthread/test.cpp
+++ b/src/test/zeromq/zeromq_portal_without_interthread/test.cpp
@@ -58,6 +58,7 @@ extern constexpr goby::middleware::Group widget{"Widget"};
 void publisher(const goby::zeromq::protobuf::InterProcessPortalConfig& cfg)
 {
     goby::zeromq::InterProcessPortal<> zmq(cfg);
+    zmq.ready();
 
     double a = 0;
     while (publish_count < max_publish)
@@ -73,9 +74,6 @@ void publisher(const goby::zeromq::protobuf::InterProcessPortalConfig& cfg)
         zmq.publish<widget>(w1);
 
         glog.is(DEBUG1) && glog << "Published: " << publish_count << std::endl;
-
-        //        if (publish_count < 0)
-        //            usleep(1e6);
 
         ++publish_count;
     }
@@ -113,6 +111,7 @@ void subscriber(const goby::zeromq::protobuf::InterProcessPortalConfig& cfg)
     zmq.subscribe<sample1, Sample>(&handle_sample1);
     zmq.subscribe<sample2, Sample>(&handle_sample2);
     zmq.subscribe<widget, Widget>(&handle_widget);
+    zmq.ready();
     while (ipc_receive_count < 3 * max_publish)
     {
         glog.is(DEBUG1) && glog << ipc_receive_count << "/" << 3 * max_publish << std::endl;

--- a/src/zeromq/protobuf/gobyd_config.proto
+++ b/src/zeromq/protobuf/gobyd_config.proto
@@ -11,5 +11,8 @@ message GobyDaemonConfig
     optional goby.middleware.protobuf.AppConfig app = 1;
     optional int32 router_threads = 2 [default = 10];
     optional goby.zeromq.protobuf.InterProcessPortalConfig interprocess = 3;
-    optional goby.middleware.intervehicle.protobuf.PortalConfig intervehicle = 4;
+    optional goby.middleware.intervehicle.protobuf.PortalConfig intervehicle =
+        4;
+
+    optional goby.zeromq.protobuf.InterProcessManagerHold hold = 10;
 }

--- a/src/zeromq/protobuf/interprocess_config.proto
+++ b/src/zeromq/protobuf/interprocess_config.proto
@@ -1,9 +1,16 @@
 syntax = "proto2";
+import "goby/protobuf/option_extensions.proto";
+
 package goby.zeromq.protobuf;
 
 message InterProcessPortalConfig
 {
-    optional string platform = 1 [default = "default_goby_platform"];
+    optional string platform = 1 [
+        default = "default_goby_platform",
+        (goby.field).description =
+            "Name for this platform (vehicle name, mooring name, topside name, "
+            "etc.)"
+    ];
 
     enum Transport
     {
@@ -11,14 +18,66 @@ message InterProcessPortalConfig
         TCP = 3;
     };
 
-    optional Transport transport = 2 [default = IPC];
-    optional string socket_name = 3;
-    optional string ipv4_address = 4 [default = "127.0.0.1"];
-    optional uint32 tcp_port = 5 [default = 11144];
+    optional Transport transport = 2 [
+        default = IPC,
+        (goby.field).description =
+            "Transport to use: IPC uses UNIX sockets and is only suitable for "
+            "single machine interprocess, TCP uses Internet Protocol and is "
+            "suitable for any reasonably high-speed LAN"
+    ];
+    optional string socket_name = 3
+        [(goby.field).description =
+             "For transport == IPC, the path to the socket file to use for "
+             "comms with the Manager (gobyd). If omitted, defaults to "
+             "\"/tmp/goby_{platform}.manager"];
+    optional string ipv4_address = 4 [
+        default = "127.0.0.1",
+        (goby.field).description =
+            "For transport == TCP, IP address for the Manager (gobyd)"
+    ];
+    optional uint32 tcp_port = 5 [
+        default = 11144,
+        (goby.field).description =
+            "For transport == TCP, TCP port for the Manager (gobyd)"
+    ];
 
-    optional uint32 send_queue_size = 6 [default = 1000];
-    optional uint32 receive_queue_size = 7 [default = 1000];
-    optional uint32 zeromq_number_io_threads = 8 [default = 4];
+    optional uint32 send_queue_size = 6 [
+        default = 1000,
+        (goby.field).description =
+            "Queue size for outbound messages, i.e. ZMQ_SNDHWM"
+    ];
+    optional uint32 receive_queue_size = 7 [
+        default = 1000,
+        (goby.field).description =
+            "Queue size for inbound messages, i.e. ZMQ_RCVHWM"
+    ];
+    optional uint32 zeromq_number_io_threads = 8 [
+        default = 4,
+        (goby.field).description =
+            "Number of threads for zmq::context_t (first constructor "
+            "argument)"
+    ];
 
-    optional uint32 manager_timeout_seconds = 10 [default = 1];
+    optional uint32 manager_timeout_seconds = 10 [
+        default = 1,
+        (goby.field).description =
+            "How long to wait for a ManagerResponse before assuming the "
+            "Manager (gobyd) is unresponsive"
+    ];
+
+    optional string client_name = 20
+        [(goby.field).description =
+             "Unique name for InterProcessPortal. Only required for Hold "
+             "functionality"];
+}
+
+message InterProcessManagerHold
+{
+    repeated string required_client = 1 [
+        (goby.field).description =
+            "List of required clients to be connected before hold is released"
+    ];
+    //        optional int32 timeout_seconds = 2 [default = 10,
+    //        (goby.field).description = "Timeout for all required clients
+    //        connecting"];
 }

--- a/src/zeromq/protobuf/interprocess_zeromq.proto
+++ b/src/zeromq/protobuf/interprocess_zeromq.proto
@@ -5,12 +5,19 @@ package goby.zeromq.protobuf;
 
 enum Request
 {
-    PROVIDE_PUB_SUB_SOCKETS = 1;
+    PROVIDE_PUB_SUB_SOCKETS = 1;  // provide sockets for publish/subscribe
+    PROVIDE_HOLD_STATE = 2;  // query if hold has been released so this process
+                             // can begin publishing
 }
 
 message ManagerRequest
 {
-    required Request request = 1;
+    required Request request = 1
+        [(goby.field).description =
+             "Request to be made of the Manager (gobyd)"];
+    optional string client_name = 2
+        [(goby.field).description =
+             "Unique name for the client making the request"];
 }
 
 message Socket
@@ -76,26 +83,36 @@ message Socket
 
 message ManagerResponse
 {
-    required Request request = 1;
-    optional Socket publish_socket = 2;
-    optional Socket subscribe_socket = 3;
+    required Request request = 1;    
+    optional string client_name = 2;
+    optional Socket publish_socket = 3;
+    optional Socket subscribe_socket = 4;
+    optional bool hold = 5 [
+        default = false,
+        (goby.field).description =
+            "Used to synchronize start of multiple processes. If true, wait "
+            "until receiving a hold == false before publishing data"
+    ];
 }
 
 message InprocControl
 {
     enum InprocControlType
     {
-        PUB_CONFIGURATION = 1;  // read->main
+        PUB_CONFIGURATION = 1;  // read -> main
         SUBSCRIBE = 2;          // main -> read
         SUBSCRIBE_ACK = 3;      // read -> main
         UNSUBSCRIBE = 4;        // main -> read
         UNSUBSCRIBE_ACK = 5;    // read -> main
         RECEIVE = 6;            // read -> main
         SHUTDOWN = 7;           // main -> read
+        HOLD_STATE = 8;         // read -> main
     }
     required InprocControlType type = 1;
 
     optional Socket publish_socket = 2;
     optional bytes subscription_identifier = 3;
     optional bytes received_data = 4;
+
+    optional bool hold = 10;
 }

--- a/src/zeromq/protobuf/interprocess_zeromq.proto
+++ b/src/zeromq/protobuf/interprocess_zeromq.proto
@@ -18,6 +18,12 @@ message ManagerRequest
     optional string client_name = 2
         [(goby.field).description =
              "Unique name for the client making the request"];
+    optional bool ready = 3 [
+        default = false,
+        (goby.field).description =
+            "Client is ready to commence accepting publications (all required "
+            "subscriptions are complete"
+    ];
 }
 
 message Socket
@@ -83,7 +89,7 @@ message Socket
 
 message ManagerResponse
 {
-    required Request request = 1;    
+    required Request request = 1;
     optional string client_name = 2;
     optional Socket publish_socket = 3;
     optional Socket subscribe_socket = 4;
@@ -106,7 +112,8 @@ message InprocControl
         UNSUBSCRIBE_ACK = 5;    // read -> main
         RECEIVE = 6;            // read -> main
         SHUTDOWN = 7;           // main -> read
-        HOLD_STATE = 8;         // read -> main
+        READY = 8;              // main -> read
+        HOLD_STATE = 9;         // read -> main
     }
     required InprocControlType type = 1;
 

--- a/src/zeromq/transport/interprocess.cpp
+++ b/src/zeromq/transport/interprocess.cpp
@@ -279,8 +279,8 @@ void goby::zeromq::InterProcessPortalReadThread::run()
                 {
                     send_manager_request(req);
                     next_hold_state_request_time_ += hold_state_request_period_;
-                    poll(cfg_.manager_timeout_seconds() * 1000);
                 }
+                poll(cfg_.manager_timeout_seconds() * 1000);
             }
             else
             {

--- a/src/zeromq/transport/interprocess.cpp
+++ b/src/zeromq/transport/interprocess.cpp
@@ -271,20 +271,17 @@ void goby::zeromq::InterProcessPortalReadThread::run()
             }
             else if (hold_)
             {
-                while (hold_)
-                {
-                    req.set_ready(ready_);
-                    auto start = goby::time::SystemClock::now();
-                    auto request_period = std::chrono::seconds(1);
+                req.set_ready(ready_);
+                auto start = goby::time::SystemClock::now();
+                auto request_period = std::chrono::seconds(1);
 
-                    req.set_request(protobuf::PROVIDE_HOLD_STATE);
-                    if (cfg_.has_client_name())
-                        req.set_client_name(cfg_.client_name());
+                req.set_request(protobuf::PROVIDE_HOLD_STATE);
+                if (cfg_.has_client_name())
+                    req.set_client_name(cfg_.client_name());
 
-                    if (!manager_waiting_for_reply_)
-                        send_manager_request(req);
-                    while (start + request_period > goby::time::SystemClock::now()) poll(10);
-                }
+                if (!manager_waiting_for_reply_)
+                    send_manager_request(req);
+                while (start + request_period > goby::time::SystemClock::now()) poll(10);
             }
         }
     }
@@ -595,10 +592,9 @@ void goby::zeromq::Manager::run()
                 reported_clients_.insert(pb_request.client_name());
 
             if (pb_request.has_client_name())
-            {
                 pb_response.set_client_name(pb_request.client_name());
-                pb_response.set_hold(hold_state());
-            }
+
+            pb_response.set_hold(hold_state());
 
             zmq::message_t reply(pb_response.ByteSize());
             pb_response.SerializeToArray((char*)reply.data(), reply.size());

--- a/src/zeromq/transport/interprocess.h
+++ b/src/zeromq/transport/interprocess.h
@@ -167,6 +167,7 @@ class InterProcessPortalImplementation
         }
     }
 
+    /// \brief When using hold functionality, call when the process is ready to receive publications (typically done after most or all subscribe calls)
     void ready()
     {
         protobuf::InprocControl control;
@@ -174,6 +175,7 @@ class InterProcessPortalImplementation
         zmq_main_.send_control_msg(control);
     }
 
+    /// \brief When using hold functionality, returns whether the system is holding (true) and thus waiting for all processes to connect and be ready, or running (false).
     bool hold_state() { return zmq_main_.hold_state(); }
 
     friend Base;
@@ -555,7 +557,7 @@ class InterProcessPortalImplementation
     static std::string to_string(int i) { return middleware::MarshallingScheme::to_string(i); }
 
   private:
-    const protobuf::InterProcessPortalConfig& cfg_;
+    const protobuf::InterProcessPortalConfig cfg_;
 
     std::unique_ptr<std::thread> zmq_thread_;
     std::atomic<bool> zmq_alive_{true};

--- a/src/zeromq/transport/interprocess.h
+++ b/src/zeromq/transport/interprocess.h
@@ -63,6 +63,7 @@ class InterProcessPortalMainThread
     void set_publish_cfg(const protobuf::Socket& cfg);
 
     void set_hold_state(bool hold);
+    bool hold_state() { return hold_; }
 
     void publish(const std::string& identifier, const char* bytes, int size);
     void subscribe(const std::string& identifier);
@@ -73,7 +74,6 @@ class InterProcessPortalMainThread
     void send_control_msg(const protobuf::InprocControl& control);
 
   private:
-
   private:
     zmq::socket_t control_socket_;
     zmq::socket_t publish_socket_;
@@ -173,6 +173,8 @@ class InterProcessPortalImplementation
         control.set_type(protobuf::InprocControl::READY);
         zmq_main_.send_control_msg(control);
     }
+
+    bool hold_state() { return zmq_main_.hold_state(); }
 
     friend Base;
     friend typename Base::Base;

--- a/src/zeromq/transport/interprocess.h
+++ b/src/zeromq/transport/interprocess.h
@@ -55,15 +55,21 @@ class InterProcessPortalMainThread
 {
   public:
     InterProcessPortalMainThread(zmq::context_t& context);
-    bool ready() { return publish_socket_configured_; }
+    bool publish_ready() { return !hold_; }
+    bool subscribe_ready() { return have_pubsub_sockets_; }
 
     bool recv(protobuf::InprocControl* control_msg,
               zmq_recv_flags_type flags = zmq_recv_flags_type());
     void set_publish_cfg(const protobuf::Socket& cfg);
+
+    void set_hold_state(bool hold);
+
     void publish(const std::string& identifier, const char* bytes, int size);
     void subscribe(const std::string& identifier);
     void unsubscribe(const std::string& identifier);
     void reader_shutdown();
+
+    std::deque<protobuf::InprocControl>& control_buffer() { return control_buffer_; }
 
   private:
     void send_control_msg(const protobuf::InprocControl& control);
@@ -71,9 +77,14 @@ class InterProcessPortalMainThread
   private:
     zmq::socket_t control_socket_;
     zmq::socket_t publish_socket_;
-    bool publish_socket_configured_{false};
+    bool hold_{true};
+    bool have_pubsub_sockets_{false};
+
     std::deque<std::pair<std::string, std::vector<char>>>
-        publish_queue_; //used before publish_socket_configured_ == true
+        publish_queue_; //used before hold == false
+
+    // buffer messages while waiting for (un)subscribe ack
+    std::deque<protobuf::InprocControl> control_buffer_;
 };
 
 // run in a separate thread to allow zmq_.poll() to block without interrupting the main thread
@@ -111,6 +122,7 @@ class InterProcessPortalReadThread
         NUMBER_SOCKETS = 3
     };
     bool have_pubsub_sockets_{false};
+    bool hold_{true};
 };
 
 template <typename InnerTransporter,
@@ -163,7 +175,7 @@ class InterProcessPortalImplementation
         // start zmq read thread
         zmq_thread_.reset(new std::thread([this]() { zmq_read_thread_.run(); }));
 
-        while (!zmq_main_.ready())
+        while (!zmq_main_.subscribe_ready())
         {
             protobuf::InprocControl control_msg;
             if (zmq_main_.recv(&control_msg))
@@ -175,6 +187,9 @@ class InterProcessPortalImplementation
                         break;
                     default: break;
                 }
+
+                if (control_msg.has_hold())
+                    zmq_main_.set_hold_state(control_msg.hold());
             }
         }
     }
@@ -266,7 +281,7 @@ class InterProcessPortalImplementation
     int _poll(std::unique_ptr<std::unique_lock<std::timed_mutex>>& lock)
     {
         int items = 0;
-        protobuf::InprocControl control_msg;
+        protobuf::InprocControl new_control_msg;
 
 #ifdef USE_OLD_ZMQ_CPP_API
         int flags = ZMQ_NOBLOCK;
@@ -274,8 +289,12 @@ class InterProcessPortalImplementation
         auto flags = zmq::recv_flags::dontwait;
 #endif
 
-        while (zmq_main_.recv(&control_msg, flags))
+        while (zmq_main_.recv(&new_control_msg, flags))
+            zmq_main_.control_buffer().push_back(new_control_msg);
+
+        while (!zmq_main_.control_buffer().empty())
         {
+            const auto& control_msg = zmq_main_.control_buffer().front();
             switch (control_msg.type())
             {
                 case protobuf::InprocControl::RECEIVE:
@@ -335,8 +354,13 @@ class InterProcessPortalImplementation
                 }
                 break;
 
+                case protobuf::InprocControl::HOLD_STATE:
+                    zmq_main_.set_hold_state(control_msg.hold());
+                    break;
+
                 default: break;
             }
+            zmq_main_.control_buffer().pop_front();
         }
         return items;
     }
@@ -579,9 +603,20 @@ class Manager
     {
     }
 
+    Manager(zmq::context_t& context, const protobuf::InterProcessPortalConfig& cfg,
+            const Router& router, const protobuf::InterProcessManagerHold& hold)
+        : Manager(context, cfg, router)
+    {
+        for (const auto& req_c : hold.required_client()) required_clients_.insert(req_c);
+    }
+
     void run();
+    bool hold_state();
 
   private:
+    std::set<std::string> reported_clients_;
+    std::set<std::string> required_clients_;
+
     zmq::context_t& context_;
     const protobuf::InterProcessPortalConfig& cfg_;
     const Router& router_;


### PR DESCRIPTION
Optional "hold" list in goby::zeromq::Manager (and thus in `gobyd`) requires that clients signal that they are "ready" before any publications are released by zeromq InterProcessPortal. Clients that participate will be required to call "ready()" on their InterProcessPortal after they are ready to receive publications (after all subscriptions are made that require not missing any initial publications).

Clients that are not on the "hold" list will be allowed to publish as soon as those that are have joined. Currently no checks are done for clients that signal ready and then subsequently quit.

Partially implements https://github.com/GobySoft/goby3/wiki/Proposal-2-Wait-until-triggered. There's no "de-register" nor are their optional applications ("Wants"). This implements what Proposal 2 refers to as "Required" clients only.

Closes https://github.com/GobySoft/goby3/issues/53