### PR TITLE
Fix ais on arm

### DIFF
--- a/src/util/ais/encode.cpp
+++ b/src/util/ais/encode.cpp
@@ -185,6 +185,9 @@ void goby::util::ais::Encoder::encode_msg_18(const goby::util::ais::protobuf::Po
          393222} // Because Class B "CS" does not use any Communication State information, this field shall be filled with the following value: 1100000000000000110.
     };
 
+    for (int i = 0, n = fields.size(); i < n; ++i)
+    { std::cout << "[" << i << "] " << fields[i] << std::endl; }
+
     concatenate_bitset(fields);
     assert(bits_.size() == 168);
 }

--- a/src/util/ais/encode.cpp
+++ b/src/util/ais/encode.cpp
@@ -170,23 +170,20 @@ void goby::util::ais::Encoder::encode_msg_18(const goby::util::ais::protobuf::Po
         {12, pos.has_course_over_ground() ? ais_angle(pos.course_over_ground_with_units(), 1)
                                           : 3600}, // cog in 0.1 degrees
         {9, pos.has_true_heading() ? ais_angle(pos.true_heading_with_units(), 0)
-                                   : 511},               // heading in 1 degree
-        {6, static_cast<uint32_t>(pos.report_second())}, // report sec
-        {2},                                             // regional reserved
-        {1, 1},                                          // CS Unit,  1 = Class B "CS" unit
-        {1},                                             // Display flag
-        {1},                                             // DSC flag
-        {1},                                             // Band flag
-        {1},                                             // Message 22 flag
-        {1},                                             // Assigned mode
-        {1, pos.raim()},                                 // RAIM
-        {1, 1},                                          // (always "1" for Class-B "CS")
+                                   : 511},                    // heading in 1 degree
+        {6, static_cast<std::uint32_t>(pos.report_second())}, // report sec
+        {2},                                                  // regional reserved
+        {1, 1},                                               // CS Unit,  1 = Class B "CS" unit
+        {1},                                                  // Display flag
+        {1},                                                  // DSC flag
+        {1},                                                  // Band flag
+        {1},                                                  // Message 22 flag
+        {1},                                                  // Assigned mode
+        {1, pos.raim()},                                      // RAIM
+        {1, 1},                                               // (always "1" for Class-B "CS")
         {19,
          393222} // Because Class B "CS" does not use any Communication State information, this field shall be filled with the following value: 1100000000000000110.
     };
-
-    for (int i = 0, n = fields.size(); i < n; ++i)
-    { std::cout << "[" << i << "] " << fields[i] << std::endl; }
 
     concatenate_bitset(fields);
     assert(bits_.size() == 168);

--- a/src/util/ais/encode.h
+++ b/src/util/ais/encode.h
@@ -86,26 +86,26 @@ class Encoder
     template <typename AngleType, typename ValueType>
     std::uint32_t ais_latlon(boost::units::quantity<AngleType, ValueType> ll)
     {
-        return std::round(boost::units::quantity<boost::units::degree::plane_angle>(ll).value() *
-                          600000.0);
+        return static_cast<std::int32_t>(std::round(
+            boost::units::quantity<boost::units::degree::plane_angle>(ll).value() * 600000.0));
     }
 
     // 0 - 360 as tenths
     template <typename AngleType, typename ValueType>
     std::uint32_t ais_angle(boost::units::quantity<AngleType, ValueType> a, int precision)
     {
-        return std::round(
+        return static_cast<std::uint32_t>(std::round(
             wrap_0_360(boost::units::quantity<boost::units::degree::plane_angle>(a)).value() *
-            std::pow(10, precision));
+            std::pow(10, precision)));
     }
 
     // 1/10 knots
     template <typename SpeedType, typename ValueType>
     std::uint32_t ais_speed(boost::units::quantity<SpeedType, ValueType> s)
     {
-        return std::round(
+        return static_cast<std::uint32_t>(std::round(
             boost::units::quantity<boost::units::metric::knot_base_unit::unit_type>(s).value() *
-            10);
+            10));
     }
 
     struct AISField;
@@ -178,8 +178,10 @@ std::ostream& operator<<(std::ostream& os, const Encoder::AISField& ais)
     if (ais.is_string)
         os << "s: " << ais.s;
     else
+    {
         os << "u: " << ais.u;
-
+        os << ", i: " << static_cast<std::int32_t>(ais.u);
+    }
     return os;
 }
 

--- a/src/util/ais/encode.h
+++ b/src/util/ais/encode.h
@@ -109,6 +109,7 @@ class Encoder
     }
 
     struct AISField;
+    friend std::ostream& operator<<(std::ostream& os, const Encoder::AISField& ais);
 
     void concatenate_bitset(const std::vector<AISField>& fields)
     {
@@ -170,6 +171,17 @@ class Encoder
 
     static std::atomic<int> sequence_id_;
 };
+
+std::ostream& operator<<(std::ostream& os, const Encoder::AISField& ais)
+{
+    os << "l:" << static_cast<int>(ais.len) << ", ";
+    if (ais.is_string)
+        os << "s: " << ais.s;
+    else
+        os << "u: " << ais.u;
+
+    return os;
+}
 
 } // namespace ais
 } // namespace util


### PR DESCRIPTION
Fixes lat: 0 or lon: 0 encoded value when using negative lat or lon values.

This exhibits on arm architectures but it was undefined behavior previously:

From https://en.cppreference.com/w/cpp/language/implicit_conversion

Floating–integral conversions

        A prvalue of floating-point type can be converted to a prvalue of any integer type. The fractional part is truncated, that is, the fractional part is discarded. If the value cannot fit into the destination type, the behavior is undefined (even when the destination type is unsigned, modulo arithmetic does not apply). If the destination type is bool, this is a boolean conversion (see below). 