### PR TITLE
3.0 logger extensions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ environment-template-common: &environment-template-common
 environment-template-amd64: &environment-template-amd64
   TARGET_ARCH: "amd64"
   # OOM issues on amd64 builds
-  DEB_BUILD_OPTIONS: "parallel=2"
+  DEB_BUILD_OPTIONS: "parallel=4"
   # one job only must do the source build for each distro
   DO_SOURCE_BUILD: "true"
 
@@ -87,6 +87,7 @@ docker-armhf-focal: &docker-armhf-focal
 ## Pre-declare job templates
 job-template-amd64: &job-template-amd64
   working_directory: /root/goby3
+  resource_class: large
   steps:
     - checkout
     - run: &run-add-continuous-packages
@@ -195,7 +196,7 @@ job-template-sanitizers: &job-template-sanitizers
     <<: *environment-template-common
     <<: *environment-template-focal
     <<: *environment-template-amd64
-    SANITIZER_NUM_JOBS: 2
+    SANITIZER_NUM_JOBS: 4
     TSAN_OPTIONS: "suppressions=/root/goby3/src/test/suppressions.tsan.txt"    
   docker: *docker-base-focal
 
@@ -203,6 +204,8 @@ job-template-sanitizers: &job-template-sanitizers
 job-template-upload: &job-template-upload
   <<: *job-template-amd64
   docker: *docker-base-bionic
+  resource_class: small
+
 
   
 # which branches to run the Debian build and upload on

--- a/src/apps/middleware/log_tool/log_tool.cpp
+++ b/src/apps/middleware/log_tool/log_tool.cpp
@@ -38,11 +38,11 @@
 #include "goby/middleware/group.h"                            // for operat...
 #include "goby/middleware/log/dccl_log_plugin.h"              // for DCCLPl...
 #include "goby/middleware/log/json_log_plugin.h"
-#include "goby/middleware/log/log_entry.h"                    // for LogEntry
-#include "goby/middleware/log/log_plugin.h"                   // for LogPlugin
-#include "goby/middleware/marshalling/interface.h"            // for Marsha...
-#include "goby/middleware/protobuf/log_tool_config.pb.h"      // for LogToo...
-#include "goby/util/debug_logger/flex_ostream.h"              // for operat...
+#include "goby/middleware/log/log_entry.h"               // for LogEntry
+#include "goby/middleware/log/log_plugin.h"              // for LogPlugin
+#include "goby/middleware/marshalling/interface.h"       // for Marsha...
+#include "goby/middleware/protobuf/log_tool_config.pb.h" // for LogToo...
+#include "goby/util/debug_logger/flex_ostream.h"         // for operat...
 
 #ifdef HAS_HDF5
 #include "goby/middleware/log/hdf5/hdf5.h" // for Writer
@@ -184,7 +184,8 @@ goby::apps::middleware::LogTool::LogTool()
                                << " | " << debug_text_msg << std::endl;
                         break;
                     }
-                    case protobuf::LogToolConfig::HDF5: {
+                    case protobuf::LogToolConfig::HDF5:
+                    {
 #ifdef HAS_HDF5
                         auto h5_entries = plugin->second->hdf5_entry(log_entry);
                         for (const auto& entry : h5_entries) h5_writer_->add_entry(entry);
@@ -205,6 +206,9 @@ goby::apps::middleware::LogTool::LogTool()
                     case protobuf::LogToolConfig::DEBUG_TEXT:
                         f_out_ << log_entry.scheme() << " | " << log_entry.group() << " | "
                                << log_entry.type() << " | "
+                               << goby::time::convert<boost::posix_time::ptime>(
+                                      log_entry.timestamp())
+                               << " | "
                                << "Unable to parse message of " << log_entry.data().size()
                                << " bytes. Reason: " << e.what() << std::endl;
                         break;

--- a/src/apps/zeromq/logger/logger.cpp
+++ b/src/apps/zeromq/logger/logger.cpp
@@ -116,7 +116,7 @@ class Logger : public goby::zeromq::SingleThreadApplication<protobuf::LoggerConf
                                 glog << "Received STOP_LOGGING but we were already stopped"
                                      << std::endl;
 
-                        logging_ = true;
+                        logging_ = false;
                         break;
 
                     case goby::middleware::protobuf::LoggerRequest::ROTATE_LOG:

--- a/src/apps/zeromq/logger/logger.cpp
+++ b/src/apps/zeromq/logger/logger.cpp
@@ -46,15 +46,17 @@
 #include "goby/middleware/application/interface.h"            // for run
 #include "goby/middleware/group.h"                            // for operat...
 #include "goby/middleware/log/dccl_log_plugin.h"              // for DCCLPl...
-#include "goby/middleware/log/log_entry.h"                    // for LogEntry
-#include "goby/middleware/log/protobuf_log_plugin.h"          // for Protob...
-#include "goby/middleware/marshalling/interface.h"            // for Marsha...
-#include "goby/time/convert.h"                                // for file_str
-#include "goby/util/debug_logger/flex_ostream.h"              // for operat...
-#include "goby/zeromq/application/single_thread.h"            // for Single...
-#include "goby/zeromq/protobuf/interprocess_config.pb.h"      // for InterP...
-#include "goby/zeromq/protobuf/logger_config.pb.h"            // for Logger...
-#include "goby/zeromq/transport/interprocess.h"               // for InterP...
+#include "goby/middleware/log/groups.h"
+#include "goby/middleware/log/log_entry.h"           // for LogEntry
+#include "goby/middleware/log/protobuf_log_plugin.h" // for Protob...
+#include "goby/middleware/marshalling/interface.h"   // for Marsha...
+#include "goby/middleware/protobuf/logger.pb.h"
+#include "goby/time/convert.h"                           // for file_str
+#include "goby/util/debug_logger/flex_ostream.h"         // for operat...
+#include "goby/zeromq/application/single_thread.h"       // for Single...
+#include "goby/zeromq/protobuf/interprocess_config.pb.h" // for InterP...
+#include "goby/zeromq/protobuf/logger_config.pb.h"       // for Logger...
+#include "goby/zeromq/transport/interprocess.h"          // for InterP...
 
 using goby::glog;
 
@@ -72,22 +74,11 @@ class Logger : public goby::zeromq::SingleThreadApplication<protobuf::LoggerConf
     Logger()
         : goby::zeromq::SingleThreadApplication<protobuf::LoggerConfig>(1 *
                                                                         boost::units::si::hertz),
-          log_file_base_(
-              std::string(cfg().log_dir() + "/" + cfg().interprocess().platform() + "_")),
-          log_file_path_(log_file_base_ + goby::time::file_str() + ".goby"),
-          log_(log_file_path_.c_str(), std::ofstream::binary)
+          log_file_base_(std::string(cfg().log_dir() + "/" + cfg().interprocess().platform() + "_"))
     {
-        if (!log_.is_open())
-            glog.is_die() && glog << "Failed to open log in directory: " << cfg().log_dir()
-                                  << std::endl;
+        open_log();
 
-        std::string file_symlink = log_file_base_ + "latest.goby";
-        remove(file_symlink.c_str());
-        int result = symlink(realpath(log_file_path_.c_str(), NULL), file_symlink.c_str());
-        if (result != 0)
-            glog.is_warn() &&
-                glog << "Cannot create symlink to latest file. Continuing onwards anyway"
-                     << std::endl;
+        logging_ = cfg().log_at_startup();
 
         namespace sp = std::placeholders;
         interprocess().subscribe_regex(
@@ -103,17 +94,74 @@ class Logger : public goby::zeromq::SingleThreadApplication<protobuf::LoggerConf
             dl_handles_.push_back(lib_handle);
         }
 
-        pb_plugin_.register_write_hooks(log_);
-        dccl_plugin_.register_write_hooks(log_);
+        pb_plugin_.register_write_hooks(*log_);
+        dccl_plugin_.register_write_hooks(*log_);
+
+        interprocess().subscribe<goby::middleware::groups::logger_request>(
+            [this](const goby::middleware::protobuf::LoggerRequest& request) {
+                switch (request.requested_state())
+                {
+                    case goby::middleware::protobuf::LoggerRequest::START_LOGGING:
+                        if (logging_)
+                            glog.is_warn() &&
+                                glog << "Received START_LOGGING but we are already logging"
+                                     << std::endl;
+
+                        logging_ = true;
+                        break;
+
+                    case goby::middleware::protobuf::LoggerRequest::STOP_LOGGING:
+                        if (!logging_)
+                            glog.is_warn() &&
+                                glog << "Received STOP_LOGGING but we were already stopped"
+                                     << std::endl;
+
+                        logging_ = true;
+                        break;
+
+                    case goby::middleware::protobuf::LoggerRequest::ROTATE_LOG:
+                        close_log();
+                        open_log();
+                        break;
+                }
+            });
     }
 
     ~Logger() override
     {
-        log_.close();
-        // set read only
-        chmod(log_file_path_.c_str(), S_IRUSR | S_IRGRP);
+        close_log();
 
         for (void* handle : dl_handles_) dlclose(handle);
+    }
+
+    static std::atomic<bool> do_quit;
+
+  private:
+    void open_log()
+    {
+        log_file_path_ = log_file_base_ + goby::time::file_str() + ".goby";
+        log_.reset(new std::ofstream(log_file_path_.c_str(), std::ofstream::binary));
+
+        if (!log_->is_open())
+            glog.is_die() && glog << "Failed to open log in directory: " << cfg().log_dir()
+                                  << std::endl;
+
+        std::string file_symlink = log_file_base_ + "latest.goby";
+        remove(file_symlink.c_str());
+        int result = symlink(realpath(log_file_path_.c_str(), NULL), file_symlink.c_str());
+        if (result != 0)
+            glog.is_warn() &&
+                glog << "Cannot create symlink to latest file. Continuing onwards anyway"
+                     << std::endl;
+    }
+
+    void close_log()
+    {
+        log_->close();
+        log_.reset();
+
+        // set read only
+        chmod(log_file_path_.c_str(), S_IRUSR | S_IRGRP);
     }
 
     void log(const std::vector<unsigned char>& data, int scheme, const std::string& type,
@@ -124,17 +172,17 @@ class Logger : public goby::zeromq::SingleThreadApplication<protobuf::LoggerConf
             quit();
     }
 
-    static std::atomic<bool> do_quit;
-
   private:
     std::string log_file_base_;
     std::string log_file_path_;
-    std::ofstream log_;
+    std::unique_ptr<std::ofstream> log_;
 
     std::vector<void*> dl_handles_;
 
     goby::middleware::log::ProtobufPlugin pb_plugin_;
     goby::middleware::log::DCCLPlugin dccl_plugin_;
+
+    bool logging_{true};
 };
 } // namespace zeromq
 } // namespace apps
@@ -176,10 +224,13 @@ void signal_handler(int /*sig*/) { goby::apps::zeromq::Logger::do_quit = true; }
 void goby::apps::zeromq::Logger::log(const std::vector<unsigned char>& data, int scheme,
                                      const std::string& type, const goby::middleware::Group& group)
 {
+    if (!logging_)
+        return;
+
     glog.is_debug1() && glog << "Received " << data.size()
                              << " bytes to log to [scheme, type, group] = [" << scheme << ", "
                              << type << ", " << group << "]" << std::endl;
 
     goby::middleware::log::LogEntry entry(data, scheme, type, group);
-    entry.serialize(&log_);
+    entry.serialize(&*log_);
 }

--- a/src/middleware/log/groups.h
+++ b/src/middleware/log/groups.h
@@ -1,0 +1,42 @@
+// Copyright 2009-2021:
+//   GobySoft, LLC (2013-)
+//   Massachusetts Institute of Technology (2007-2014)
+//   Community contributors (see AUTHORS file)
+// File authors:
+//   Toby Schneider <toby@gobysoft.org>
+//
+//
+// This file is part of the Goby Underwater Autonomy Project Libraries
+// ("The Goby Libraries").
+//
+// The Goby Libraries are free software: you can redistribute them and/or modify
+// them under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// The Goby Libraries are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Goby.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef GOBY_MIDDLEWARE_LOG_GROUPS_H
+#define GOBY_MIDDLEWARE_LOG_GROUPS_H
+
+#include "goby/middleware/group.h"
+
+namespace goby
+{
+namespace middleware
+{
+namespace groups
+{
+constexpr goby::middleware::Group logger_request{"goby::logger::request"};
+
+} // namespace groups
+} // namespace middleware
+} // namespace goby
+
+#endif

--- a/src/middleware/log/protobuf_log_plugin.h
+++ b/src/middleware/log/protobuf_log_plugin.h
@@ -181,18 +181,30 @@ template <int scheme> class ProtobufPluginBase : public LogPlugin
                 [this, &out_log_file](
                     const std::vector<const google::protobuf::FieldDescriptor*> extensions) {
                     for (const auto* field_desc : extensions)
-                        insert_protobuf_file_desc(field_desc->containing_type()->file(),
-                                                  out_log_file);
+                    { insert_protobuf_file_desc(field_desc->file(), out_log_file); }
                 };
 
             std::vector<const google::protobuf::FieldDescriptor*> generated_extensions;
             google::protobuf::DescriptorPool::generated_pool()->FindAllExtensions(
                 desc, &generated_extensions);
+
+            for (const auto* desc : generated_extensions)
+                goby::glog.is_debug1() && goby::glog << "Found generated extension ["
+                                                     << desc->number() << "]: " << desc->full_name()
+                                                     << " in file: " << desc->file()->name()
+                                                     << std::endl;
+
             insert_extensions(generated_extensions);
 
             std::vector<const google::protobuf::FieldDescriptor*> user_extensions;
             dccl::DynamicProtobufManager::user_descriptor_pool().FindAllExtensions(
                 desc, &user_extensions);
+
+            for (const auto* desc : user_extensions)
+                goby::glog.is_debug1() && goby::glog << "Found user extension [" << desc->number()
+                                                     << "]: " << desc->full_name()
+                                                     << " in file: " << desc->file()->name()
+                                                     << std::endl;
             insert_extensions(user_extensions);
         }
     }

--- a/src/middleware/protobuf/logger.proto
+++ b/src/middleware/protobuf/logger.proto
@@ -1,0 +1,16 @@
+syntax = "proto2";
+
+import "dccl/option_extensions.proto";
+
+package goby.middleware.protobuf;
+
+message LoggerRequest
+{
+    enum State
+    {
+        START_LOGGING = 1;
+        STOP_LOGGING = 2;
+        ROTATE_LOG = 3;
+    }
+    required State requested_state = 1;
+}

--- a/src/middleware/src.cmake
+++ b/src/middleware/src.cmake
@@ -22,6 +22,7 @@ protobuf_generate_cpp(MIDDLEWARE_PROTO_SRCS MIDDLEWARE_PROTO_HDRS
   middleware/protobuf/intermodule.proto
   middleware/protobuf/pty_config.proto
   middleware/protobuf/navigation.proto
+  middleware/protobuf/logger.proto 
   )
 
 set(MIDDLEWARE_SRC

--- a/src/zeromq/protobuf/logger_config.proto
+++ b/src/zeromq/protobuf/logger_config.proto
@@ -17,6 +17,8 @@ message LoggerConfig
     optional string group_regex = 5 [default = ".*"];
 
     repeated string load_shared_library = 10;
+
+    optional bool log_at_startup = 12 [default = true];
 }
 
 message PlaybackConfig
@@ -26,9 +28,9 @@ message PlaybackConfig
     optional goby.middleware.protobuf.AppConfig app = 1;
     optional goby.zeromq.protobuf.InterProcessPortalConfig interprocess = 2;
 
-    required string input_file = 10 [(goby.field).description =
-                                         "Input goby_logger file to read (e.g. "
-                                         "'vehicle_20200204T121314.goby')"];
+    required string input_file = 10
+        [(goby.field).description = "Input goby_logger file to read (e.g. "
+                                    "'vehicle_20200204T121314.goby')"];
 
     optional double rate = 11 [default = 1];
 


### PR DESCRIPTION
- Fix bug where extension protos weren't correctly written to .goby
- Add log control subscription in goby_logger to allow start, stop and rotation of log.

https://github.com/GobySoft/goby3/issues/247