### PR TITLE
Add marshalling support for nlohmann JSON

### DIFF
--- a/src/middleware/marshalling/interface.cpp
+++ b/src/middleware/marshalling/interface.cpp
@@ -24,11 +24,8 @@
 #include "interface.h"
 
 const std::map<int, std::string> goby::middleware::MarshallingScheme::e2s = {
-    {CSTR, "CSTR"},
-    {PROTOBUF, "PROTOBUF"},
-    {DCCL, "DCCL"},
-    {CXX_OBJECT, "CXX_OBJECT"},
-    {MAVLINK, "MAVLINK"}};
+    {CSTR, "CSTR"},       {PROTOBUF, "PROTOBUF"}, {DCCL, "DCCL"}, {CXX_OBJECT, "CXX_OBJECT"},
+    {MAVLINK, "MAVLINK"}, {JSON, "JSON"}};
 
 std::map<std::string, int> invert_map(const std::map<int, std::string>& e2s)
 {

--- a/src/middleware/marshalling/interface.h
+++ b/src/middleware/marshalling/interface.h
@@ -55,7 +55,8 @@ struct MarshallingScheme
         //        CAPTN_PROTO = 3,
         //        MSGPACK = 4,
         CXX_OBJECT = 5,
-        MAVLINK = 6
+        MAVLINK = 6,
+        JSON = 7
     };
 
     /// \brief Convert a known marshalling scheme to a human-readable string or an unknown scheme to the string representation of its numeric value

--- a/src/middleware/marshalling/json.h
+++ b/src/middleware/marshalling/json.h
@@ -1,0 +1,105 @@
+// Copyright 2016-2021:
+//   GobySoft, LLC (2013-)
+//   Community contributors (see AUTHORS file)
+// File authors:
+//   Toby Schneider <toby@gobysoft.org>
+//
+//
+// This file is part of the Goby Underwater Autonomy Project Libraries
+// ("The Goby Libraries").
+//
+// The Goby Libraries are free software: you can redistribute them and/or modify
+// them under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// The Goby Libraries are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Goby.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef GOBY_MIDDLEWARE_MARSHALLING_JSON_H
+#define GOBY_MIDDLEWARE_MARSHALLING_JSON_H
+
+#include <boost/type_index.hpp>
+
+#include "goby/util/thirdparty/nlohmann/json.hpp"
+
+#include "interface.h"
+
+namespace goby
+{
+namespace middleware
+{
+/// \brief Support nlohmann JSON library in Goby3 using BSON encoding
+template <> struct SerializerParserHelper<nlohmann::json, MarshallingScheme::JSON>
+{
+    static std::vector<char> serialize(const nlohmann::json& msg)
+    {
+        auto bson = nlohmann::json::to_bson(msg);
+        std::vector<char> bytes(bson.begin(), bson.end());
+        return bytes;
+    }
+
+    static std::string type_name(const nlohmann::json& d = nlohmann::json())
+    {
+        return "nlohmann::json";
+    }
+
+    template <typename CharIterator>
+    static std::shared_ptr<nlohmann::json> parse(CharIterator bytes_begin, CharIterator bytes_end,
+                                                 CharIterator& actual_end,
+                                                 const std::string& type = type_name())
+    {
+        actual_end = bytes_end;
+        return std::make_shared<nlohmann::json>(nlohmann::json::from_bson(bytes_begin, bytes_end));
+    }
+};
+
+template <typename T, class Enable = void> constexpr const char* json_type_name()
+{
+    return T::goby_json_type;
+}
+
+/// \brief Support arbitrary data types using nlohmann JSON (must define to_json/from_json functions for your data type: see nlohmann JSON docs)
+template <typename T> struct SerializerParserHelper<T, MarshallingScheme::JSON>
+{
+    static std::vector<char> serialize(const T& msg)
+    {
+        nlohmann::json j = msg;
+        return SerializerParserHelper<nlohmann::json, MarshallingScheme::JSON>::serialize(j);
+    }
+
+    static std::string type_name(const T& t = T()) { return json_type_name<T>(); }
+
+    template <typename CharIterator>
+    static std::shared_ptr<T> parse(CharIterator bytes_begin, CharIterator bytes_end,
+                                    CharIterator& actual_end, const std::string& type = type_name())
+    {
+        auto j = SerializerParserHelper<nlohmann::json, MarshallingScheme::JSON>::parse(
+            bytes_begin, bytes_end, actual_end, type);
+
+        return std::make_shared<T>(j->template get<T>());
+    }
+};
+
+template <typename T,
+          typename std::enable_if<std::is_same<T, nlohmann::json>::value>::type* = nullptr>
+constexpr int scheme()
+{
+    return goby::middleware::MarshallingScheme::JSON;
+}
+
+template <typename T, typename std::enable_if<T::goby_json_type != nullptr>::type* = nullptr>
+constexpr int scheme()
+{
+    return goby::middleware::MarshallingScheme::JSON;
+}
+
+} // namespace middleware
+} // namespace goby
+
+#endif

--- a/src/test/middleware/CMakeLists.txt
+++ b/src/test/middleware/CMakeLists.txt
@@ -9,3 +9,6 @@ endif()
 if(enable_mavlink)
   add_subdirectory(mavlink)
 endif()
+
+add_subdirectory(json)
+

--- a/src/test/middleware/json/CMakeLists.txt
+++ b/src/test/middleware/json/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_executable(goby_test_middleware_json json.cpp)
+target_link_libraries(goby_test_middleware_json goby)
+add_test(goby_test_middleware_json ${goby_BIN_DIR}/goby_test_middleware_json)
+

--- a/src/test/middleware/json/json.cpp
+++ b/src/test/middleware/json/json.cpp
@@ -1,0 +1,154 @@
+// Copyright 2019-2021:
+//   GobySoft, LLC (2013-)
+//   Community contributors (see AUTHORS file)
+// File authors:
+//   Toby Schneider <toby@gobysoft.org>
+//
+//
+// This file is part of the Goby Underwater Autonomy Project Binaries
+// ("The Goby Binaries").
+//
+// The Goby Binaries are free software: you can redistribute them and/or modify
+// them under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// The Goby Binaries are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Goby.  If not, see <http://www.gnu.org/licenses/>.
+
+#define BOOST_TEST_MODULE json_test
+#include <boost/test/included/unit_test.hpp>
+
+#include "goby/middleware/marshalling/json.h"
+#include "goby/util/debug_logger.h"
+
+using goby::middleware::SerializerParserHelper;
+using json = nlohmann::json;
+
+struct GlogConfig
+{
+    GlogConfig()
+    {
+        goby::glog.add_stream(goby::util::logger::DEBUG3, &std::cerr);
+        goby::glog.set_name("json");
+    }
+    ~GlogConfig() = default;
+};
+
+BOOST_GLOBAL_FIXTURE(GlogConfig);
+
+json run_serialize_parse(const json& packet_in)
+{
+    std::cout << "In: " << packet_in.dump() << std::endl;
+
+    auto bytes =
+        SerializerParserHelper<json, goby::middleware::scheme<json>()>::serialize(packet_in);
+
+    std::cout << "Bytes: ";
+    for (int c : bytes)
+        std::cout << std::setfill('0') << std::setw(2) << std::hex << (c & 0xFF) << " ";
+    std::cout << std::endl;
+
+    auto bytes_begin = bytes.begin(), bytes_end = bytes.end(), actual_end = bytes.begin();
+    auto packet_out = SerializerParserHelper<json, goby::middleware::scheme<json>()>::parse(
+        bytes_begin, bytes_end, actual_end);
+    std::cout << "Out: " << packet_out->dump() << std::endl;
+    return *packet_out;
+}
+
+BOOST_AUTO_TEST_CASE(json_simple)
+{
+    constexpr auto scheme = goby::middleware::scheme<json>();
+
+    BOOST_REQUIRE_EQUAL(scheme, goby::middleware::MarshallingScheme::JSON);
+
+    std::string name =
+        SerializerParserHelper<json, goby::middleware::MarshallingScheme::JSON>::type_name();
+    std::string expected_name = "nlohmann::json";
+    BOOST_REQUIRE_EQUAL(name, expected_name);
+
+    auto j_in = json::parse(R"({"happy": true, "pi": 3.141})");
+
+    auto j_out = run_serialize_parse(j_in);
+
+    BOOST_CHECK_EQUAL(j_in["happy"], j_out["happy"]);
+    BOOST_CHECK_EQUAL(j_in["pi"], j_out["pi"]);
+}
+
+// arbitrary type
+namespace ns
+{
+// a simple struct to model a person
+struct person
+{
+    // use 'type' field to indicate type for Goby
+    static constexpr auto goby_json_type = "person";
+    std::string name;
+    std::string address;
+    int age;
+};
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(person, name, address, age)
+
+struct person2
+{
+    std::string name;
+    std::string address;
+    int age;
+};
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(person2, name, address, age)
+} // namespace ns
+
+namespace goby
+{
+namespace middleware
+{
+// use template specialization to indicate type field for goby
+template <> constexpr const char* json_type_name<ns::person2>() { return "person2"; }
+} // namespace middleware
+} // namespace goby
+
+BOOST_AUTO_TEST_CASE(json_arbitrary_person)
+{
+    ns::person p_in{"Ned Flanders", "744 Evergreen Terrace", 60};
+    ns::person2 p2_in{"Ned Flanders2", "744 Evergreen Terrace", 61};
+
+    auto bytes =
+        SerializerParserHelper<ns::person, goby::middleware::scheme<ns::person>()>::serialize(p_in);
+    auto bytes2 =
+        SerializerParserHelper<ns::person2, goby::middleware::MarshallingScheme::JSON>::serialize(
+            p2_in);
+
+    std::cout << "Bytes: ";
+    for (int c : bytes)
+        std::cout << std::setfill('0') << std::setw(2) << std::hex << (c & 0xFF) << " ";
+    std::cout << std::endl;
+
+    auto bytes_begin = bytes.begin(), bytes_end = bytes.end(), actual_end = bytes.begin();
+    auto p_out =
+        SerializerParserHelper<ns::person, goby::middleware::MarshallingScheme::JSON>::parse(
+            bytes_begin, bytes_end, actual_end);
+
+    auto bytes2_begin = bytes2.begin(), bytes2_end = bytes2.end(), actual2_end = bytes2.begin();
+    auto p2_out =
+        SerializerParserHelper<ns::person2, goby::middleware::MarshallingScheme::JSON>::parse(
+            bytes2_begin, bytes2_end, actual2_end);
+
+    std::string person_name =
+        SerializerParserHelper<ns::person, goby::middleware::MarshallingScheme::JSON>::type_name();
+    std::cout << "Person Name: " << person_name << std::endl;
+    std::string person2_name =
+        SerializerParserHelper<ns::person2, goby::middleware::MarshallingScheme::JSON>::type_name();
+    std::cout << "Person2 Name: " << person2_name << std::endl;
+
+    BOOST_CHECK_EQUAL(person_name, "person");
+    BOOST_CHECK_EQUAL(person2_name, "person2");
+
+    BOOST_CHECK_EQUAL(p_in.name, p_out->name);
+    BOOST_CHECK_EQUAL(p_in.address, p_out->address);
+    BOOST_CHECK_EQUAL(p_in.age, p_out->age);
+}


### PR DESCRIPTION
Also support for arbitrary types encoded using JSON.

Starting with:
```
struct NavigationReport
{
    double x{0};
    double y{0};
    double z{0};
};
```

User simply needs to add a bit of metadata to their struct:
```
struct NavigationReport
{
    // required by Goby to define type
    static constexpr auto goby_json_type = "NavigationReport";
    double x{0};
    double y{0};
    double z{0};
};
// required by nlohmann JSON to encode/decode as JSON
NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(NavigationReport, x, y, z);
```

or they can specialize json_type_name if modifying the class isn't possible:
```
struct NavigationReport
{
    double x{0};
    double y{0};
    double z{0};
};
// required by nlohmann JSON to encode/decode as JSON
NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(NavigationReport, x, y, z);

namespace goby
{
namespace middleware
{
template <> constexpr const char* json_type_name<NavigationReport>() { return "NavigationReport"; }
}
}
```