### PR TITLE
Add config for partial frame padding in mm_driver

### DIFF
--- a/src/acomms/modemdriver/mm_driver.cpp
+++ b/src/acomms/modemdriver/mm_driver.cpp
@@ -1305,10 +1305,16 @@ void goby::acomms::MMDriver::cadrq(const NMEASentence& nmea_in,
         nmea_out.push_back(m.dest());
         nmea_out.push_back(int(m.ack_requested()));
 
-        int max_bytes = nmea_in.as<int>(5);
-        nmea_out.push_back(
-            hex_encode(m.frame(frame) + std::string(max_bytes - m.frame(frame).size(), '\0')));
-        // nmea_out.push_back(hex_encode(m.frame(frame)));
+        if (mm_driver_cfg().pad_partial_frames())
+        {
+            int max_bytes = nmea_in.as<int>(5);
+            nmea_out.push_back(
+                hex_encode(m.frame(frame) + std::string(max_bytes - m.frame(frame).size(), '\0')));
+        }
+        else
+        {
+            nmea_out.push_back(hex_encode(m.frame(frame)));
+        }
 
         if (m.ack_requested())
         {

--- a/src/acomms/protobuf/mm_driver.proto
+++ b/src/acomms/protobuf/mm_driver.proto
@@ -114,6 +114,12 @@ message Config
     
     optional bool query_cfg_on_startup = 22 [default = true];
 
+    optional bool pad_partial_frames = 23 [
+        default = false,
+        (goby.field).description =
+            "Pad partial frames with trailing zeros to reach the full frame length. This was a workaround for a bug in early versions of the MM2 firmware."
+    ];
+
     message Revision
     {
 	required int32 mm_major = 1;


### PR DESCRIPTION
This also changes the default behavior to *not* pad partial frames. The padding can cause problems for custom encoding/decoding schemes which depend on the message length being preserved.

Closes #286