### PR TITLE
Add config to assign Iver modes to frontseat states

### DIFF
--- a/src/middleware/frontseat/iver/iver_driver.cpp
+++ b/src/middleware/frontseat/iver/iver_driver.cpp
@@ -224,24 +224,30 @@ void goby::middleware::frontseat::Iver::process_receive(const std::string& s)
 
             switch (reported_mission_mode_)
             {
-                case gpb::IverState::IVER_MODE_UNKNOWN:
-                case gpb::IverState::IVER_MODE_STOPPED:
-                    frontseat_state_ = gpb::FRONTSEAT_IDLE;
-                    break;
-
-                case gpb::IverState::IVER_MODE_PARKING:
-                    frontseat_state_ = gpb::FRONTSEAT_IN_CONTROL;
-                    break;
-
-                    // all these modes can take a backseat command
-                case gpb::IverState::IVER_MODE_NORMAL:
-                case gpb::IverState::IVER_MODE_MANUAL_OVERRIDE:
-                case gpb::IverState::IVER_MODE_MANUAL_PARKING:
-                case gpb::IverState::IVER_MODE_SERVO_MODE:
-                case gpb::IverState::IVER_MODE_MISSION_MODE:
-                    // no explicit handshake for frontseat command
-                    frontseat_state_ = gpb::FRONTSEAT_ACCEPTING_COMMANDS;
-                    break;
+            case gpb::IverState::IVER_MODE_UNKNOWN:
+                frontseat_state_ = iver_config_.mode_assignments().unknown();
+                break;
+            case gpb::IverState::IVER_MODE_NORMAL:
+                frontseat_state_ = iver_config_.mode_assignments().normal();
+                break;
+            case gpb::IverState::IVER_MODE_STOPPED:
+                frontseat_state_ = iver_config_.mode_assignments().stopped();
+                break;
+            case gpb::IverState::IVER_MODE_PARKING:
+                frontseat_state_ = iver_config_.mode_assignments().parking();
+                break;
+            case gpb::IverState::IVER_MODE_MANUAL_OVERRIDE:
+                frontseat_state_ = iver_config_.mode_assignments().manual_override();
+                break;
+            case gpb::IverState::IVER_MODE_MANUAL_PARKING:
+                frontseat_state_ = iver_config_.mode_assignments().manual_parking();
+                break;
+            case gpb::IverState::IVER_MODE_SERVO_MODE:
+                frontseat_state_ = iver_config_.mode_assignments().servo_mode();
+                break;
+            case gpb::IverState::IVER_MODE_MISSION_MODE:
+                frontseat_state_ = iver_config_.mode_assignments().mission_mode();
+                break;
             }
 
             static const boost::units::imperial::foot_base_unit::unit_type feet;

--- a/src/middleware/frontseat/iver/iver_driver_config.proto
+++ b/src/middleware/frontseat/iver/iver_driver_config.proto
@@ -1,4 +1,5 @@
 syntax = "proto2";
+import "goby/middleware/protobuf/frontseat.proto";
 import "goby/middleware/protobuf/frontseat_config.proto";
 import "goby/protobuf/option_extensions.proto";
 import "dccl/option_extensions.proto";
@@ -31,6 +32,19 @@ message IverConfig
         default = 5,
         (dccl.field) = { min: 0 max: 120 },
         (goby.field).description = "Timeout for $OMS, in seconds."
+    ];
+    message IverModeAssignments {
+        optional FrontSeatState unknown = 1 [default = FRONTSEAT_IDLE];
+        optional FrontSeatState normal = 2 [default = FRONTSEAT_ACCEPTING_COMMANDS];
+        optional FrontSeatState stopped = 3 [default = FRONTSEAT_IDLE];
+        optional FrontSeatState parking = 4 [default = FRONTSEAT_IN_CONTROL];
+        optional FrontSeatState manual_override = 5 [default = FRONTSEAT_ACCEPTING_COMMANDS];
+        optional FrontSeatState manual_parking = 6 [default = FRONTSEAT_ACCEPTING_COMMANDS];
+        optional FrontSeatState servo_mode = 7 [default = FRONTSEAT_ACCEPTING_COMMANDS];
+        optional FrontSeatState mission_mode = 8 [default = FRONTSEAT_ACCEPTING_COMMANDS];
+    }
+    optional IverModeAssignments mode_assignments = 7 [
+        (goby.field).description = "Assignments of mission modes to frontseat states."
     ];
 }
 


### PR DESCRIPTION
The appropriate assignments of Iver mission modes to frontseat states (i.e. which mission modes should accept backseat commands) depend on how the user plans to operate the vehicle. For example, while the default assignments are useful in many cases, in some cases it may be more convenient to keep the frontseat in control when in NORMAL mode (to allow the frontseat to drive the vehicle to a waypoint and park) and allow backseat control when in PARKING mode (to allow the backseat to take over once the vehicle parks at the waypoint).