### PR TITLE
Provide more metadata to the intervehicle subscriber

### DIFF
--- a/scripts/goby_launch
+++ b/scripts/goby_launch
@@ -216,7 +216,7 @@ cat ${origlaunchfile} > ${launchfile}
 
 
 # search for gobyd so we can use the same interprocess { } configuration for goby_terminate
-gobyd_line=$(cat "$launchfile" | egrep "^ *[/a-zA-Z0-9_]*gobyd")
+gobyd_line=$(cat "$launchfile" | egrep "^ *(\[.*\])? *[/a-zA-Z0-9_]*gobyd")
 num_gobyd=$(echo "$gobyd_line" | wc -l)
 
 use_goby_terminate=true
@@ -227,7 +227,28 @@ elif [[ "$gobyd_line"  == "" ]]; then
     echo "Note: no line found for launching 'gobyd' - will use SIGTERM instead of goby_terminate to kill processes (unless otherwise marked with [kill=...])"
     use_goby_terminate=false
 else
-    gobyd_escline=$(echo "$gobyd_line" | sed 's/"/\\"/g')
+    directive_str=
+    echo "$gobyd_line" | egrep -q '\[.*\]'  &&
+        directive_str=$(echo "$gobyd_line" | sed 's/^ *\[\(.*\)\].*$/\1/')    
+    if [ ! -z "$directive_str" ]; then
+
+        IFS=';, ' read -r -a directives <<< "$directive_str" 
+        for ((i=0; i<${#directives[@]}; i++))
+        do
+            directive=${directives[$i]}
+            key=$(echo "$directive" | cut -d "=" -f 1)
+            value=$(echo "$directive" | cut -d "=" -f 2-)
+            case $key in
+                env)
+                    eval "export $value"
+                    ;;
+                *)
+                    ;;
+            esac
+        done               
+    fi
+    gobyd_line=$(echo "$gobyd_line"  | sed 's/^ *\[.*\]//' )
+    gobyd_escline=$(echo "$gobyd_line" |  sed 's/"/\\"/g')
     gobyd_interprocess=$(bash -c "$gobyd_line --app 'debug_cfg: true'" | sed -n "/^ *interprocess/,/}/p;")    
     gobyd_platform=$(echo "$gobyd_interprocess" | grep platform | sed 's/.*platform: \"\(.*\)\".*/\1/')
     if [ ! -z "$gobyd_platform" ]; then

--- a/src/middleware/protobuf/intervehicle.proto
+++ b/src/middleware/protobuf/intervehicle.proto
@@ -4,6 +4,7 @@ import "goby/protobuf/option_extensions.proto";
 import "goby/acomms/protobuf/driver_base.proto";
 import "goby/acomms/protobuf/amac_config.proto";
 import "goby/acomms/protobuf/buffer.proto";
+import "goby/acomms/protobuf/modem_message.proto";
 import "goby/middleware/protobuf/intervehicle_transporter_config.proto";
 import "goby/middleware/protobuf/serializer_transporter.proto";
 
@@ -97,6 +98,7 @@ message Header
 {
     required int32 src = 1 [(dccl.field) = {min: 0 max: 65535}];
     repeated int32 dest = 2 [(dccl.field) = {min: 0 max: 65535 max_repeat: 4}];
+    optional goby.acomms.protobuf.ModemTransmission modem_msg = 10 [(dccl.field).omit = true];
 }
 
 message DCCLPacket
@@ -109,7 +111,8 @@ message DCCLPacket
 // IDs loaded
 message DCCLForwardedData
 {
-    repeated DCCLPacket frame = 1;
+    required Header header = 1;
+    repeated DCCLPacket frame = 2;
 }
 
 message AckData

--- a/src/middleware/transport/interprocess.h
+++ b/src/middleware/transport/interprocess.h
@@ -310,7 +310,13 @@ class InterProcessForwarder
                     std::shared_ptr<const goby::middleware::protobuf::SerializerTransporterMessage>
                         msg) { _receive_regex_data_forwarded(msg); });
     }
-    virtual ~InterProcessForwarder() { this->unsubscribe_all(); }
+    virtual ~InterProcessForwarder()
+    {
+        this->unsubscribe_all();
+
+        // TODO - remove by adding in an explicit handshake with the unsubscribe_all publication so that we don't delete ourself (and thus our inner()) before the Portal has deleted all the subscriptions
+        usleep(1e5);
+    }
 
     friend Base;
 

--- a/src/middleware/transport/intervehicle.h
+++ b/src/middleware/transport/intervehicle.h
@@ -326,9 +326,9 @@ class InterVehicleTransporterBase
                     throw(InvalidSubscription(ss.str()));
                 }
 
-                auto subscription =
-                    std::make_shared<SerializationSubscription<Data, MarshallingScheme::DCCL>>(
-                        func, group, subscriber);
+                auto subscription = std::make_shared<
+                    IntervehicleSerializationSubscription<Data, MarshallingScheme::DCCL>>(
+                    func, group, subscriber);
 
                 this->subscriptions_[dccl_id][group] = subscription;
             }
@@ -434,7 +434,7 @@ class InterVehicleTransporterBase
         for (const auto& packet : packets.frame())
         {
             for (auto p : this->subscriptions_[packet.dccl_id()])
-                p.second->post(packet.data().begin(), packet.data().end());
+                p.second->post(packet.data().begin(), packet.data().end(), packets.header());
         }
     }
 
@@ -480,7 +480,8 @@ class InterVehicleTransporterBase
     // maps DCCL ID to map of Group->subscription
     // only one subscription allowed per IntervehicleForwarder/Portal (new subscription overwrites old one)
     std::unordered_map<
-        int, std::unordered_map<std::string, std::shared_ptr<const SerializationHandlerBase<>>>>
+        int, std::unordered_map<std::string, std::shared_ptr<const SerializationHandlerBase<
+                                                 intervehicle::protobuf::Header>>>>
         subscriptions_;
 
   private:
@@ -727,9 +728,9 @@ class InterVehiclePortal
                                       intervehicle::protobuf::Subscription,
                                       MarshallingScheme::PROTOBUF>(d);
             };
-            auto subscription =
-                std::make_shared<SerializationSubscription<Subscription, MarshallingScheme::DCCL>>(
-                    subscribe_lambda);
+            auto subscription = std::make_shared<
+                IntervehicleSerializationSubscription<Subscription, MarshallingScheme::DCCL>>(
+                subscribe_lambda);
 
             auto dccl_id = SerializerParserHelper<Subscription, MarshallingScheme::DCCL>::id();
             this->subscriptions_[dccl_id].insert(

--- a/src/middleware/transport/intervehicle/driver_thread.cpp
+++ b/src/middleware/transport/intervehicle/driver_thread.cpp
@@ -600,8 +600,11 @@ void goby::middleware::intervehicle::ModemDriverThread::_receive(
         {
             for (auto& frame : rx_msg.frame())
             {
-                const intervehicle::protobuf::DCCLForwardedData packets(
+                intervehicle::protobuf::DCCLForwardedData packets(
                     detail::DCCLSerializerParserHelperBase::unpack(frame));
+                packets.mutable_header()->set_src(full_src);
+                packets.mutable_header()->add_dest(full_dest);
+                *packets.mutable_header()->mutable_modem_msg() = rx_msg;
                 interprocess_->publish<groups::modem_data_in>(packets);
             }
         }


### PR DESCRIPTION
Add Header metadata that includes src, dest and ModemTransmission to DCCLForwardedData so that we can add a set_link_data_func to Subscriber that allows mutating the received message based on various physical link parameters.

This can be used to include which link a message was received on, stats about the message itself, etc.