### PR TITLE
Update node_status on $OSI message in Iver driver

### DIFF
--- a/src/middleware/frontseat/iver/iver_driver.cpp
+++ b/src/middleware/frontseat/iver/iver_driver.cpp
@@ -253,6 +253,7 @@ void goby::middleware::frontseat::Iver::process_receive(const std::string& s)
             gpb::InterfaceData fs_data;
             gpb::IverState& iver_state = *fs_data.MutableExtension(gpb::iver_state);
             iver_state.set_mode(reported_mission_mode_);
+            fs_data.mutable_node_status()->CopyFrom(status_);
             signal_data_from_frontseat(fs_data);
         }
         else if (nmea.at(0).substr(0, 2) == "$C")

--- a/src/middleware/frontseat/iver/iver_driver.cpp
+++ b/src/middleware/frontseat/iver/iver_driver.cpp
@@ -249,6 +249,7 @@ void goby::middleware::frontseat::Iver::process_receive(const std::string& s)
                                                                   feet);
             status_.mutable_pose()->set_heading_with_units(nmea.as<double>(TRUEHEADING) *
                                                            boost::units::degree::degrees);
+            compute_missing(&status_);
 
             gpb::InterfaceData fs_data;
             gpb::IverState& iver_state = *fs_data.MutableExtension(gpb::iver_state);


### PR DESCRIPTION
Before, the `node_status` field was updated when the driver received messages starting with `$C`, but not when it received `$OSI` messages. This commit changes the driver to also update the node status when receiving `$OSI` messages.