### PR TITLE
Add support for Remote Helm version 5 in iver_driver

### DIFF
--- a/src/middleware/frontseat/iver/iver_driver_config.proto
+++ b/src/middleware/frontseat/iver/iver_driver_config.proto
@@ -12,6 +12,7 @@ message IverConfig
     // write GPS feed to this serial port for NTP to use
     optional string ntp_serial_port = 3;
     optional int32 max_pitch_angle_degrees = 4 [default = 45];
+    optional int32 remote_helm_version_major = 5 [default = 5];
     // Timeout for $OMS, in seconds.
     optional uint32 oms_timeout = 6
         [default = 5, (dccl.field) = {min: 0 max: 120}];

--- a/src/middleware/frontseat/iver/iver_driver_config.proto
+++ b/src/middleware/frontseat/iver/iver_driver_config.proto
@@ -24,7 +24,6 @@ message IverConfig
             "The maximum pitch that this driver will command (in degrees)"
     ];
     required int32 remote_helm_version_major = 5 [
-        default = 5,
         (goby.field).description =
             "Sets the Iver Remote Helm major version that this driver will connect to. Important: Iver Remote Helm changed OMS from feet to meters in major version 5"
     ];

--- a/src/middleware/frontseat/iver/iver_driver_config.proto
+++ b/src/middleware/frontseat/iver/iver_driver_config.proto
@@ -7,15 +7,32 @@ package goby.middleware.frontseat.protobuf;
 
 message IverConfig
 {
-    required string serial_port = 1;
-    optional uint32 serial_baud = 2 [default = 19200];
-    // write GPS feed to this serial port for NTP to use
-    optional string ntp_serial_port = 3;
-    optional int32 max_pitch_angle_degrees = 4 [default = 45];
-    optional int32 remote_helm_version_major = 5 [default = 5];
-    // Timeout for $OMS, in seconds.
-    optional uint32 oms_timeout = 6
-        [default = 5, (dccl.field) = {min: 0 max: 120}];
+    required string serial_port = 1
+        [(goby.field).description =
+             "Serial port connected to Iver Remote Helm"];
+    optional uint32 serial_baud = 2 [
+        default = 19200,
+        (goby.field).description = "Serial baud rate for 'serial_port'"
+    ];
+    optional string ntp_serial_port = 3 [
+        (goby.field).description =
+            "If set, write the GPS feed from the Iver to this serial port for NTP to use"
+    ];
+    optional int32 max_pitch_angle_degrees = 4 [
+        default = 45,
+        (goby.field).description =
+            "The maximum pitch that this driver will command (in degrees)"
+    ];
+    required int32 remote_helm_version_major = 5 [
+        default = 5,
+        (goby.field).description =
+            "Sets the Iver Remote Helm major version that this driver will connect to. Important: Iver Remote Helm changed OMS from feet to meters in major version 5"
+    ];
+    optional uint32 oms_timeout = 6 [
+        default = 5,
+        (dccl.field) = { min: 0 max: 120 },
+        (goby.field).description = "Timeout for $OMS, in seconds."
+    ];
 }
 
 extend Config


### PR DESCRIPTION
This adds a required field to IverConfig to specify the vehicle version and makes the changes necessary for the Iver3 case. So far, the only difference we've found between Iver2 and Iver3 is the units for depth in the $OMS message.

According to Revision 5.3.3 (April 2019) of the Iver3 manual and confirmed by testing on an Iver3 vehicle, the Iver3 remote helm interface expects the depth value of the $OMS message to be in meters.

Revision 3.5 (Feb. 2010) of the Iver2 manual says that the depth value is expected to be in feet, so this appears to be a change between the Iver2 and Iver3 vehicles.