### PR TITLE
Change iFrontSeat to also publish NAV_YAW

### DIFF
--- a/src/doc/user_manual/chap_goby_moos.tex
+++ b/src/doc/user_manual/chap_goby_moos.tex
@@ -597,7 +597,7 @@ The transitional MOOS variables \textbf{subscribed} to by iFrontSeat include:
 The transitional MOOS variables \textbf{published} by iFrontSeat include:
 
 \begin{itemize}
-\item If !publish_nav: true!, then !NAV_X! (meters), !NAV_Y! (meters), !NAV_LAT! (degrees), !NAV_LONG! (degrees), !NAV_Z! (meters, negative down), !NAV_DEPTH! (meters, positive down), !NAV_YAW! (degrees), !NAV_HEADING! (degrees), !NAV_SPEED! (meters/second), !NAV_PITCH! (radians), !NAV_ROLL! (radians), !NAV_ALTITUDE! (meters). All these double values are generated from the !FrontSeatInterfaceData! message when it contains !node_status! information.
+\item If !publish_nav: true!, then !NAV_X! (meters), !NAV_Y! (meters), !NAV_LAT! (degrees), !NAV_LONG! (degrees), !NAV_Z! (meters, negative down), !NAV_DEPTH! (meters, positive down), !NAV_YAW! (radians), !NAV_HEADING! (degrees), !NAV_SPEED! (meters/second), !NAV_PITCH! (radians), !NAV_ROLL! (radians), !NAV_ALTITUDE! (meters). All these double values are generated from the !FrontSeatInterfaceData! message when it contains !node_status! information.
 \item If !publish_fs_bs_ready: true!, then !BACKSEAT_READY!: Published as 1 (true) when the Helm State becomes !HELM_DRIVE!, otherwise 0 (false).
 \item If !publish_fs_bs_ready: true!, then !FRONTSEAT_READY!: Published as 1 (true) when the FrontSeat State becomes !FRONTSEAT_ACCEPTING_COMMANDS!, otherwise 0 (false).
 \item !GPS_UPDATE_RECEIVED!: Published as !Timestamp=double seconds since Unix! when a !BluefinExtraCommands::GPS_REQUEST! command responds successfully.

--- a/src/moos/frontseat/convert.cpp
+++ b/src/moos/frontseat/convert.cpp
@@ -58,10 +58,14 @@ void goby::moos::convert_and_publish_node_status(
         moos_comms.Notify("NAV_DEPTH",
                           status.global_fix().depth_with_units<quantity<si::length>>().value());
 
-    if (status.pose().has_heading())
+    if (status.pose().has_heading()) {
         moos_comms.Notify(
             "NAV_HEADING",
             status.pose().heading_with_units<quantity<degree::plane_angle>>().value());
+        moos_comms.Notify(
+            "NAV_YAW",
+            -status.pose().heading_with_units<quantity<si::plane_angle>>().value());
+    }
 
     moos_comms.Notify("NAV_SPEED",
                       status.speed().over_ground_with_units<quantity<si::velocity>>().value());


### PR DESCRIPTION
Before, `iFrontSeat` published `NAV_HEADING` but not `NAV_YAW`. Also, fix the documentation to state that `NAV_YAW` is in radians, not degrees. (See the [MOOS Conventions][1] document.)

[1]: https://www.robots.ox.ac.uk/~pnewman/MOOSDocumentation/MOOSConventions/latex/Conventions.pdf