### PR TITLE
In goby_gps, subscribe before launching the TCPThread so we don't miss the CONNECT event if it is sent immediately

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,16 +183,16 @@ job-template-deb-amd64: &job-template-deb-amd64
 job-template-deb-cross: &job-template-deb-cross
   <<: *job-template-deb-amd64
 
-# base sanitizer off Jammy build
+# base sanitizer off Focal build
 job-template-sanitizers: &job-template-sanitizers
   <<: *job-template-amd64
   environment:
     <<: *environment-template-common
-    <<: *environment-template-jammy
+    <<: *environment-template-focal
     <<: *environment-template-amd64
     SANITIZER_NUM_JOBS: 4
     TSAN_OPTIONS: "suppressions=/root/goby3/src/test/suppressions.tsan.txt"    
-  docker: *docker-base-jammy
+  docker: *docker-base-focal
 
 # Base upload off Bionic build
 job-template-upload: &job-template-upload
@@ -237,8 +237,8 @@ workflows:
           <<: *filter-template-non-master
       - amd64-focal-build:
           <<: *filter-template-non-master
-      - amd64-jammy-build:
-          <<: *filter-template-non-master
+#      - amd64-jammy-build:
+#          <<: *filter-template-non-master
 
           
       - amd64-jammy-minimal-build:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,7 @@ add_custom_command(OUTPUT ShareLink COMMAND ${CMAKE_COMMAND} -E create_symlink $
 add_custom_target(share_link ALL DEPENDS ShareLink)
 
 
-set(GOBY_DEBUG_OPTIONS -Wall -Werror)
+set(GOBY_DEBUG_OPTIONS -Wall -Werror -Wno-sign-compare)
 add_compile_options("$<$<CONFIG:DEBUG>:${GOBY_DEBUG_OPTIONS}>")
 add_compile_options("$<$<CXX_COMPILER_ID:Clang>:-Wdocumentation>")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,7 @@ add_custom_command(OUTPUT ShareLink COMMAND ${CMAKE_COMMAND} -E create_symlink $
 add_custom_target(share_link ALL DEPENDS ShareLink)
 
 
-set(GOBY_DEBUG_OPTIONS -Wall -Werror -Wno-sign-compare)
+set(GOBY_DEBUG_OPTIONS -Wall -Werror -Wno-sign-compare -Wno-unknown-warning-option)
 add_compile_options("$<$<CONFIG:DEBUG>:${GOBY_DEBUG_OPTIONS}>")
 add_compile_options("$<$<CXX_COMPILER_ID:Clang>:-Wdocumentation>")
 

--- a/src/acomms/protobuf/modem_message.proto
+++ b/src/acomms/protobuf/modem_message.proto
@@ -122,6 +122,7 @@ message ModemTransmission
     // extensions 1401-1420 used by benthos_atm900.proto
     // extensions 1421-1440 used by mccs_driver.proto
     // extension 1441 used by popoto_driver.proto
+    // extensions 1500-1509 used by Jaiabot: https://github.com/jaiarobotics/jaiabot/
     extensions 1000 to max;
 }
 

--- a/src/apps/zeromq/logger/logger.cpp
+++ b/src/apps/zeromq/logger/logger.cpp
@@ -104,7 +104,7 @@ class Logger : public goby::zeromq::SingleThreadApplication<protobuf::LoggerConf
                                 glog << "Received START_LOGGING but we are already logging"
                                      << std::endl;
                         else
-                            glog.is_debug1() && glog << "Logging started" << std::endl;
+                            glog.is_verbose() && glog << "Logging started" << std::endl;
 
                         logging_ = true;
                         break;
@@ -115,13 +115,13 @@ class Logger : public goby::zeromq::SingleThreadApplication<protobuf::LoggerConf
                                 glog << "Received STOP_LOGGING but we were already stopped"
                                      << std::endl;
                         else
-                            glog.is_debug1() && glog << "Logging stopped" << std::endl;
+                            glog.is_verbose() && glog << "Logging stopped" << std::endl;
 
                         logging_ = false;
                         break;
 
                     case goby::middleware::protobuf::LoggerRequest::ROTATE_LOG:
-                        glog.is_debug1() && glog << "Log rotated" << std::endl;
+                        glog.is_verbose() && glog << "Log rotated" << std::endl;
                         close_log();
                         open_log();
                         break;


### PR DESCRIPTION
Avoids occasional bug when WATCH is never sent to gpsd upon startup of goby_gps