### PR TITLE
Remove warnings, ninja support

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,11 +10,9 @@ fi
 
 set -e -u
 echo "Configuring Goby"
-echo "cmake .. ${GOBY_CMAKE_FLAGS}"
 mkdir -p build
 pushd build >& /dev/null
-cmake .. ${GOBY_CMAKE_FLAGS}
+(set -x; cmake .. ${GOBY_CMAKE_FLAGS})
 echo "Building Goby"
-echo "make ${GOBY_MAKE_FLAGS} $@"
-make ${GOBY_MAKE_FLAGS} $@
+(set -x; cmake --build . -- ${GOBY_MAKE_FLAGS} $@ )
 popd >& /dev/null

--- a/cmake_modules/FindProtobufGoby.cmake
+++ b/cmake_modules/FindProtobufGoby.cmake
@@ -97,7 +97,7 @@ function(PROTOBUF_GENERATE_CPP SRCS HDRS)
     # message(STATUS ${REL_FIL})
     # message(STATUS ${FIL_PATH})
 
-    include_directories(${FIL_PATH})
+#    include_directories(${FIL_PATH})
 
     list(APPEND ${SRCS} "${FIL_PATH}/${FIL_WE}.pb.cc")
     list(APPEND ${HDRS} "${FIL_PATH}/${FIL_WE}.pb.h")

--- a/src/acomms/modemdriver/popoto_driver.cpp
+++ b/src/acomms/modemdriver/popoto_driver.cpp
@@ -360,10 +360,10 @@ std::string goby::acomms::PopotoDriver::binary_to_json(const std::uint8_t* buf, 
 {
     std::string output;
 
-    for (int i = 0; i < num_bytes; i++)
+    for (int i = 0, n = num_bytes; i < n; i++)
     {
         output.append(std::to_string((uint8_t)buf[i]));
-        if (i < num_bytes - 1)
+        if (i < n - 1)
         {
             output.append(",");
         }

--- a/src/apps/middleware/clang_tool/pubsub_entry.h
+++ b/src/apps/middleware/clang_tool/pubsub_entry.h
@@ -178,6 +178,7 @@ struct PubSubEntry
         {
             case goby::middleware::Necessity::REQUIRED: return "required";
             case goby::middleware::Necessity::RECOMMENDED: return "recommended";
+            default:
             case goby::middleware::Necessity::OPTIONAL: return "optional";
         }
     }

--- a/src/apps/middleware/serial_mux/mux.cpp
+++ b/src/apps/middleware/serial_mux/mux.cpp
@@ -27,7 +27,7 @@
 #include "goby/middleware/io/line_based/pty.h"
 #include "goby/middleware/io/line_based/serial.h"
 
-#include "config.pb.h"
+#include "goby/apps/middleware/serial_mux/config.pb.h"
 
 namespace goby
 {

--- a/src/apps/moos/pTranslator/pTranslator.h
+++ b/src/apps/moos/pTranslator/pTranslator.h
@@ -35,7 +35,7 @@
 #include "goby/moos/goby_moos_app.h"
 #include "goby/moos/moos_translator.h"
 
-#include "pTranslator_config.pb.h"
+#include "goby/apps/moos/pTranslator/pTranslator_config.pb.h"
 
 namespace goby
 {

--- a/src/apps/zeromq/gobyd/gobyd.cpp
+++ b/src/apps/zeromq/gobyd/gobyd.cpp
@@ -146,7 +146,10 @@ goby::apps::zeromq::Daemon::Daemon()
     interprocess_.subscribe<goby::middleware::groups::terminate_result>(
         [this](const goby::middleware::protobuf::TerminateResult& result) {
             std::cout << result.DebugString() << std::endl;
-            if (result.has_target_pid() && result.target_pid() == getpid() &&
+
+            auto our_pid = getpid();
+            if (result.has_target_pid() &&
+                static_cast<decltype(our_pid)>(result.target_pid()) == our_pid &&
                 result.result() == goby::middleware::protobuf::TerminateResult::PROCESS_RESPONDED)
                 quit();
         });

--- a/src/middleware/frontseat/iver/iver_driver.h
+++ b/src/middleware/frontseat/iver/iver_driver.h
@@ -39,7 +39,7 @@
 #include "goby/util/primitive_types.h"
 #include "goby/util/sci.h"
 
-#include "iver_driver_config.pb.h"
+#include "goby/middleware/frontseat/iver/iver_driver_config.pb.h"
 
 namespace goby
 {

--- a/src/middleware/frontseat/simulator/basic/basic_simulator_frontseat_driver.h
+++ b/src/middleware/frontseat/simulator/basic/basic_simulator_frontseat_driver.h
@@ -30,7 +30,7 @@
 #include "goby/time/system_clock.h"
 #include "goby/util/linebasedcomms/tcp_client.h"
 
-#include "basic_simulator_frontseat_driver_config.pb.h"
+#include "goby/middleware/frontseat/simulator/basic/basic_simulator_frontseat_driver_config.pb.h"
 
 extern "C"
 {

--- a/src/middleware/frontseat/simulator/basic/basic_simulator_frontseat_driver.proto
+++ b/src/middleware/frontseat/simulator/basic/basic_simulator_frontseat_driver.proto
@@ -1,4 +1,5 @@
 syntax = "proto2";
-import "goby/middleware/protobuf/frontseat.proto";
+
+//import "goby/middleware/protobuf/frontseat.proto";
 
 package goby.middleware.frontseat.protobuf;

--- a/src/middleware/frontseat/waveglider/waveglider_sv2_codecs.cpp
+++ b/src/middleware/frontseat/waveglider/waveglider_sv2_codecs.cpp
@@ -23,8 +23,8 @@
 
 #include <dccl/codecs3/field_codec_default.h>
 
+#include "goby/middleware/frontseat/waveglider/waveglider_sv2_frontseat_driver.pb.h"
 #include "waveglider_sv2_codecs.h"
-#include "waveglider_sv2_frontseat_driver.pb.h"
 
 extern "C"
 {

--- a/src/middleware/frontseat/waveglider/waveglider_sv2_codecs.h
+++ b/src/middleware/frontseat/waveglider/waveglider_sv2_codecs.h
@@ -21,9 +21,10 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with Goby.  If not, see <http://www.gnu.org/licenses/>.
 
-#include "waveglider_sv2_frontseat_driver.pb.h"
 #include <dccl.h>
 #include <dccl/field_codec_id.h>
+
+#include "goby/middleware/frontseat/waveglider/waveglider_sv2_frontseat_driver.pb.h"
 
 extern "C"
 {

--- a/src/middleware/frontseat/waveglider/waveglider_sv2_frontseat_driver.h
+++ b/src/middleware/frontseat/waveglider/waveglider_sv2_frontseat_driver.h
@@ -32,8 +32,9 @@
 
 #include "goby/middleware/frontseat/interface.h"
 
-#include "waveglider_sv2_frontseat_driver.pb.h"
-#include "waveglider_sv2_frontseat_driver_config.pb.h"
+#include "goby/middleware/frontseat/waveglider/waveglider_sv2_frontseat_driver.pb.h"
+#include "goby/middleware/frontseat/waveglider/waveglider_sv2_frontseat_driver_config.pb.h"
+
 #include "waveglider_sv2_serial_client.h"
 
 namespace goby

--- a/src/middleware/transport/serialization_handlers.h
+++ b/src/middleware/transport/serialization_handlers.h
@@ -388,6 +388,7 @@ class SerializationInterModuleSubscription : public SerializationHandlerBase<>
     {
         switch (sub_cfg_.action())
         {
+            default:
             case intermodule::protobuf::Subscription::SUBSCRIBE:
                 return SerializationHandlerBase<>::SubscriptionAction::SUBSCRIBE;
             case intermodule::protobuf::Subscription::UNSUBSCRIBE:

--- a/src/moos/protobuf/desired_course.proto
+++ b/src/moos/protobuf/desired_course.proto
@@ -1,2 +1,3 @@
 // placeholder for messages moved to:
+syntax = "proto2";
 import public "goby/middleware/protobuf/frontseat_data.proto";

--- a/src/moos/protobuf/node_status.proto
+++ b/src/moos/protobuf/node_status.proto
@@ -1,2 +1,3 @@
 // placeholder for messages moved to:
+syntax = "proto2";
 import public "goby/middleware/protobuf/frontseat_data.proto";

--- a/src/test/acomms/CMakeLists.txt
+++ b/src/test/acomms/CMakeLists.txt
@@ -1,5 +1,6 @@
-protobuf_generate_cpp(DCCL3_TEST_PROTO_SRCS DCCL3_TEST_PROTO_HDRS dccl3/test.proto dccl3/header.proto)
-add_library(goby_test_proto_messages STATIC ${DCCL3_TEST_PROTO_SRCS} ${DCCL3_TEST_PROTO_HDRS})
+protobuf_generate_cpp(TEST_PROTO_SRCS TEST_PROTO_HDRS dccl1/test.proto dccl3/test.proto dccl3/header.proto)
+add_library(goby_test_proto_messages STATIC ${TEST_PROTO_SRCS} ${TEST_PROTO_HDRS})
+target_compile_options(goby_test_proto_messages PRIVATE -fPIC)
 
 add_subdirectory(queue1)
 add_subdirectory(queue2)

--- a/src/test/acomms/CMakeLists.txt
+++ b/src/test/acomms/CMakeLists.txt
@@ -1,3 +1,6 @@
+protobuf_generate_cpp(DCCL3_TEST_PROTO_SRCS DCCL3_TEST_PROTO_HDRS dccl3/test.proto dccl3/header.proto)
+add_library(goby_test_proto_messages STATIC ${DCCL3_TEST_PROTO_SRCS} ${DCCL3_TEST_PROTO_HDRS})
+
 add_subdirectory(queue1)
 add_subdirectory(queue2)
 add_subdirectory(queue3)

--- a/src/test/acomms/mmdriver2/test.cpp
+++ b/src/test/acomms/mmdriver2/test.cpp
@@ -31,7 +31,8 @@
 #include "goby/util/debug_logger.h"
 #include "goby/util/protobuf/io.h"
 
-#include "test_config.pb.h"
+#include "goby/test/acomms/mmdriver2/test_config.pb.h"
+
 using namespace goby::acomms;
 using namespace goby::util::logger;
 using namespace goby::util::logger_lock;

--- a/src/test/acomms/queue1/test.cpp
+++ b/src/test/acomms/queue1/test.cpp
@@ -30,7 +30,7 @@
 #include "goby/util/debug_logger.h"
 #include "goby/util/protobuf/io.h"
 
-#include "test.pb.h"
+#include "goby/test/acomms/queue1/test.pb.h"
 
 using goby::test::acomms::protobuf::TestMsg;
 

--- a/src/test/acomms/queue2/CMakeLists.txt
+++ b/src/test/acomms/queue2/CMakeLists.txt
@@ -1,6 +1,4 @@
-protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS ../dccl3/test.proto ../dccl3/header.proto)
-
-add_executable(goby_test_queue2 test.cpp ${PROTO_SRCS} ${PROTO_HDRS})
-target_link_libraries(goby_test_queue2 goby)
+add_executable(goby_test_queue2 test.cpp)
+target_link_libraries(goby_test_queue2 goby goby_test_proto_messages)
 
 add_test(goby_test_queue2 ${goby_BIN_DIR}/goby_test_queue2)

--- a/src/test/acomms/queue2/test.cpp
+++ b/src/test/acomms/queue2/test.cpp
@@ -30,7 +30,7 @@
 #include "goby/util/debug_logger.h"
 #include "goby/util/protobuf/io.h"
 
-#include "test.pb.h"
+#include "goby/test/acomms/dccl3/test.pb.h"
 // tests basic DCCL queuing with non-BROADCAST destination
 
 using goby::test::acomms::protobuf::GobyMessage;

--- a/src/test/acomms/queue3/CMakeLists.txt
+++ b/src/test/acomms/queue3/CMakeLists.txt
@@ -1,6 +1,4 @@
-protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS ../dccl3/test.proto ../dccl3/header.proto)
-
-add_executable(goby_test_queue3 test.cpp ${PROTO_SRCS} ${PROTO_HDRS})
-target_link_libraries(goby_test_queue3 goby)
+add_executable(goby_test_queue3 test.cpp)
+target_link_libraries(goby_test_queue3 goby goby_test_proto_messages)
 
 add_test(goby_test_queue3 ${goby_BIN_DIR}/goby_test_queue3)

--- a/src/test/acomms/queue3/test.cpp
+++ b/src/test/acomms/queue3/test.cpp
@@ -31,7 +31,7 @@
 #include "goby/util/debug_logger.h"
 #include "goby/util/protobuf/io.h"
 
-#include "test.pb.h"
+#include "goby/test/acomms/dccl3/test.pb.h"
 // tests basic DCCL queuing with non-BROADCAST destination
 
 using goby::test::acomms::protobuf::GobyMessage;

--- a/src/test/acomms/queue4/CMakeLists.txt
+++ b/src/test/acomms/queue4/CMakeLists.txt
@@ -1,6 +1,4 @@
-protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS ../dccl3/test.proto ../dccl3/header.proto)
-
-add_executable(goby_test_queue4 test.cpp ${PROTO_SRCS} ${PROTO_HDRS})
-target_link_libraries(goby_test_queue4 goby)
+add_executable(goby_test_queue4 test.cpp)
+target_link_libraries(goby_test_queue4 goby goby_test_proto_messages)
 
 add_test(goby_test_queue4 ${goby_BIN_DIR}/goby_test_queue4)

--- a/src/test/acomms/queue4/test.cpp
+++ b/src/test/acomms/queue4/test.cpp
@@ -30,7 +30,7 @@
 #include "goby/util/debug_logger.h"
 #include "goby/util/protobuf/io.h"
 
-#include "test.pb.h"
+#include "goby/test/acomms/dccl3/test.pb.h"
 
 // tests multi-frame DCCL queuing with non-BROADCAST destination
 

--- a/src/test/acomms/queue5/test.cpp
+++ b/src/test/acomms/queue5/test.cpp
@@ -30,7 +30,7 @@
 #include "goby/util/debug_logger.h"
 #include "goby/util/protobuf/io.h"
 
-#include "test.pb.h"
+#include "goby/test/acomms/queue5/test.pb.h"
 
 // tests "encode_on_demand" functionality
 using goby::test::acomms::protobuf::GobyMessage;

--- a/src/test/acomms/queue6/test.cpp
+++ b/src/test/acomms/queue6/test.cpp
@@ -29,7 +29,7 @@
 #include "goby/util/debug_logger.h"
 #include "goby/util/protobuf/io.h"
 
-#include "test.pb.h"
+#include "goby/test/acomms/queue6/test.pb.h"
 
 // tests various manipulators' functionality
 using goby::test::acomms::protobuf::GobyMessage;

--- a/src/test/acomms/route1/test.cpp
+++ b/src/test/acomms/route1/test.cpp
@@ -39,11 +39,11 @@
 #include "goby/acomms/connect.h"
 #include "goby/acomms/modemdriver/udp_driver.h"
 #include "goby/acomms/route/route.h"
+#include "goby/test/acomms/route1/test.pb.h"
 #include "goby/time.h"
 #include "goby/util/as.h"
 #include "goby/util/binary.h"
 #include "goby/util/debug_logger.h"
-#include "test.pb.h"
 #include <cstdlib>
 
 using namespace goby::util::logger;

--- a/src/test/acomms/udpdriver3/CMakeLists.txt
+++ b/src/test/acomms/udpdriver3/CMakeLists.txt
@@ -1,7 +1,5 @@
-protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS ../dccl3/test.proto ../dccl3/header.proto)
-
-add_executable(goby_test_udpdriver3 test.cpp ${PROTO_SRCS} ${PROTO_HDRS})
-target_link_libraries(goby_test_udpdriver3 goby)
+add_executable(goby_test_udpdriver3 test.cpp)
+target_link_libraries(goby_test_udpdriver3 goby goby_test_proto_messages)
 
 add_test(goby_test_udpdriver3 ${goby_BIN_DIR}/goby_test_udpdriver3)
   

--- a/src/test/acomms/udpdriver3/test.cpp
+++ b/src/test/acomms/udpdriver3/test.cpp
@@ -33,7 +33,7 @@
 #include "goby/util/debug_logger.h"
 #include "goby/util/protobuf/io.h"
 
-#include "test.pb.h"
+#include "goby/test/acomms/dccl3/test.pb.h"
 
 using goby::acomms::udp::protobuf::config;
 using goby::test::acomms::protobuf::GobyMessage;

--- a/src/test/middleware/hdf5/CMakeLists.txt
+++ b/src/test/middleware/hdf5/CMakeLists.txt
@@ -1,9 +1,9 @@
 add_definitions(-DGOBY_LIB_DIR="${goby_LIB_DIR}")
 
-protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS ../../acomms/dccl1/test.proto test2.proto)
+protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS test2.proto)
 
 add_library(goby_hdf5test SHARED test-plugin.cpp ${PROTO_SRCS} ${PROTO_HDRS})
-target_link_libraries(goby_hdf5test goby dccl)
+target_link_libraries(goby_hdf5test goby dccl goby_test_proto_messages)
 
 add_executable(goby_test_hdf5 test.cpp)
 target_link_libraries(goby_test_hdf5 goby)

--- a/src/test/middleware/hdf5/test-plugin.cpp
+++ b/src/test/middleware/hdf5/test-plugin.cpp
@@ -27,8 +27,8 @@
 #include "goby/time.h"
 #include "goby/util/binary.h"
 
-#include "test.pb.h"
-#include "test2.pb.h"
+#include "goby/test/acomms/dccl1/test.pb.h"
+#include "goby/test/middleware/hdf5/test2.pb.h"
 
 using namespace goby::test::middleware;
 

--- a/src/test/middleware/log/test.cpp
+++ b/src/test/middleware/log/test.cpp
@@ -27,7 +27,7 @@
 #include "goby/middleware/marshalling/interface.h"
 #include "goby/util/debug_logger.h"
 
-#include "test.pb.h"
+#include "goby/test/middleware/log/test.pb.h"
 
 using goby::test::middleware::protobuf::CTDSample;
 using goby::test::middleware::protobuf::TempSample;

--- a/src/test/middleware/middleware_interthread/test.cpp
+++ b/src/test/middleware/middleware_interthread/test.cpp
@@ -25,8 +25,8 @@
 #include <deque>
 
 #include "goby/middleware/transport/interthread.h"
+#include "goby/test/middleware/middleware_interthread/test.pb.h"
 #include "goby/util/debug_logger.h"
-#include "test.pb.h"
 
 // tests InterThreadTransporter
 

--- a/src/test/moos/goby_app_config/test.cpp
+++ b/src/test/moos/goby_app_config/test.cpp
@@ -21,8 +21,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Goby.  If not, see <http://www.gnu.org/licenses/>.
 
-#include "config.pb.h"
 #include "goby/moos/goby_moos_app.h"
+#include "goby/test/moos/goby_app_config/config.pb.h"
 
 namespace goby
 {

--- a/src/test/moos/translator1/CMakeLists.txt
+++ b/src/test/moos/translator1/CMakeLists.txt
@@ -1,9 +1,9 @@
 get_filename_component(translator_test_dir ./ ABSOLUTE)
 add_definitions(-DTRANSLATOR_TEST_DIR="${translator_test_dir}")
 
-protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS ../../acomms/dccl1/test.proto basic_node_report.proto)
+protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS basic_node_report.proto)
 
 add_executable(goby_test_translator1 test.cpp ${PROTO_SRCS} ${PROTO_HDRS})
-target_link_libraries(goby_test_translator1 goby_moos)
+target_link_libraries(goby_test_translator1 goby_moos goby_test_proto_messages)
 
 add_test(goby_test_translator1 ${goby_BIN_DIR}/goby_test_translator1)

--- a/src/test/moos/translator1/test.cpp
+++ b/src/test/moos/translator1/test.cpp
@@ -24,12 +24,12 @@
 
 #include <iostream>
 
-#include "basic_node_report.pb.h"
 #include "goby/moos/moos_translator.h"
+#include "goby/test/acomms/dccl1/test.pb.h"
+#include "goby/test/moos/translator1/basic_node_report.pb.h"
 #include "goby/util/binary.h"
 #include "goby/util/debug_logger.h"
 #include "goby/util/sci.h"
-#include "test.pb.h"
 
 using namespace goby::moos;
 using goby::test::moos::protobuf::BasicNodeReport;

--- a/src/test/zeromq/middleware_basic/test.cpp
+++ b/src/test/zeromq/middleware_basic/test.cpp
@@ -34,8 +34,8 @@
 #include "goby/middleware/transport/intervehicle.h"
 #include "goby/zeromq/transport/interprocess.h"
 
+#include "goby/test/zeromq/middleware_basic/test.pb.h"
 #include "goby/util/debug_logger.h"
-#include "test.pb.h"
 
 using goby::test::zeromq::protobuf::CTDSample;
 using goby::test::zeromq::protobuf::TempSample;

--- a/src/test/zeromq/middleware_interprocess_forwarder/test.cpp
+++ b/src/test/zeromq/middleware_interprocess_forwarder/test.cpp
@@ -31,8 +31,8 @@
 #include "goby/middleware/transport/interthread.h"
 #include "goby/zeromq/transport/interprocess.h"
 
+#include "goby/test/zeromq/middleware_interprocess_forwarder/test.pb.h"
 #include "goby/util/debug_logger.h"
-#include "test.pb.h"
 
 #include <zmq.hpp>
 

--- a/src/test/zeromq/middleware_regex/test.cpp
+++ b/src/test/zeromq/middleware_regex/test.cpp
@@ -32,7 +32,7 @@
 #include "goby/util/debug_logger.h"
 #include "goby/zeromq/transport/interprocess.h"
 
-#include "test.pb.h"
+#include "goby/test/zeromq/middleware_regex/test.pb.h"
 
 #include <zmq.hpp>
 

--- a/src/test/zeromq/middleware_speed/test.cpp
+++ b/src/test/zeromq/middleware_speed/test.cpp
@@ -37,7 +37,7 @@
 #include "goby/util/debug_logger.h"
 #include "goby/zeromq/transport/interprocess.h"
 
-#include "test.pb.h"
+#include "goby/test/zeromq/middleware_speed/test.pb.h"
 
 // speed test for interprocess
 //#define LARGE_MESSAGE

--- a/src/test/zeromq/multi_thread_app1/test.cpp
+++ b/src/test/zeromq/multi_thread_app1/test.cpp
@@ -30,7 +30,7 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 
-#include "test.pb.h"
+#include "goby/test/zeromq/multi_thread_app1/test.pb.h"
 using goby::glog;
 
 using namespace goby::test::zeromq::protobuf;

--- a/src/test/zeromq/multi_thread_app2/test.cpp
+++ b/src/test/zeromq/multi_thread_app2/test.cpp
@@ -30,7 +30,7 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 
-#include "test.pb.h"
+#include "goby/test/zeromq/multi_thread_app2/test.pb.h"
 using goby::glog;
 using namespace goby::util::logger;
 using namespace goby::test::zeromq::protobuf;

--- a/src/test/zeromq/single_thread_app1/test.cpp
+++ b/src/test/zeromq/single_thread_app1/test.cpp
@@ -30,7 +30,7 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 
-#include "test.pb.h"
+#include "goby/test/zeromq/single_thread_app1/test.pb.h"
 using goby::glog;
 using namespace goby::util::logger;
 using namespace goby::test::zeromq::protobuf;

--- a/src/test/zeromq/zeromq_and_intervehicle/test.cpp
+++ b/src/test/zeromq/zeromq_and_intervehicle/test.cpp
@@ -34,7 +34,7 @@
 #include "goby/util/debug_logger.h"
 #include "goby/zeromq/transport/interprocess.h"
 
-#include "test.pb.h"
+#include "goby/test/zeromq/zeromq_and_intervehicle/test.pb.h"
 
 using namespace goby::test::zeromq::protobuf;
 

--- a/src/test/zeromq/zeromq_intermodule_and_interprocess/test.cpp
+++ b/src/test/zeromq/zeromq_intermodule_and_interprocess/test.cpp
@@ -31,8 +31,8 @@
 #include "goby/zeromq/transport/intermodule.h"
 #include "goby/zeromq/transport/interprocess.h"
 
+#include "goby/test/zeromq/zeromq_intermodule_and_interprocess/test.pb.h"
 #include "goby/util/debug_logger.h"
-#include "test.pb.h"
 
 #include <zmq.hpp>
 

--- a/src/test/zeromq/zeromq_portal_without_interthread/test.cpp
+++ b/src/test/zeromq/zeromq_portal_without_interthread/test.cpp
@@ -30,8 +30,8 @@
 #include "goby/middleware/marshalling/protobuf.h"
 #include "goby/zeromq/transport/interprocess.h"
 
+#include "goby/test/zeromq/zeromq_portal_without_interthread/test.pb.h"
 #include "goby/util/debug_logger.h"
-#include "test.pb.h"
 
 #include <zmq.hpp>
 


### PR DESCRIPTION
- Fix warnings in GCC 9.
- Rework protobuf messages in test code to support building with ninja (removed duplicate generation of some pb.h output).

