### PR TITLE
Fix bug in intervehicle duplicate subscription handling

### DIFF
--- a/src/middleware/transport/intervehicle/driver_thread.cpp
+++ b/src/middleware/transport/intervehicle/driver_thread.cpp
@@ -465,8 +465,10 @@ void goby::middleware::intervehicle::ModemDriverThread::_accept_subscription(
             for (auto it = it_pair.first, end = it_pair.second; it != end; ++it)
             {
                 if (it->second.intervehicle() == subscription.intervehicle())
+                {
                     is_new_cfg = false;
-                break;
+                    break;
+                }
             }
 
             if (is_new_cfg)


### PR DESCRIPTION
Misplaced `break` meant that only the first subscription was checked against any new subscriptions for rejecting duplicates.

This PR fixes that bug #222 