### PR TITLE
Update goby_gps to not use GPSD client library

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,10 +95,9 @@ job-template-amd64: &job-template-amd64
           true
     - run: &run-update-apt
         name: Update apt packages
-        # TODO: Remove libgps-dev, libmysqlclient-dev from this command once all Docker containers are updated to include it
+        # TODO: Remove libmysqlclient-dev from this command once all Docker containers are updated to include it
         command: |
           apt-get update && apt-get dist-upgrade -y &&
-          apt-get install libgps-dev:${TARGET_ARCH} -y &&
           (apt-get install default-libmysqlclient-dev:${TARGET_ARCH} -y ||
           apt-get install libmysqlclient-dev:${TARGET_ARCH} -y)
     - run: &run-build

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -159,19 +159,6 @@ macro(generate_middleware_interfaces target)
   endif()
 endmacro()
 
-
-## GPSD
-set(GPSD_DOC_STRING "Build the GPSD components (requires libgps-dev)")
-find_file(GPSD_HEADER_PATH gps.h)
-if(GPSD_HEADER_PATH)
-  message(STATUS "Using GSPD header at ${GPSD_HEADER_PATH}")
-  option(enable_gpsd ${GPSD_DOC_STRING} ON)
-else()
-  message(">> setting enable_gpsd to OFF ... if you need this functionality: 1) install libgps (\"apt install libgps-dev\"; 2) run cmake -Denable_gpsd=ON")
-  option(enable_gpsd ${GPSD_DOC_STRING} OFF)
-endif()
-
-
 ## Mysql (for GEOV)
 set(MYSQL_DOC_STRING "Build the MySQL components (requires libmysqlclient-dev)")
 find_package(MYSQL QUIET)

--- a/src/apps/zeromq/gpsd_client/gpsd_client.h
+++ b/src/apps/zeromq/gpsd_client/gpsd_client.h
@@ -28,10 +28,8 @@
 #include <set>    // for set
 #include <string> // for string
 
-#include <gps.h> // for gpsmm
-
-#include "goby/util/thirdparty/nlohmann/json.hpp"  // for json
-#include "goby/zeromq/application/single_thread.h" // for SingleThreadA...
+#include "goby/util/thirdparty/nlohmann/json.hpp" // for json
+#include "goby/zeromq/application/multi_thread.h"
 #include "goby/zeromq/protobuf/gps_config.pb.h"
 
 namespace goby
@@ -40,21 +38,19 @@ namespace apps
 {
 namespace zeromq
 {
-class GPSDClient : public goby::zeromq::SingleThreadApplication<protobuf::GPSDConfig>
+class GPSDClient : public goby::zeromq::MultiThreadApplication<protobuf::GPSDConfig>
 {
   public:
     GPSDClient();
 
   private:
-    void loop() override;
+    void handle_response(nlohmann::json& json_data);
 
     void handle_tpv(nlohmann::json& data);
     void handle_sky(nlohmann::json& data);
     void handle_att(nlohmann::json& data);
 
   private:
-    gpsmm gps_rec_;
-
     std::set<std::string> device_list_;
     bool publish_all_{false};
 };

--- a/src/zeromq/protobuf/gps_config.proto
+++ b/src/zeromq/protobuf/gps_config.proto
@@ -2,18 +2,16 @@ syntax = "proto2";
 import "goby/middleware/protobuf/app_config.proto";
 import "goby/zeromq/protobuf/interprocess_config.proto";
 import "goby/protobuf/option_extensions.proto";
+import "goby/middleware/protobuf/tcp_config.proto";
 
 package goby.apps.zeromq.protobuf;
 
 message GPSDConfig
 {
-  optional goby.middleware.protobuf.AppConfig app = 1;
-  optional goby.zeromq.protobuf.InterProcessPortalConfig interprocess = 2;
+    optional goby.middleware.protobuf.AppConfig app = 1;
+    optional goby.zeromq.protobuf.InterProcessPortalConfig interprocess = 2;
 
-  optional string hostname = 3 [default = "localhost"];
-  optional uint32 port = 4 [default = 2947];
+    required goby.middleware.protobuf.TCPClientConfig gpsd = 3;
 
-
-  repeated string device_name = 5 ;
-
+    repeated string device_name = 5;
 }


### PR DESCRIPTION
I couldn't get `goby_gps` to work with the Ubuntu 20.04 version of the gpsd client library, so I did away with it.

Instead now we just connect directly using the TCPClientLineBased to the gpsd tcp socket and speak its JSON protocol directly.

Much cleaner, it works, and removes a lib dependency.

@shawndooley Mind taking a look?