### PR TITLE
3.0 fix log tool extensions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,6 @@ job-template-amd64: &job-template-amd64
           apt-get install libmysqlclient-dev:${TARGET_ARCH} -y ||
           apt-get install libmariadb-dev:${TARGET_ARCH} libmariadb-dev-compat:${TARGET_ARCH} default-libmysqlclient-dev:${TARGET_ARCH} -y ||
           apt-get install libmariadbclient-dev:${TARGET_ARCH} libmariadbclient-dev-compat:${TARGET_ARCH} default-libmysqlclient-dev:${TARGET_ARCH} -y)
-          [ -z "${CIRCLE_TAG}" ] &&
           apt-get install libdccl4-dev:${TARGET_ARCH} libdccl4:${TARGET_ARCH} dccl4-compiler -y || true
     - run: &run-build
         name: Build
@@ -461,7 +460,7 @@ jobs:
           name: Install apt packages
           command: |
             apt-get update &&
-            apt-get -y install git build-essential cmake libboost-dev libboost-system-dev libboost-date-time-dev libboost-program-options-dev libboost-filesystem-dev libprotobuf-dev libprotoc-dev protobuf-compiler libproj-dev libdccl3-dev dccl3-compiler
+            apt-get -y install git build-essential cmake libboost-dev libboost-system-dev libboost-date-time-dev libboost-program-options-dev libboost-filesystem-dev libprotobuf-dev libprotoc-dev protobuf-compiler libproj-dev libdccl4-dev dccl4-compiler
       - checkout
       - run: 
           name: Build

--- a/.circleci/docker/bionic/arm64/Dockerfile
+++ b/.circleci/docker/bionic/arm64/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Overwrite non-multiarch packages
 RUN apt-get update && \
-    apt-get -y install libdccl3-dev:arm64 \
+    apt-get -y install libdccl4-dev:arm64 \
             libcrypto++-dev:arm64 \
             libcrypto++6:arm64 \
             libwt-dev:arm64 libwtdbo-dev:arm64 libwtdbosqlite-dev:arm64 libwthttp-dev:arm64 \

--- a/.circleci/docker/bionic/armhf/Dockerfile
+++ b/.circleci/docker/bionic/armhf/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Overwrite non-multiarch packages
 RUN apt-get update && \
-    apt-get -y install libdccl3-dev:armhf \
+    apt-get -y install libdccl4-dev:armhf \
             libcrypto++-dev:armhf \
             libcrypto++6:armhf \
             libwt-dev:armhf libwtdbo-dev:armhf libwtdbosqlite-dev:armhf libwthttp-dev:armhf \

--- a/.circleci/docker/bullseye/arm64/Dockerfile
+++ b/.circleci/docker/bullseye/arm64/Dockerfile
@@ -2,8 +2,8 @@ FROM gobysoft/goby3-debian-build-base:11.1
 
 # Overwrite non-multiarch packages
 RUN apt-get update && \
-    apt-get -y remove libdccl3-dev:amd64 libdccl3:amd64 && \
-    apt-get -y install  libdccl3-dev:arm64 \
+    apt-get -y remove libdccl4-dev:amd64 libdccl4:amd64 && \
+    apt-get -y install  libdccl4-dev:arm64 \
             libwt-dev:arm64 libwtdbo-dev:arm64 libwtdbosqlite-dev:arm64 libwthttp-dev:arm64 \
             libboost-regex-dev:arm64 libicu-dev:arm64 \
             libhdf5-dev:arm64 \

--- a/.circleci/docker/bullseye/armhf/Dockerfile
+++ b/.circleci/docker/bullseye/armhf/Dockerfile
@@ -2,8 +2,8 @@ FROM gobysoft/goby3-debian-build-base:11.1
 
 # Overwrite non-multiarch packages
 RUN apt-get update && \
-    apt-get -y remove libdccl3-dev:amd64 libdccl3:amd64 && \
-    apt-get -y install  libdccl3-dev:armhf \
+    apt-get -y remove libdccl4-dev:amd64 libdccl4:amd64 && \
+    apt-get -y install  libdccl4-dev:armhf \
             libwt-dev:armhf libwtdbo-dev:armhf libwtdbosqlite-dev:armhf libwthttp-dev:armhf \
             libboost-regex-dev:armhf libicu-dev:armhf \
             libhdf5-dev:armhf \

--- a/.circleci/docker/buster/arm64/Dockerfile
+++ b/.circleci/docker/buster/arm64/Dockerfile
@@ -2,7 +2,7 @@ FROM gobysoft/goby3-debian-build-base:10.1
 
 # Overwrite non-multiarch packages
 RUN apt-get update && \
-    apt-get -y install libdccl3-dev:arm64 \
+    apt-get -y install libdccl4-dev:arm64 \
             libwt-dev:arm64 libwtdbo-dev:arm64 libwtdbosqlite-dev:arm64 libwthttp-dev:arm64 \
             libboost-regex-dev:arm64 libicu-dev:arm64 \
             libhdf5-dev:arm64 \

--- a/.circleci/docker/buster/armhf/Dockerfile
+++ b/.circleci/docker/buster/armhf/Dockerfile
@@ -2,7 +2,7 @@ FROM gobysoft/goby3-debian-build-base:10.1
 
 # Overwrite non-multiarch packages
 RUN apt-get update && \
-    apt-get -y install libdccl3-dev:armhf \
+    apt-get -y install libdccl4-dev:armhf \
             libwt-dev:armhf libwtdbo-dev:armhf libwtdbosqlite-dev:armhf libwthttp-dev:armhf \
             libboost-regex-dev:armhf libicu-dev:armhf \
             libhdf5-dev:armhf \

--- a/.circleci/docker/focal/arm64/Dockerfile
+++ b/.circleci/docker/focal/arm64/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Overwrite non-multiarch packages
 RUN apt-get update && \
-    apt-get -y install libdccl3-dev:arm64 \
+    apt-get -y install libdccl4-dev:arm64 \
             libcrypto++-dev:arm64 \
             libcrypto++6:arm64 \
             libwt-dev:arm64 libwtdbo-dev:arm64 libwtdbosqlite-dev:arm64 libwthttp-dev:arm64 \

--- a/.circleci/docker/focal/armhf/Dockerfile
+++ b/.circleci/docker/focal/armhf/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Overwrite non-multiarch packages
 RUN apt-get update && \
-    apt-get -y install libdccl3-dev:armhf \
+    apt-get -y install libdccl4-dev:armhf \
             libcrypto++-dev:armhf \
             libcrypto++6:armhf \
             libwt-dev:armhf libwtdbo-dev:armhf libwtdbosqlite-dev:armhf libwthttp-dev:armhf \

--- a/.circleci/docker/stretch/arm64/Dockerfile
+++ b/.circleci/docker/stretch/arm64/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Overwrite non-multiarch packages
 RUN apt-get update && \
-    apt-get -y install libdccl3-dev:arm64 \
+    apt-get -y install libdccl4-dev:arm64 \
             libcrypto++-dev:arm64 \
             libcrypto++6:arm64 \
             libwt-dev:arm64 libwtdbo-dev:arm64 libwtdbosqlite-dev:arm64 libwthttp-dev:arm64 \

--- a/.circleci/docker/stretch/armhf/Dockerfile
+++ b/.circleci/docker/stretch/armhf/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Overwrite non-multiarch packages
 RUN apt-get update && \
-    apt-get -y install libdccl3-dev:armhf \
+    apt-get -y install libdccl4-dev:armhf \
             libcrypto++-dev:armhf \
             libcrypto++6:armhf \
             libwt-dev:armhf libwtdbo-dev:armhf libwtdbosqlite-dev:armhf libwthttp-dev:armhf \

--- a/.circleci/docker/xenial/arm64/Dockerfile
+++ b/.circleci/docker/xenial/arm64/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Overwrite non-multiarch packages
 RUN apt-get update && \
-    apt-get -y install libdccl3-dev:arm64 \
+    apt-get -y install libdccl4-dev:arm64 \
             libcrypto++-dev:arm64 \
             libcrypto++9v5:arm64 \
             libwt-dev:arm64 libwtdbo-dev:arm64 libwtdbosqlite-dev:arm64 libwthttp-dev:arm64 \

--- a/.circleci/docker/xenial/armhf/Dockerfile
+++ b/.circleci/docker/xenial/armhf/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Overwrite non-multiarch packages
 RUN apt-get update && \
-    apt-get -y install libdccl3-dev:armhf \
+    apt-get -y install libdccl4-dev:armhf \
             libcrypto++-dev:armhf \
             libcrypto++9v5:armhf \
             libwt-dev:armhf libwtdbo-dev:armhf libwtdbosqlite-dev:armhf libwthttp-dev:armhf \

--- a/src/apps/middleware/log_tool/log_tool.cpp
+++ b/src/apps/middleware/log_tool/log_tool.cpp
@@ -154,9 +154,9 @@ goby::apps::middleware::LogTool::LogTool()
     }
 
     plugins_[goby::middleware::MarshallingScheme::PROTOBUF] =
-        std::make_unique<goby::middleware::log::ProtobufPlugin>();
+        std::make_unique<goby::middleware::log::ProtobufPlugin>(true /* user pool first to ensure we pick up all extensions embedded in the .goby */ );
     plugins_[goby::middleware::MarshallingScheme::DCCL] =
-        std::make_unique<goby::middleware::log::DCCLPlugin>();
+        std::make_unique<goby::middleware::log::DCCLPlugin>(true);
     plugins_[goby::middleware::MarshallingScheme::JSON] =
         std::make_unique<goby::middleware::log::JSONPlugin>();
 

--- a/src/doc/markdown/main.md
+++ b/src/doc/markdown/main.md
@@ -95,7 +95,7 @@ libprotobuf-dev libprotoc-dev protobuf-compiler
 # PROJ Geodetic Projections
 libproj-dev
 # DCCL
-libdccl3-dev dccl3-compiler
+libdccl4-dev dccl4-compiler
 ```
 
 Once you have resolved the dependencies, you can build from source using these steps:

--- a/src/middleware/log/dccl_log_plugin.h
+++ b/src/middleware/log/dccl_log_plugin.h
@@ -39,6 +39,11 @@ namespace log
 {
 class DCCLPlugin : public ProtobufPluginBase<goby::middleware::MarshallingScheme::DCCL>
 {
+public:
+    DCCLPlugin(bool user_pool_first = false)
+        : ProtobufPluginBase<goby::middleware::MarshallingScheme::DCCL>(user_pool_first)
+    {
+    }
 };
 
 } // namespace log

--- a/src/middleware/log/protobuf_log_plugin.h
+++ b/src/middleware/log/protobuf_log_plugin.h
@@ -52,6 +52,8 @@ template <int scheme> class ProtobufPluginBase : public LogPlugin
                   "Scheme must be PROTOBUF or DCCL");
 
   public:
+    ProtobufPluginBase(bool user_pool_first) : user_pool_first_(user_pool_first) {}
+
     std::string debug_text_message(LogEntry& log_entry) override
     {
         auto msgs = parse_message(log_entry);
@@ -139,8 +141,7 @@ template <int scheme> class ProtobufPluginBase : public LogPlugin
             try
             {
                 auto msg = SerializerParserHelper<google::protobuf::Message, scheme>::parse(
-                    bytes_begin, bytes_end, actual_end, log_entry.type(),
-                    true /*user pool first for extensions*/);
+                    bytes_begin, bytes_end, actual_end, log_entry.type(), user_pool_first_);
                 msgs.push_back(msg);
             }
             catch (std::exception& e)
@@ -233,10 +234,16 @@ template <int scheme> class ProtobufPluginBase : public LogPlugin
   private:
     std::set<const google::protobuf::FileDescriptor*> written_file_desc_;
     std::set<std::string> read_file_desc_names_;
+    bool user_pool_first_;
 };
 
 class ProtobufPlugin : public ProtobufPluginBase<goby::middleware::MarshallingScheme::PROTOBUF>
 {
+  public:
+    ProtobufPlugin(bool user_pool_first = false)
+        : ProtobufPluginBase<goby::middleware::MarshallingScheme::PROTOBUF>(user_pool_first)
+    {
+    }
 };
 
 } // namespace log

--- a/src/middleware/log/protobuf_log_plugin.h
+++ b/src/middleware/log/protobuf_log_plugin.h
@@ -139,7 +139,8 @@ template <int scheme> class ProtobufPluginBase : public LogPlugin
             try
             {
                 auto msg = SerializerParserHelper<google::protobuf::Message, scheme>::parse(
-                    bytes_begin, bytes_end, actual_end, log_entry.type());
+                    bytes_begin, bytes_end, actual_end, log_entry.type(),
+                    true /*user pool first for extensions*/);
                 msgs.push_back(msg);
             }
             catch (std::exception& e)

--- a/src/middleware/marshalling/dccl.h
+++ b/src/middleware/marshalling/dccl.h
@@ -145,12 +145,12 @@ struct SerializerParserHelper<google::protobuf::Message, MarshallingScheme::DCCL
     template <typename CharIterator>
     static std::shared_ptr<google::protobuf::Message>
     parse(CharIterator bytes_begin, CharIterator bytes_end, CharIterator& actual_end,
-          const std::string& type)
+          const std::string& type, bool user_pool_first = false)
     {
         std::lock_guard<std::mutex> lock(dccl_mutex_);
 
         auto msg = dccl::DynamicProtobufManager::new_protobuf_message<
-            std::shared_ptr<google::protobuf::Message>>(type);
+            std::shared_ptr<google::protobuf::Message>>(type, user_pool_first);
 
         check_load(msg->GetDescriptor());
         actual_end = codec().decode(bytes_begin, bytes_end, msg.get());

--- a/src/middleware/marshalling/protobuf.h
+++ b/src/middleware/marshalling/protobuf.h
@@ -26,8 +26,8 @@
 
 #include <mutex>
 
-#include <google/protobuf/message.h>
 #include <dccl/dynamic_protobuf_manager.h>
+#include <google/protobuf/message.h>
 
 #include "goby/middleware/protobuf/intervehicle.pb.h"
 
@@ -117,7 +117,7 @@ template <> struct SerializerParserHelper<google::protobuf::Message, Marshalling
     template <typename CharIterator>
     static std::shared_ptr<google::protobuf::Message>
     parse(CharIterator bytes_begin, CharIterator bytes_end, CharIterator& actual_end,
-          const std::string& type)
+          const std::string& type, bool user_pool_first = false)
     {
         std::shared_ptr<google::protobuf::Message> msg;
 
@@ -125,7 +125,7 @@ template <> struct SerializerParserHelper<google::protobuf::Message, Marshalling
             static std::mutex dynamic_protobuf_manager_mutex;
             std::lock_guard<std::mutex> lock(dynamic_protobuf_manager_mutex);
             msg = dccl::DynamicProtobufManager::new_protobuf_message<
-                std::shared_ptr<google::protobuf::Message>>(type);
+                std::shared_ptr<google::protobuf::Message>>(type, user_pool_first);
         }
 
         msg->ParseFromArray(&*bytes_begin, bytes_end - bytes_begin);

--- a/src/test/acomms/dccl1/test.proto
+++ b/src/test/acomms/dccl1/test.proto
@@ -35,6 +35,7 @@ message TestMsg
 {
     option (dccl.msg).id = 2;
     option (dccl.msg).max_bytes = 512;
+    option (dccl.msg).codec_version = 3;
 
     // test default enc/dec
     optional double double_default_optional = 1 [

--- a/src/test/acomms/dccl3/test.proto
+++ b/src/test/acomms/dccl3/test.proto
@@ -9,7 +9,8 @@ message GobyMessage
 {
     option (dccl.msg).id = 4;
     option (dccl.msg).max_bytes = 32;
+    option (dccl.msg).codec_version = 3;
 
     required string telegram = 1 [(dccl.field).max_length = 10];
-    required Header header = 2;
+    required Header header = 2 [(dccl.field).in_head = true];
 }

--- a/src/test/acomms/queue1/test.proto
+++ b/src/test/acomms/queue1/test.proto
@@ -7,6 +7,7 @@ message TestMsg
 {
     option (dccl.msg).id = 2;
     option (dccl.msg).max_bytes = 32;
+    option (dccl.msg).codec_version = 3;
 
     // test default enc/dec
     optional double double_default_optional = 1 [

--- a/src/test/acomms/queue5/test.proto
+++ b/src/test/acomms/queue5/test.proto
@@ -7,6 +7,7 @@ message GobyMessage
 {
     option (dccl.msg).id = 4;
     option (dccl.msg).max_bytes = 32;
+    option (dccl.msg).codec_version = 3;
 
     // one byte
     required int32 telegram = 1 [(dccl.field).min = 0, (dccl.field).max = 255];

--- a/src/test/acomms/queue6/test.proto
+++ b/src/test/acomms/queue6/test.proto
@@ -7,7 +7,8 @@ message GobyMessage
 {
     option (dccl.msg).id = 4;
     option (dccl.msg).max_bytes = 32;
-
+    option (dccl.msg).codec_version = 3;
+    
     // one byte
     required int32 dest = 1 [(dccl.field).min = 0, (dccl.field).max = 255];
     // one byte


### PR DESCRIPTION
- Fix log tool use of extensions when reading .goby.
- Switch to DCCL4.
