### PR TITLE
Updates for DCCL 4.1 - thread safety

### DIFF
--- a/src/acomms/dccl/dccl.h
+++ b/src/acomms/dccl/dccl.h
@@ -39,7 +39,6 @@
 #include <dccl/field_codec_fixed.h>                   // for TypedFixedFi...
 #include <dccl/field_codec_manager.h>                 // for FieldCodecMa...
 #include <dccl/field_codec_typed.h>                   // for RepeatedType...
-#include <dccl/internal/field_codec_message_stack.h>
 #include <dccl/logger.h>                   // for DECODE, ENCODE
 #include <dccl/option_extensions.pb.h>     // for DCCLMessageO...
 #include <google/protobuf/descriptor.h>    // for Descriptor
@@ -53,6 +52,7 @@
 #include "goby/util/debug_logger/flex_ostream.h"        // for operator<<
 #include "goby/util/debug_logger/flex_ostreambuf.h"     // for WARN, DEBUG1
 #include "goby/util/debug_logger/logger_manipulators.h" // for operator<<
+#include "goby/util/dccl_compat.h"
 
 namespace google
 {
@@ -79,16 +79,6 @@ using DCCLDefaultBoolCodec = dccl::v2::DefaultBoolCodec;
 using DCCLDefaultStringCodec = dccl::v2::DefaultStringCodec;
 using DCCLDefaultBytesCodec = dccl::v2::DefaultBytesCodec;
 using DCCLDefaultEnumCodec = dccl::v2::DefaultEnumCodec;
-
-class MessageHandler : public dccl::internal::MessageStack
-{
-  public:
-    MessageHandler(const google::protobuf::FieldDescriptor* field = nullptr) : MessageStack(field)
-    {
-    }
-    using MessagePart = dccl::MessagePart;
-    static const MessagePart HEAD = dccl::HEAD, BODY = dccl::BODY, UNKNOWN = dccl::UNKNOWN;
-};
 
 template <typename TimeType> class TimeCodec : public dccl::v2::TimeCodecBase<TimeType, 0>
 {
@@ -132,14 +122,8 @@ struct DCCLRepeatedTypedFieldCodec : public dccl::RepeatedTypedFieldCodec<WireTy
 };
 
 using DCCLFieldCodecManager = dccl::FieldCodecManager;
-//        typedef dccl::TypedFieldCodec DCCLTypedFieldCodec;
 using DCCLFieldCodecManager = dccl::FieldCodecManager;
-using FromProtoCppTypeBase = dccl::internal::FromProtoCppTypeBase;
-//       typedef dccl::FromProtoType FromProtoType;
-// typedef dccl::FromProtoCppType FromProtoCppType;
-//typedef dccl::ToProtoCppType ToProtoCppType;
 using Bitset = dccl::Bitset;
-using DCCLTypeHelper = dccl::internal::TypeHelper;
 
 class DCCLCodec
 {
@@ -293,7 +277,11 @@ class DCCLCodec
 
     template <typename DCCLTypedFieldCodecUint32> void add_id_codec(const std::string& identifier)
     {
+#ifdef DCCL_VERSION_4_1_OR_NEWER
+        codec()->manager().add<DCCLTypedFieldCodecUint32>(identifier);
+#else
         dccl::FieldCodecManager::add<DCCLTypedFieldCodecUint32>(identifier);
+#endif
     }
 
     void set_id_codec(const std::string& identifier)

--- a/src/acomms/modemdriver/benthos_atm900_driver.h
+++ b/src/acomms/modemdriver/benthos_atm900_driver.h
@@ -36,16 +36,18 @@
 #include <dccl/exception.h>                          // for NullValueException
 #include <dccl/field_codec_fixed.h>                  // for TypedFixedField...
 #include <dccl/field_codec_manager.h>                // for FieldCodecManager
-#include <memory>                                    // for shared_ptr, __s...
-#include <string>                                    // for string, operator+
-#include <vector>                                    // for vector
+#include <dccl/version.h>
+#include <memory> // for shared_ptr, __s...
+#include <string> // for string, operator+
+#include <vector> // for vector
 
 #include "benthos_atm900_driver_fsm.h"              // for BenthosATM900FSM
 #include "driver_base.h"                            // for ModemDriverBase
 #include "goby/acomms/protobuf/benthos_atm900.pb.h" // for BenthosHeader
 #include "goby/acomms/protobuf/driver_base.pb.h"    // for DriverConfig
 #include "goby/acomms/protobuf/modem_message.pb.h"  // for ModemTransmission
-#include "rudics_packet.h"                          // for parse_rudics_pa...
+#include "goby/util/dccl_compat.h"
+#include "rudics_packet.h" // for parse_rudics_pa...
 
 namespace goby
 {
@@ -94,8 +96,14 @@ extern std::shared_ptr<dccl::Codec> benthos_header_dccl_;
 
 inline void init_benthos_dccl()
 {
-    dccl::FieldCodecManager::add<NoOpIdentifierCodec>("benthos_header_id");
-    benthos_header_dccl_.reset(new dccl::Codec("benthos_header_id"));
+    auto benthos_id_name = "benthos_header_id";
+#ifdef DCCL_VERSION_4_1_OR_NEWER
+    benthos_header_dccl_.reset(new dccl::Codec(benthos_id_name, NoOpIdentifierCodec()));
+#else
+    dccl::FieldCodecManager::add<NoOpIdentifierCodec>(benthos_id_name);
+    benthos_header_dccl_.reset(new dccl::Codec(benthos_id_name));
+#endif
+
     benthos_header_dccl_->load<benthos::protobuf::BenthosHeader>();
 }
 

--- a/src/acomms/modemdriver/iridium_driver_common.h
+++ b/src/acomms/modemdriver/iridium_driver_common.h
@@ -30,6 +30,7 @@
 
 #include "goby/acomms/protobuf/iridium_driver.pb.h"
 #include "goby/time/system_clock.h"
+#include "goby/util/dccl_compat.h"
 
 namespace goby
 {
@@ -97,8 +98,13 @@ extern std::shared_ptr<dccl::Codec> iridium_header_dccl_;
 
 inline void init_iridium_dccl()
 {
-    dccl::FieldCodecManager::add<IridiumHeaderIdentifierCodec>("iridium_header_id");
-    iridium_header_dccl_.reset(new dccl::Codec("iridium_header_id"));
+    auto iridium_id_name = "iridium_header_id";
+#ifdef DCCL_VERSION_4_1_OR_NEWER
+    iridium_header_dccl_.reset(new dccl::Codec(iridium_id_name, IridiumHeaderIdentifierCodec()));
+#else
+    dccl::FieldCodecManager::add<IridiumHeaderIdentifierCodec>(iridium_id_name);
+    iridium_header_dccl_.reset(new dccl::Codec(iridium_id_name));
+#endif
     iridium_header_dccl_->load<goby::acomms::iridium::protobuf::IridiumHeader>();
 }
 

--- a/src/acomms/queue/queue.cpp
+++ b/src/acomms/queue/queue.cpp
@@ -285,7 +285,12 @@ boost::any goby::acomms::Queue::find_queue_field(const std::string& field_name,
         if (field_desc->is_repeated())
             throw(QueueException("Cannot assign a Queue role to a repeated field"));
 
-        auto helper = goby::acomms::DCCLTypeHelper::find(field_desc);
+#ifdef DCCL_VERSION_4_1_OR_NEWER
+        auto helper =
+            goby::acomms::DCCLCodec::get()->codec()->manager().type_helper().find(field_desc);
+#else
+        auto helper = dccl::internal::TypeHelper::find(field_desc);
+#endif
 
         // last field_name
         if (i == (n - 1))
@@ -496,9 +501,9 @@ void goby::acomms::Queue::stream_for_pop(const QueuedMessage& queued_msg)
                             << std::endl;
 }
 
-std::vector<std::shared_ptr<google::protobuf::Message> > goby::acomms::Queue::expire()
+std::vector<std::shared_ptr<google::protobuf::Message>> goby::acomms::Queue::expire()
 {
-    std::vector<std::shared_ptr<google::protobuf::Message> > expired_msgs;
+    std::vector<std::shared_ptr<google::protobuf::Message>> expired_msgs;
 
     while (!messages_.empty())
     {
@@ -603,7 +608,7 @@ void goby::acomms::Queue::process_cfg()
 
     // used to check that the FIELD_VALUE roles fields actually exist
     auto new_msg = dccl::DynamicProtobufManager::new_protobuf_message<
-        std::shared_ptr<google::protobuf::Message> >(desc_);
+        std::shared_ptr<google::protobuf::Message>>(desc_);
 
     for (int i = 0, n = cfg_.role_size(); i < n; ++i)
     {

--- a/src/apps/zeromq/liaison/liaison.cpp
+++ b/src/apps/zeromq/liaison/liaison.cpp
@@ -68,6 +68,7 @@
 #else
 #include "goby/zeromq/application/multi_thread.h" // for MultiThreadApp...
 #endif
+#include "goby/util/dccl_compat.h"
 
 #include "liaison_wt_thread.h" // for Liaiso...
 
@@ -282,8 +283,14 @@ void goby::apps::zeromq::Liaison::load_proto_file(const std::string& path)
 
     glog.is(VERBOSE) && glog << "Loading protobuf file: " << bpath << std::endl;
 
+#ifdef DCCL_VERSION_4_1_OR_NEWER
+    if (!dccl::DynamicProtobufManager::user_descriptor_pool_call(
+            &google::protobuf::DescriptorPool::FindFileByName, bpath.string()))
+        glog.is(DIE) && glog << "Failed to load file." << std::endl;
+#else
     if (!dccl::DynamicProtobufManager::user_descriptor_pool().FindFileByName(bpath.string()))
         glog.is(DIE) && glog << "Failed to load file." << std::endl;
+#endif
 }
 
 void goby::apps::zeromq::Liaison::loop()

--- a/src/apps/zeromq/liaison/liaison_commander.cpp
+++ b/src/apps/zeromq/liaison/liaison_commander.cpp
@@ -96,6 +96,7 @@
 #include "goby/time/types.h"                        // for MicroTime
 #include "goby/util/as.h"                           // for as, FLOAT_FIXED
 #include "goby/util/binary.h"                       // for hex_encode
+#include "goby/util/dccl_compat.h"
 #include "goby/util/debug_logger/flex_ostreambuf.h" // for DEBUG1, WARN
 #include "liaison_commander.h"
 
@@ -1198,7 +1199,12 @@ void goby::apps::zeromq::LiaisonCommander::ControlsContainer::CommandContainer::
         generate_tree_row(parent, message, desc->field(i), parent_hierarchy);
 
     std::vector<const google::protobuf::FieldDescriptor*> extensions;
+#ifdef DCCL_VERSION_4_1_OR_NEWER
+    dccl::DynamicProtobufManager::user_descriptor_pool_call(
+        &google::protobuf::DescriptorPool::FindAllExtensions, desc, &extensions);
+#else
     dccl::DynamicProtobufManager::user_descriptor_pool().FindAllExtensions(desc, &extensions);
+#endif
     google::protobuf::DescriptorPool::generated_pool()->FindAllExtensions(desc, &extensions);
     for (auto& extension : extensions)
         generate_tree_row(parent, message, extension, parent_hierarchy);

--- a/src/middleware/frontseat/waveglider/waveglider_sv2_codecs.cpp
+++ b/src/middleware/frontseat/waveglider/waveglider_sv2_codecs.cpp
@@ -28,9 +28,11 @@
 #include <dccl/exception.h>
 #include <dccl/field_codec_manager.h>
 #include <dccl/option_extensions.pb.h>
+#include <dccl/version.h>
 #include <google/protobuf/descriptor.h>
 
 #include "goby/middleware/frontseat/waveglider/waveglider_sv2_frontseat_driver.pb.h"
+#include "goby/util/dccl_compat.h"
 #include "waveglider_sv2_codecs.h"
 
 extern "C"
@@ -39,12 +41,22 @@ extern "C"
     {
         using namespace dccl;
 
+#ifdef DCCL_VERSION_4_1_OR_NEWER
+        dccl->manager().add<goby::middleware::frontseat::SV2IdentifierCodec>("SV2.id");
+        dccl->manager()
+            .add<dccl::v3::DefaultMessageCodec, google::protobuf::FieldDescriptor::TYPE_MESSAGE>(
+                "SV2");
+        dccl->manager()
+            .add<dccl::v3::DefaultBytesCodec, google::protobuf::FieldDescriptor::TYPE_BYTES>("SV2");
+        dccl->manager().add<goby::middleware::frontseat::SV2NumericCodec<dccl::uint32>>("SV2");
+#else
         FieldCodecManager::add<goby::middleware::frontseat::SV2IdentifierCodec>("SV2.id");
         FieldCodecManager::add<dccl::v3::DefaultMessageCodec,
                                google::protobuf::FieldDescriptor::TYPE_MESSAGE>("SV2");
         FieldCodecManager::add<dccl::v3::DefaultBytesCodec,
                                google::protobuf::FieldDescriptor::TYPE_BYTES>("SV2");
         FieldCodecManager::add<goby::middleware::frontseat::SV2NumericCodec<dccl::uint32>>("SV2");
+#endif
 
         dccl->load<goby::middleware::frontseat::protobuf::SV2RequestEnumerate>();
         dccl->load<goby::middleware::frontseat::protobuf::SV2ReplyEnumerate>();
@@ -79,6 +91,16 @@ extern "C"
         dccl->unload<goby::middleware::frontseat::protobuf::SV2CommandFollowFixedHeading::
                          CommandFollowFixedHeadingBody>();
 
+#ifdef DCCL_VERSION_4_1_OR_NEWER
+        dccl->manager().remove<goby::middleware::frontseat::SV2IdentifierCodec>("SV2.id");
+        dccl->manager()
+            .remove<dccl::v3::DefaultMessageCodec, google::protobuf::FieldDescriptor::TYPE_MESSAGE>(
+                "SV2");
+        dccl->manager()
+            .remove<dccl::v3::DefaultBytesCodec, google::protobuf::FieldDescriptor::TYPE_BYTES>(
+                "SV2");
+        dccl->manager().remove<goby::middleware::frontseat::SV2NumericCodec<dccl::uint32>>("SV2");
+#else
         FieldCodecManager::remove<goby::middleware::frontseat::SV2IdentifierCodec>("SV2.id");
         FieldCodecManager::remove<dccl::v3::DefaultMessageCodec,
                                   google::protobuf::FieldDescriptor::TYPE_MESSAGE>("SV2");
@@ -86,5 +108,6 @@ extern "C"
                                   google::protobuf::FieldDescriptor::TYPE_BYTES>("SV2");
         FieldCodecManager::remove<goby::middleware::frontseat::SV2NumericCodec<dccl::uint32>>(
             "SV2");
+#endif
     }
 }

--- a/src/middleware/log/hdf5/hdf5.cpp
+++ b/src/middleware/log/hdf5/hdf5.cpp
@@ -29,9 +29,11 @@
 #include <boost/algorithm/string/predicate_facade.hpp> // for predicate_facade
 #include <boost/algorithm/string/split.hpp>            // for split
 #include <boost/algorithm/string/trim.hpp>             // for trim_copy_if
-#include <dccl/dynamic_protobuf_manager.h>             // for DynamicProtob...
+
+#include <dccl/dynamic_protobuf_manager.h> // for DynamicProtob...
 
 #include "goby/time/types.h" // for MicroTime
+#include "goby/util/dccl_compat.h"
 #include "goby/util/debug_logger.h"
 
 #include "hdf5.h"
@@ -144,7 +146,13 @@ void goby::middleware::hdf5::Writer::write_message_collection(
 
     std::vector<const google::protobuf::FieldDescriptor*> extensions;
     google::protobuf::DescriptorPool::generated_pool()->FindAllExtensions(desc, &extensions);
+
+#ifdef DCCL_VERSION_4_1_OR_NEWER
+    dccl::DynamicProtobufManager::user_descriptor_pool_call(
+        &google::protobuf::DescriptorPool::FindAllExtensions, desc, &extensions);
+#else
     dccl::DynamicProtobufManager::user_descriptor_pool().FindAllExtensions(desc, &extensions);
+#endif
 
     for (auto field_desc : extensions) { write_field(field_desc); }
 }
@@ -208,8 +216,14 @@ void goby::middleware::hdf5::Writer::write_embedded_message(
         std::vector<const google::protobuf::FieldDescriptor*> extensions;
         google::protobuf::DescriptorPool::generated_pool()->FindAllExtensions(sub_desc,
                                                                               &extensions);
+#ifdef DCCL_VERSION_4_1_OR_NEWER
+        dccl::DynamicProtobufManager::user_descriptor_pool_call(
+            &google::protobuf::DescriptorPool::FindAllExtensions, sub_desc, &extensions);
+#else
         dccl::DynamicProtobufManager::user_descriptor_pool().FindAllExtensions(sub_desc,
                                                                                &extensions);
+
+#endif
         for (auto sub_field_desc : extensions) { write_field(sub_field_desc); }
 
         hs.pop_back();
@@ -253,8 +267,13 @@ void goby::middleware::hdf5::Writer::write_embedded_message(
         std::vector<const google::protobuf::FieldDescriptor*> extensions;
         google::protobuf::DescriptorPool::generated_pool()->FindAllExtensions(sub_desc,
                                                                               &extensions);
+#ifdef DCCL_VERSION_4_1_OR_NEWER
+        dccl::DynamicProtobufManager::user_descriptor_pool_call(
+            &google::protobuf::DescriptorPool::FindAllExtensions, sub_desc, &extensions);
+#else
         dccl::DynamicProtobufManager::user_descriptor_pool().FindAllExtensions(sub_desc,
                                                                                &extensions);
+#endif
         for (auto sub_field_desc : extensions) { write_field(sub_field_desc); }
     }
 }

--- a/src/middleware/log/protobuf_log_plugin.h
+++ b/src/middleware/log/protobuf_log_plugin.h
@@ -30,6 +30,7 @@
 #include "goby/middleware/marshalling/protobuf.h"
 #include "goby/middleware/protobuf/log_tool_config.pb.h"
 #include "goby/time/convert.h"
+#include "goby/util/dccl_compat.h"
 #include "log_plugin.h"
 
 #if GOOGLE_PROTOBUF_VERSION < 3001000
@@ -219,8 +220,14 @@ template <int scheme> class ProtobufPluginBase : public LogPlugin
             insert_extensions(generated_extensions);
 
             std::vector<const google::protobuf::FieldDescriptor*> user_extensions;
+
+#ifdef DCCL_VERSION_4_1_OR_NEWER
+            dccl::DynamicProtobufManager::user_descriptor_pool_call(
+                &google::protobuf::DescriptorPool::FindAllExtensions, desc, &user_extensions);
+#else
             dccl::DynamicProtobufManager::user_descriptor_pool().FindAllExtensions(
                 desc, &user_extensions);
+#endif
 
             for (const auto* desc : user_extensions)
                 goby::glog.is_debug1() && goby::glog << "Found user extension [" << desc->number()

--- a/src/test/acomms/ipcodecs/test.cpp
+++ b/src/test/acomms/ipcodecs/test.cpp
@@ -27,6 +27,7 @@
 
 #include "goby/acomms/ip_codecs.h"
 #include "goby/util/binary.h"
+#include "goby/util/dccl_compat.h"
 #include "goby/util/debug_logger.h"
 
 using namespace goby::util::logger;
@@ -58,13 +59,21 @@ int main(int /*argc*/, char* argv[])
     goby::glog.add_stream(goby::util::logger::DEBUG3, &std::cerr);
     goby::glog.set_name(argv[0]);
 
-    dccl::FieldCodecManager::add<goby::acomms::IPGatewayEmptyIdentifierCodec<0xF001> >(
+#ifdef DCCL_VERSION_4_1_OR_NEWER
+    dccl::Codec dccl_1("ip_gateway_id_codec_1",
+                       goby::acomms::IPGatewayEmptyIdentifierCodec<0xF001>());
+    dccl_1.manager().add<goby::acomms::NetShortCodec>("net.short");
+    dccl_1.manager().add<goby::acomms::IPv4AddressCodec>("ip.v4.address");
+    dccl_1.manager().add<goby::acomms::IPv4FlagsFragOffsetCodec>("ip.v4.flagsfragoffset");
+#else
+    dccl::FieldCodecManager::add<goby::acomms::IPGatewayEmptyIdentifierCodec<0xF001>>(
         "ip_gateway_id_codec_1");
     dccl::FieldCodecManager::add<goby::acomms::NetShortCodec>("net.short");
     dccl::FieldCodecManager::add<goby::acomms::IPv4AddressCodec>("ip.v4.address");
     dccl::FieldCodecManager::add<goby::acomms::IPv4FlagsFragOffsetCodec>("ip.v4.flagsfragoffset");
 
     dccl::Codec dccl_1("ip_gateway_id_codec_1");
+#endif
     dccl_1.load<goby::acomms::protobuf::IPv4Header>();
 
     // ICMP Ping

--- a/src/util/dccl_compat.h
+++ b/src/util/dccl_compat.h
@@ -1,0 +1,9 @@
+#ifndef GOBY_UTIL_DCCL_COMPAT_H
+#define GOBY_UTIL_DCCL_COMPAT_H
+
+#include <dccl/version.h>
+#if (DCCL_VERSION_MAJOR > 4) || (DCCL_VERSION_MAJOR == 4 && DCCL_VERSION_MINOR >= 1)
+#define DCCL_VERSION_4_1_OR_NEWER
+#endif
+
+#endif


### PR DESCRIPTION
Add new definition DCCL_VERSION_4_1_OR_NEWER and conditionally compile code that requires breaking changes due to DCCL 4.1's thread safety.