### PR TITLE
Fix geodesy zone 60

### DIFF
--- a/src/test/util/geodesy/test.cpp
+++ b/src/test/util/geodesy/test.cpp
@@ -78,6 +78,31 @@ int main()
         assert(double_cmp(utm.y / meters, 100, 3));
     }
 
+    {
+        goby::util::UTMGeodesy geodesy({41 * degrees, 175 * degrees});
+        std::cout << "zone: " << geodesy.origin_utm_zone() << std::endl;
+        assert(geodesy.origin_utm_zone() == 60);
+
+        auto geo = geodesy.convert(goby::util::UTMGeodesy::XYPoint({100 * meters, 100 * meters}));
+        auto origin_geo = geodesy.origin_geo();
+
+        std::cout << "geo origin: " << std::setprecision(std::numeric_limits<double>::digits10)
+                  << origin_geo.lat << ", " << origin_geo.lon << std::endl;
+        std::cout << "(x = 100, y = 100) as (lat, lon): ("
+                  << std::setprecision(std::numeric_limits<double>::digits10) << geo.lat << ", "
+                  << geo.lon << ")" << std::endl;
+
+        assert(double_cmp(geo.lat / degrees, 41.00092, 5));
+        assert(double_cmp(geo.lon / degrees, 175.001161, 5));
+
+        auto utm = geodesy.convert(geo);
+        std::cout << "reconvert as (x, y): ("
+                  << std::setprecision(std::numeric_limits<double>::digits10) << utm.x << ", "
+                  << utm.y << ")" << std::endl;
+        assert(double_cmp(utm.x / meters, 100, 3));
+        assert(double_cmp(utm.y / meters, 100, 3));
+    }
+
     std::cout << "all tests passed" << std::endl;
     return 0;
 }

--- a/src/util/geodesy.cpp
+++ b/src/util/geodesy.cpp
@@ -37,7 +37,7 @@ goby::util::UTMGeodesy::UTMGeodesy(const LatLonPoint& origin)
     : origin_geo_(origin), origin_zone_(0), pj_utm_(nullptr), pj_latlong_(nullptr)
 {
     double origin_lon_deg = origin.lon / boost::units::degree::degrees;
-    origin_zone_ = (static_cast<int>(std::floor((origin_lon_deg + 180) / 6)) + 1) % 60;
+    origin_zone_ = (static_cast<int>(std::floor((origin_lon_deg + 180) / 6))) % 60 + 1;
 
     std::stringstream proj_utm;
     proj_utm << "+proj=utm +ellps=WGS84 +zone=" << origin_zone_;


### PR DESCRIPTION
Previously UTM zone 60 (174-180E) was reported as zone 0, which does not exist.

This fixes that bug.