### PR TITLE
Publish configuration and implement multithread health reporting

### DIFF
--- a/src/apps/zeromq/geov/geov.cpp
+++ b/src/apps/zeromq/geov/geov.cpp
@@ -32,13 +32,13 @@
 #include "goby/middleware/frontseat/groups.h"
 #include "goby/middleware/protobuf/frontseat_data.pb.h"
 #include "goby/util/as.h"
-#include "goby/zeromq/application/multi_thread.h"
+#include "goby/zeromq/application/single_thread.h"
 #include "goby/zeromq/protobuf/geov_config.pb.h"
 
 using goby::glog;
 namespace si = boost::units::si;
 using ApplicationBase =
-    goby::zeromq::MultiThreadApplication<goby::apps::zeromq::protobuf::GEOVInterfaceConfig>;
+    goby::zeromq::SingleThreadApplication<goby::apps::zeromq::protobuf::GEOVInterfaceConfig>;
 
 namespace goby
 {

--- a/src/middleware/application/detail/thread_type_selector.h
+++ b/src/middleware/application/detail/thread_type_selector.h
@@ -32,14 +32,15 @@ namespace middleware
 {
 namespace detail
 {
-/// \brief Selects which constructor to use based on whether the thread is launched with an index or not (that is, index == -1). Not directly called by user code.
-template <typename ThreadType, typename ThreadConfig, bool has_index> struct ThreadTypeSelector
+/// \brief Selects which constructor to use based on whether the thread is launched with an index or not (that is, index == -1), and with a configuration object or not. Not directly called by user code.
+template <typename ThreadType, typename ThreadConfig, bool has_index, bool has_config>
+struct ThreadTypeSelector
 {
 };
 
-/// \brief ThreadTypeSelector instantiation for calling a constructor \e without an index parameter, e.g. "MyThread(const MyConfig& cfg)"
+/// \brief ThreadTypeSelector instantiation for calling a constructor \e without an index parameter but \e with a configuration value, e.g. "MyThread(const MyConfig& cfg)"
 template <typename ThreadType, typename ThreadConfig>
-struct ThreadTypeSelector<ThreadType, ThreadConfig, false>
+struct ThreadTypeSelector<ThreadType, ThreadConfig, false, true>
 {
     static std::shared_ptr<ThreadType> thread(const ThreadConfig& cfg, int index = -1)
     {
@@ -47,15 +48,36 @@ struct ThreadTypeSelector<ThreadType, ThreadConfig, false>
     };
 };
 
-/// \brief ThreadTypeSelector instantiation for calling a constructor \e with an index parameter, e.g. "MyThread(const MyConfig& cfg, int index)"
+/// \brief ThreadTypeSelector instantiation for calling a constructor \e with an index parameter and a  configuration value, e.g. "MyThread(const MyConfig& cfg, int index)"
 template <typename ThreadType, typename ThreadConfig>
-struct ThreadTypeSelector<ThreadType, ThreadConfig, true>
+struct ThreadTypeSelector<ThreadType, ThreadConfig, true, true>
 {
     static std::shared_ptr<ThreadType> thread(const ThreadConfig& cfg, int index)
     {
         return std::make_shared<ThreadType>(cfg, index);
     };
 };
+
+/// \brief ThreadTypeSelector instantiation for calling a constructor \e without an index parameter ora configuration value, e.g. "MyThread()"
+template <typename ThreadType, typename ThreadConfig>
+struct ThreadTypeSelector<ThreadType, ThreadConfig, false, false>
+{
+    static std::shared_ptr<ThreadType> thread(const ThreadConfig& cfg, int index = -1)
+    {
+        return std::make_shared<ThreadType>();
+    };
+};
+
+/// \brief ThreadTypeSelector instantiation for calling a constructor \e with an index parameter and without a configuration value, e.g. "MyThread(int index)"
+template <typename ThreadType, typename ThreadConfig>
+struct ThreadTypeSelector<ThreadType, ThreadConfig, true, false>
+{
+    static std::shared_ptr<ThreadType> thread(const ThreadConfig& cfg, int index)
+    {
+        return std::make_shared<ThreadType>(index);
+    };
+};
+
 } // namespace detail
 } // namespace middleware
 } // namespace goby

--- a/src/middleware/application/groups.h
+++ b/src/middleware/application/groups.h
@@ -1,0 +1,41 @@
+// Copyright 2009-2021:
+//   GobySoft, LLC (2013-)
+//   Massachusetts Institute of Technology (2007-2014)
+//   Community contributors (see AUTHORS file)
+// File authors:
+//   Toby Schneider <toby@gobysoft.org>
+//
+//
+// This file is part of the Goby Underwater Autonomy Project Libraries
+// ("The Goby Libraries").
+//
+// The Goby Libraries are free software: you can redistribute them and/or modify
+// them under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// The Goby Libraries are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Goby.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef GOBY_MIDDLEWARE_APPLICATION_GROUPS_H
+#define GOBY_MIDDLEWARE_APPLICATION_GROUPS_H
+
+#include "goby/middleware/group.h"
+
+namespace goby
+{
+namespace middleware
+{
+namespace groups
+{
+constexpr goby::middleware::Group configuration{"goby::configuration"};
+} // namespace groups
+} // namespace middleware
+} // namespace goby
+
+#endif

--- a/src/middleware/application/multi_thread.h
+++ b/src/middleware/application/multi_thread.h
@@ -24,6 +24,7 @@
 #ifndef GOBY_MIDDLEWARE_APPLICATION_MULTI_THREAD_H
 #define GOBY_MIDDLEWARE_APPLICATION_MULTI_THREAD_H
 
+#include <boost/core/demangle.hpp>
 #include <boost/units/systems/si.hpp>
 
 #include "goby/middleware/coroner/coroner.h"
@@ -35,6 +36,7 @@
 #include "goby/middleware/application/detail/thread_type_selector.h"
 #include "goby/middleware/application/groups.h"
 #include "goby/middleware/application/interface.h"
+#include "goby/middleware/application/simple_thread.h"
 #include "goby/middleware/application/thread.h"
 
 #include "goby/middleware/transport/interprocess.h"
@@ -45,112 +47,6 @@ namespace goby
 {
 namespace middleware
 {
-/// \brief Implements Thread for a three layer middleware setup ([ intervehicle [ interprocess [ interthread ] ] ]) based around InterVehicleForwarder.
-///
-/// \tparam Config Configuration type
-/// Derive from this class to create standalone threads that can be launched and joined by MultiThreadApplication's launch_thread and join_thread methods.
-template <typename Config>
-class SimpleThread
-    : public Thread<Config, InterVehicleForwarder<InterProcessForwarder<InterThreadTransporter>>>
-{
-    using SimpleThreadBase =
-        Thread<Config, InterVehicleForwarder<InterProcessForwarder<InterThreadTransporter>>>;
-
-  public:
-    /// \brief Construct a thread with a given configuration, optionally a loop frequency and/or index
-    ///
-    /// \param cfg Data to configure the code running in this thread
-    /// \param loop_freq_hertz The frequency at which to attempt to call loop(), assuming the thread isn't blocked handling transporter callbacks (e.g. subscribe callbacks). Zero or negative indicates loop() will never be called.
-    /// \param index Numeric index to identify this instantiation of the SimpleThread (only necessary if multiple Threads of the same type are created)
-    SimpleThread(const Config& cfg, double loop_freq_hertz = 0, int index = -1)
-        : SimpleThread(cfg, loop_freq_hertz * boost::units::si::hertz, index)
-    {
-    }
-
-    /// \brief Construct a thread with a given configuration, a loop frequency (using boost::units) and optionally an index
-    ///
-    /// \param cfg Data to configure the code running in this thread
-    /// \param loop_freq The frequency at which to attempt to call loop(), assuming the thread isn't blocked handling transporter callbacks (e.g. subscribe callbacks). Zero or negative indicates loop() will never be called.
-    /// \param index Numeric index to identify this instantiation of the SimpleThread (only necessary if multiple Threads of the same type are created)
-    SimpleThread(const Config& cfg, boost::units::quantity<boost::units::si::frequency> loop_freq,
-                 int index = -1)
-        : SimpleThreadBase(cfg, loop_freq, index)
-    {
-        interthread_.reset(new InterThreadTransporter);
-        interprocess_.reset(new InterProcessForwarder<InterThreadTransporter>(*interthread_));
-        intervehicle_.reset(
-            new InterVehicleForwarder<InterProcessForwarder<InterThreadTransporter>>(
-                *interprocess_));
-
-        this->set_transporter(intervehicle_.get());
-
-        this->interthread().template subscribe<groups::health_request>(
-            [this](const protobuf::HealthRequest& request) {
-                protobuf::ProcessHealth response;
-                this->thread_health(*response.mutable_main()->add_child());
-                this->interthread().template publish<groups::health_response>(response);
-            });
-    }
-
-    /// \brief Access the transporter on the intervehicle layer (which wraps interprocess and interthread)
-    InterVehicleForwarder<InterProcessForwarder<InterThreadTransporter>>& intervehicle()
-    {
-        return this->transporter();
-    }
-
-    /// \brief Access the transporter on the interprocess layer (which wraps interthread)
-    InterProcessForwarder<InterThreadTransporter>& interprocess()
-    {
-        return this->transporter().inner();
-    }
-
-    /// \brief Access the transporter on the interthread layer (this is the innermost transporter)
-    InterThreadTransporter& interthread() { return this->transporter().innermost(); }
-
-  private:
-    std::unique_ptr<InterThreadTransporter> interthread_;
-    std::unique_ptr<InterProcessForwarder<InterThreadTransporter>> interprocess_;
-    std::unique_ptr<InterVehicleForwarder<InterProcessForwarder<InterThreadTransporter>>>
-        intervehicle_;
-};
-
-template <class Config> class HealthMonitorThread : public SimpleThread<Config>
-{
-  public:
-    HealthMonitorThread(const Config& cfg)
-        : SimpleThread<Config>(cfg, 1.0 * boost::units::si::hertz)
-    {
-        // handle goby_coroner request
-        this->interprocess().template subscribe<groups::health_request, protobuf::HealthRequest>(
-            [this](const protobuf::HealthRequest& request) {
-                health_response_.Clear();
-                this->interthread().template publish<groups::health_request>(
-                    protobuf::HealthRequest());
-                last_health_request_time_ = goby::time::SteadyClock::now();
-            });
-
-        this->interthread().template subscribe<groups::health_response>(
-            [this](const protobuf::ProcessHealth& response) {
-                health_response_.MergeFrom(response);
-            });
-    }
-
-  private:
-    void loop() override
-    {
-        if (goby::time::SteadyClock::now() > last_health_request_time_ + health_request_timeout_)
-        {
-            if (health_response_.IsInitialized())
-                this->interprocess().template publish<groups::health_response>(health_response_);
-        }
-    }
-
-  private:
-    protobuf::ProcessHealth health_response_;
-    goby::time::SteadyClock::time_point last_health_request_time_;
-    const goby::time::SteadyClock::duration health_request_timeout_{std::chrono::seconds(1)};
-};
-
 /// \brief Thread that simply publishes an empty message on its loop interval to TimerThread::group
 ///
 /// This can be launched to provide a simple timer by subscribing to TimerThread::group.
@@ -210,34 +106,45 @@ class MultiThreadApplicationBase : public goby::middleware::Application<Config>,
 
         std::atomic<bool> alive{true};
         std::string name;
+        int uid;
         std::unique_ptr<std::thread> thread;
     };
 
     static std::exception_ptr thread_exception_;
 
     std::map<std::type_index, std::map<int, ThreadManagement>> threads_;
+    int thread_uid_{0};
     int running_thread_count_{0};
     InterThreadTransporter interthread_;
 
   public:
     template <typename ThreadType> void launch_thread()
     {
-        _launch_thread<ThreadType, Config, false>(-1, this->app_cfg());
+        _launch_thread<ThreadType, Config, false, true>(-1, this->app_cfg());
     }
     template <typename ThreadType> void launch_thread(int index)
     {
-        _launch_thread<ThreadType, Config, true>(index, this->app_cfg());
+        _launch_thread<ThreadType, Config, true, true>(index, this->app_cfg());
     }
 
     template <typename ThreadType, typename ThreadConfig>
     void launch_thread(const ThreadConfig& cfg)
     {
-        _launch_thread<ThreadType, ThreadConfig, false>(-1, cfg);
+        _launch_thread<ThreadType, ThreadConfig, false, true>(-1, cfg);
     }
     template <typename ThreadType, typename ThreadConfig>
     void launch_thread(int index, const ThreadConfig& cfg)
     {
-        _launch_thread<ThreadType, ThreadConfig, true>(index, cfg);
+        _launch_thread<ThreadType, ThreadConfig, true, true>(index, cfg);
+    }
+
+    template <typename ThreadType> void launch_thread_without_cfg()
+    {
+        _launch_thread<ThreadType, Config, false, false>(-1, this->app_cfg());
+    }
+    template <typename ThreadType> void launch_thread_without_cfg(int index)
+    {
+        _launch_thread<ThreadType, Config, true, false>(index, this->app_cfg());
     }
 
     template <typename ThreadType> void join_thread(int index = -1)
@@ -277,13 +184,15 @@ class MultiThreadApplicationBase : public goby::middleware::Application<Config>,
             });
 
         if (this->app_cfg().app().health_cfg().run_health_monitor_thread())
-            launch_thread<HealthMonitorThread<Config>>();
+            launch_thread_without_cfg<HealthMonitorThread>();
     }
 
     virtual ~MultiThreadApplicationBase() {}
 
     InterThreadTransporter& interthread() { return interthread_; }
     virtual void post_finalize() override { join_all_threads(); }
+
+    std::map<std::type_index, std::map<int, ThreadManagement>>& threads() { return threads_; }
 
     void join_all_threads()
     {
@@ -328,7 +237,7 @@ class MultiThreadApplicationBase : public goby::middleware::Application<Config>,
         }
     }
 
-    template <typename ThreadType, typename ThreadConfig, bool has_index>
+    template <typename ThreadType, typename ThreadConfig, bool has_index, bool has_config>
     void _launch_thread(int index, const ThreadConfig& cfg);
 
     void _join_thread(const std::type_index& type_i, int index);
@@ -348,6 +257,8 @@ class MultiThreadApplication
     InterVehicleForwarder<InterProcessPortal<InterThreadTransporter>> intervehicle_;
     using Base = MultiThreadApplicationBase<
         Config, InterVehicleForwarder<InterProcessPortal<InterThreadTransporter>>>;
+
+    std::shared_ptr<protobuf::ProcessHealth> health_response_{new protobuf::ProcessHealth};
 
   public:
     /// \brief Construct the application calling loop() at the given frequency (double overload)
@@ -382,13 +293,28 @@ class MultiThreadApplication
             });
 
         // handle request from HealthMonitor thread
+        health_response_->set_name(this->app_name());
+        health_response_->set_pid(getpid());
+
         this->interthread().template subscribe<groups::health_request>(
             [this](const protobuf::HealthRequest& request) {
-                protobuf::ProcessHealth response;
-                response.set_name(this->app_name());
-                response.set_pid(getpid());
-                this->thread_health(*response.mutable_main());
-                this->interthread().template publish<groups::health_response>(response);
+                health_response_->mutable_main()->clear_child();
+                // preseed all threads with error in case they don't respond
+                for (const auto& type_map_p : this->threads())
+                {
+                    for (const auto& index_manager_p : type_map_p.second)
+                    {
+                        const auto& thread_manager = index_manager_p.second;
+                        auto& thread_health = *health_response_->mutable_main()->add_child();
+                        thread_health.set_name(thread_manager.name);
+                        thread_health.set_uid(thread_manager.uid);
+                        thread_health.set_state(protobuf::HEALTH__FAILED);
+                        thread_health.set_error(protobuf::ERROR__THREAD_NOT_RESPONDING);
+                    }
+                }
+
+                this->thread_health(*health_response_->mutable_main());
+                this->interthread().template publish<groups::health_response>(health_response_);
             });
 
         this->interprocess().template subscribe<goby::middleware::groups::datum_update>(
@@ -484,7 +410,7 @@ std::exception_ptr
     goby::middleware::MultiThreadApplicationBase<Config, Transporter>::thread_exception_(nullptr);
 
 template <class Config, class Transporter>
-template <typename ThreadType, typename ThreadConfig, bool has_index>
+template <typename ThreadType, typename ThreadConfig, bool has_index, bool has_config>
 void goby::middleware::MultiThreadApplicationBase<Config, Transporter>::_launch_thread(
     int index, const ThreadConfig& cfg)
 {
@@ -496,15 +422,22 @@ void goby::middleware::MultiThreadApplicationBase<Config, Transporter>::_launch_
 
     auto& thread_manager = threads_[type_i][index];
     thread_manager.alive = true;
+    thread_manager.name = boost::core::demangle(typeid(ThreadType).name());
+    if (has_index)
+        thread_manager.name += "/" + std::to_string(index);
+    thread_manager.uid = thread_uid_++;
 
     // copy configuration
     auto thread_lambda = [this, type_i, index, cfg, &thread_manager]() {
         try
         {
             std::shared_ptr<ThreadType> goby_thread(
-                detail::ThreadTypeSelector<ThreadType, ThreadConfig, has_index>::thread(cfg,
-                                                                                        index));
+                detail::ThreadTypeSelector<ThreadType, ThreadConfig, has_index, has_config>::thread(
+                    cfg, index));
+
+            goby_thread->set_name(thread_manager.name);
             goby_thread->set_type_index(type_i);
+            goby_thread->set_uid(thread_manager.uid);
             goby_thread->run(thread_manager.alive);
         }
         catch (...)
@@ -515,8 +448,11 @@ void goby::middleware::MultiThreadApplicationBase<Config, Transporter>::_launch_
         interthread_.publish<MainThreadBase::joinable_group_>(ThreadIdentifier{type_i, index});
     };
 
-    thread_manager.name = std::string(typeid(ThreadType).name()) + "_index" + std::to_string(index);
     thread_manager.thread = std::unique_ptr<std::thread>(new std::thread(thread_lambda));
+
+    // set thread name for debugging purposes
+    pthread_setname_np(thread_manager.thread->native_handle(), thread_manager.name.c_str());
+
     ++running_thread_count_;
 }
 

--- a/src/middleware/application/simple_thread.h
+++ b/src/middleware/application/simple_thread.h
@@ -1,0 +1,109 @@
+// Copyright 2016-2021:
+//   GobySoft, LLC (2013-)
+//   Community contributors (see AUTHORS file)
+// File authors:
+//   Toby Schneider <toby@gobysoft.org>
+//
+//
+// This file is part of the Goby Underwater Autonomy Project Libraries
+// ("The Goby Libraries").
+//
+// The Goby Libraries are free software: you can redistribute them and/or modify
+// them under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// The Goby Libraries are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Goby.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef GOBY_MIDDLEWARE_APPLICATION_SIMPLE_THREAD_H
+#define GOBY_MIDDLEWARE_APPLICATION_SIMPLE_THREAD_H
+
+#include "goby/middleware/application/thread.h"
+#include "goby/middleware/coroner/coroner.h"
+
+#include "goby/middleware/transport/interprocess.h"
+#include "goby/middleware/transport/interthread.h"
+#include "goby/middleware/transport/intervehicle.h"
+
+namespace goby
+{
+namespace middleware
+{
+/// \brief Implements Thread for a three layer middleware setup ([ intervehicle [ interprocess [ interthread ] ] ]) based around InterVehicleForwarder.
+///
+/// \tparam Config Configuration type
+/// Derive from this class to create standalone threads that can be launched and joined by MultiThreadApplication's launch_thread and join_thread methods.
+template <typename Config>
+class SimpleThread
+    : public Thread<Config, InterVehicleForwarder<InterProcessForwarder<InterThreadTransporter>>>
+{
+    using SimpleThreadBase =
+        Thread<Config, InterVehicleForwarder<InterProcessForwarder<InterThreadTransporter>>>;
+
+  public:
+    /// \brief Construct a thread with a given configuration, optionally a loop frequency and/or index
+    ///
+    /// \param cfg Data to configure the code running in this thread
+    /// \param loop_freq_hertz The frequency at which to attempt to call loop(), assuming the thread isn't blocked handling transporter callbacks (e.g. subscribe callbacks). Zero or negative indicates loop() will never be called.
+    /// \param index Numeric index to identify this instantiation of the SimpleThread (only necessary if multiple Threads of the same type are created)
+    SimpleThread(const Config& cfg, double loop_freq_hertz = 0, int index = -1)
+        : SimpleThread(cfg, loop_freq_hertz * boost::units::si::hertz, index)
+    {
+    }
+
+    /// \brief Construct a thread with a given configuration, a loop frequency (using boost::units) and optionally an index
+    ///
+    /// \param cfg Data to configure the code running in this thread
+    /// \param loop_freq The frequency at which to attempt to call loop(), assuming the thread isn't blocked handling transporter callbacks (e.g. subscribe callbacks). Zero or negative indicates loop() will never be called.
+    /// \param index Numeric index to identify this instantiation of the SimpleThread (only necessary if multiple Threads of the same type are created)
+    SimpleThread(const Config& cfg, boost::units::quantity<boost::units::si::frequency> loop_freq,
+                 int index = -1)
+        : SimpleThreadBase(cfg, loop_freq, index)
+    {
+        interthread_.reset(new InterThreadTransporter);
+        interprocess_.reset(new InterProcessForwarder<InterThreadTransporter>(*interthread_));
+        intervehicle_.reset(
+            new InterVehicleForwarder<InterProcessForwarder<InterThreadTransporter>>(
+                *interprocess_));
+
+        this->set_transporter(intervehicle_.get());
+
+        this->interthread().template subscribe<groups::health_request>(
+            [this](const protobuf::HealthRequest& request) {
+                std::shared_ptr<protobuf::ThreadHealth> response(new protobuf::ThreadHealth);
+                this->thread_health(*response);
+                this->interthread().template publish<groups::health_response>(response);
+            });
+    }
+
+    /// \brief Access the transporter on the intervehicle layer (which wraps interprocess and interthread)
+    InterVehicleForwarder<InterProcessForwarder<InterThreadTransporter>>& intervehicle()
+    {
+        return this->transporter();
+    }
+
+    /// \brief Access the transporter on the interprocess layer (which wraps interthread)
+    InterProcessForwarder<InterThreadTransporter>& interprocess()
+    {
+        return this->transporter().inner();
+    }
+
+    /// \brief Access the transporter on the interthread layer (this is the innermost transporter)
+    InterThreadTransporter& interthread() { return this->transporter().innermost(); }
+
+  private:
+    std::unique_ptr<InterThreadTransporter> interthread_;
+    std::unique_ptr<InterProcessForwarder<InterThreadTransporter>> interprocess_;
+    std::unique_ptr<InterVehicleForwarder<InterProcessForwarder<InterThreadTransporter>>>
+        intervehicle_;
+};
+} // namespace middleware
+} // namespace goby
+
+#endif

--- a/src/middleware/application/single_thread.h
+++ b/src/middleware/application/single_thread.h
@@ -31,6 +31,7 @@
 #include "goby/middleware/terminate/terminate.h"
 
 #include "goby/middleware/application/detail/interprocess_common.h"
+#include "goby/middleware/application/groups.h"
 #include "goby/middleware/application/interface.h"
 #include "goby/middleware/application/thread.h"
 
@@ -105,6 +106,9 @@ class SingleThreadApplication : public goby::middleware::Application<Config>,
                 this->configure_geodesy(
                     {datum_update.datum().lat_with_units(), datum_update.datum().lon_with_units()});
             });
+
+        this->interprocess().template publish<goby::middleware::groups::configuration>(
+            this->app_cfg());
     }
 
     virtual ~SingleThreadApplication() {}

--- a/src/middleware/application/thread.h
+++ b/src/middleware/application/thread.h
@@ -29,6 +29,7 @@
 #include <memory>
 #include <mutex>
 #include <typeindex>
+#include <unistd.h> // for gettid
 
 #include <boost/units/systems/si.hpp>
 

--- a/src/middleware/application/thread.h
+++ b/src/middleware/application/thread.h
@@ -29,7 +29,6 @@
 #include <memory>
 #include <mutex>
 #include <typeindex>
-#include <unistd.h> // for gettid
 
 #include <boost/units/systems/si.hpp>
 
@@ -159,7 +158,7 @@ template <typename Config, typename TransporterType> class Thread
           loop_time_(std::chrono::system_clock::now()),
           cfg_(cfg),
           index_(index),
-          thread_id_(gettid()),
+          thread_id_(goby::middleware::gettid()),
           thread_name_(std::to_string(thread_id_)),
           uid_(-1)
     {

--- a/src/middleware/coroner/coroner.cpp
+++ b/src/middleware/coroner/coroner.cpp
@@ -1,0 +1,57 @@
+#include "goby/middleware/coroner/coroner.h"
+
+goby::middleware::HealthMonitorThread::HealthMonitorThread()
+    : SimpleThread<NullConfig>(NullConfig(), 1.0 * boost::units::si::hertz)
+{
+    // handle goby_coroner request
+    this->interprocess().template subscribe<groups::health_request, protobuf::HealthRequest>(
+        [this](const protobuf::HealthRequest& request) {
+            this->interthread().template publish<groups::health_request>(protobuf::HealthRequest());
+            waiting_for_responses_ = true;
+            last_health_request_time_ = goby::time::SteadyClock::now();
+
+            std::shared_ptr<protobuf::ThreadHealth> our_response(new protobuf::ThreadHealth);
+            this->thread_health(*our_response);
+            child_responses_[our_response->uid()] = our_response;
+        });
+
+    // handle response from main thread
+    this->interthread().template subscribe<groups::health_response>(
+        [this](std::shared_ptr<const protobuf::ProcessHealth> response) {
+            health_response_ = *response;
+        });
+
+    // handle response from child threads
+    this->interthread().template subscribe<groups::health_response>(
+        [this](std::shared_ptr<const protobuf::ThreadHealth> response) {
+            child_responses_[response->uid()] = response;
+        });
+}
+
+void goby::middleware::HealthMonitorThread::loop()
+{
+    if (waiting_for_responses_ &&
+        goby::time::SteadyClock::now() > last_health_request_time_ + health_request_timeout_)
+    {
+        goby::middleware::protobuf::HealthState health_state =
+            goby::middleware::protobuf::HEALTH__OK;
+
+        // overwrite any child responses we got
+        for (auto& thread_health : *health_response_.mutable_main()->mutable_child())
+        {
+            if (child_responses_.count(thread_health.uid()))
+                thread_health = *child_responses_.at(thread_health.uid());
+
+            if (thread_health.state() > health_state)
+                health_state = thread_health.state();
+        }
+
+        health_response_.mutable_main()->set_state(health_state);
+
+        if (health_response_.IsInitialized())
+            this->interprocess().template publish<groups::health_response>(health_response_);
+
+        waiting_for_responses_ = false;
+        child_responses_.clear();
+    }
+}

--- a/src/middleware/coroner/coroner.h
+++ b/src/middleware/coroner/coroner.h
@@ -28,4 +28,34 @@
 #include "goby/middleware/marshalling/protobuf.h"
 #include "goby/middleware/protobuf/coroner.pb.h"
 
+#include "goby/middleware/application/simple_thread.h"
+
+namespace goby
+{
+namespace middleware
+{
+struct NullConfig
+{
+};
+
+class HealthMonitorThread : public SimpleThread<NullConfig>
+{
+  public:
+    HealthMonitorThread();
+
+  private:
+    void loop() override;
+    void initialize() override { this->set_name("health_monitor"); }
+
+  private:
+    protobuf::ProcessHealth health_response_;
+    // uid to response
+    std::map<int, std::shared_ptr<const protobuf::ThreadHealth>> child_responses_;
+    goby::time::SteadyClock::time_point last_health_request_time_;
+    const goby::time::SteadyClock::duration health_request_timeout_{std::chrono::seconds(1)};
+    bool waiting_for_responses_{false};
+};
+} // namespace middleware
+} // namespace goby
+
 #endif

--- a/src/middleware/io/detail/io_interface.h
+++ b/src/middleware/io/detail/io_interface.h
@@ -101,7 +101,7 @@ class IOThread : public ThreadType<IOConfig>,
               IOThread<line_in_group, line_out_group, publish_layer, subscribe_layer, IOConfig,
                        SocketType, ThreadType, use_indexed_groups>,
               line_out_group, subscribe_layer, use_indexed_groups>(index),
-          glog_group_(glog_group + " / t" + std::to_string(gettid())),
+          glog_group_(glog_group + " / t" + std::to_string(goby::middleware::gettid())),
           thread_name_(glog_group)
     {
         auto data_out_callback =

--- a/src/middleware/io/detail/io_interface.h
+++ b/src/middleware/io/detail/io_interface.h
@@ -101,7 +101,8 @@ class IOThread : public ThreadType<IOConfig>,
               IOThread<line_in_group, line_out_group, publish_layer, subscribe_layer, IOConfig,
                        SocketType, ThreadType, use_indexed_groups>,
               line_out_group, subscribe_layer, use_indexed_groups>(index),
-          glog_group_(glog_group + " / t" + goby::middleware::thread_id().substr(0, 6))
+          glog_group_(glog_group + " / t" + std::to_string(gettid())),
+          thread_name_(glog_group)
     {
         auto data_out_callback =
             [this](std::shared_ptr<const goby::middleware::protobuf::IOData> io_msg) {
@@ -132,6 +133,8 @@ class IOThread : public ThreadType<IOConfig>,
                 io_.post([]() {});
             }
         }));
+
+        this->set_name(thread_name_);
     }
 
     void finalize() override
@@ -250,6 +253,7 @@ class IOThread : public ThreadType<IOConfig>,
     std::unique_ptr<std::thread> incoming_mail_notify_thread_;
 
     std::string glog_group_;
+    std::string thread_name_;
     bool glog_group_added_{false};
 };
 

--- a/src/middleware/log/protobuf_log_plugin.h
+++ b/src/middleware/log/protobuf_log_plugin.h
@@ -176,6 +176,24 @@ template <int scheme> class ProtobufPluginBase : public LogPlugin
         else
         {
             insert_protobuf_file_desc(desc->file(), out_log_file);
+
+            auto insert_extensions =
+                [this, &out_log_file](
+                    const std::vector<const google::protobuf::FieldDescriptor*> extensions) {
+                    for (const auto* field_desc : extensions)
+                        insert_protobuf_file_desc(field_desc->containing_type()->file(),
+                                                  out_log_file);
+                };
+
+            std::vector<const google::protobuf::FieldDescriptor*> generated_extensions;
+            google::protobuf::DescriptorPool::generated_pool()->FindAllExtensions(
+                desc, &generated_extensions);
+            insert_extensions(generated_extensions);
+
+            std::vector<const google::protobuf::FieldDescriptor*> user_extensions;
+            dccl::DynamicProtobufManager::user_descriptor_pool().FindAllExtensions(
+                desc, &user_extensions);
+            insert_extensions(user_extensions);
         }
     }
 

--- a/src/middleware/protobuf/app_config.proto
+++ b/src/middleware/protobuf/app_config.proto
@@ -45,7 +45,7 @@ message AppConfig
                     "year). The time difference between now and the reference "
                     "time is multiplied by the warp factor to calculate the "
                     "modified simulation time",
-                (dccl.field).units = {prefix: "micro" base_dimensions: "T"}
+                (dccl.field).units = { prefix: "micro" base_dimensions: "T" }
             ];
         }
         optional Time time = 1;
@@ -66,6 +66,12 @@ message AppConfig
     }
     optional Geodesy geodesy = 30
         [(goby.field).description = "Geodesy related settings"];
+
+    message Health
+    {
+        optional bool run_health_monitor_thread = 1 [default = true];
+    }
+    optional Health health_cfg = 40;
 
     optional bool debug_cfg = 100 [
         default = false,

--- a/src/middleware/protobuf/coroner.proto
+++ b/src/middleware/protobuf/coroner.proto
@@ -4,9 +4,7 @@ import "dccl/option_extensions.proto";
 
 package goby.middleware.protobuf;
 
-message HealthRequest
-{
-}
+message HealthRequest {}
 
 enum HealthState
 {
@@ -18,12 +16,15 @@ enum HealthState
 enum Error
 {
     ERROR__PROCESS_DIED = 1;
+
+    ERROR__THREAD_NOT_RESPONDING = 100;
 }
 
 message ThreadHealth
 {
     required string name = 1;
-    optional string thread_id = 2;
+    optional int32 thread_id = 2;
+    optional int32 uid = 3;
     required HealthState state = 10;
     repeated ThreadHealth child = 11;
     optional Error error = 20;
@@ -44,7 +45,8 @@ message VehicleHealth
 {
     option (dccl.msg).unit_system = "si";
 
-    required uint64 time = 1 [(dccl.field).units = {prefix: "micro" base_dimensions: "T"}];
+    required uint64 time = 1
+        [(dccl.field).units = { prefix: "micro" base_dimensions: "T" }];
     required string platform = 2;
 
     required HealthState state = 10;

--- a/src/middleware/protobuf/coroner.proto
+++ b/src/middleware/protobuf/coroner.proto
@@ -39,6 +39,8 @@ message ProcessHealth
     optional uint32 pid = 2;
 
     required ThreadHealth main = 10;
+
+    extensions 1000 to max;
 }
 
 message VehicleHealth
@@ -51,4 +53,6 @@ message VehicleHealth
 
     required HealthState state = 10;
     repeated ProcessHealth process = 11;
+
+    extensions 1000 to max;
 }

--- a/src/middleware/src.cmake
+++ b/src/middleware/src.cmake
@@ -32,6 +32,7 @@ set(MIDDLEWARE_SRC
   middleware/application/configuration_reader.cpp
   middleware/log/log_entry.cpp
   middleware/frontseat/interface.cpp
+  middleware/coroner/coroner.cpp
   ${MIDDLEWARE_PROTO_SRCS} ${MIDDLEWARE_PROTO_HDRS} 
   )
 

--- a/src/middleware/transport/intervehicle.h
+++ b/src/middleware/transport/intervehicle.h
@@ -789,6 +789,7 @@ class InterVehiclePortal
                     goby::glog.is_warn() &&
                         goby::glog << "Modem driver thread had uncaught exception: " << e.what()
                                    << std::endl;
+                    throw;
                 }
             }));
         }


### PR DESCRIPTION
1. Publish each app's configuration to "goby::configuration" group upon startup (primarily for logging purposes).
2. Implement child thread reporting for apps reporting to goby_coroner.

Fixes #224.
Fixes #64 