### PR TITLE
Str update benthos driver

### DIFF
--- a/src/acomms/modemdriver/benthos_atm900_driver_fsm.h
+++ b/src/acomms/modemdriver/benthos_atm900_driver_fsm.h
@@ -373,7 +373,7 @@ struct Configure : boost::statechart::state<Configure, Command>, StateNotify
         }
 
         // ensure serial output is the format we expect
-        context<Command>().push_clam_command("@Prompt=7");
+        context<Command>().push_clam_command("@P1Prompt=7");
         context<Command>().push_clam_command("@Verbose=3");
 
         // Goby will handle retries

--- a/src/acomms/modemdriver/driver_base.cpp
+++ b/src/acomms/modemdriver/driver_base.cpp
@@ -148,8 +148,9 @@ void goby::acomms::ModemDriverBase::modem_start(const protobuf::DriverConfig& cf
         }
     }
     else {
-        goby::glog.is(DEBUG1) && goby::glog << group(glog_out_group_)
-                                                    << "NO modem connection_type specified in your configuration file!";
+        goby::glog.is(DEBUG1) && goby::glog << group(glog_out_group_) << warn
+                                                    << "NO modem connection_type specified in your configuration file."
+                                                    << std::endl;
     }
 
     if (cfg.has_raw_log())
@@ -200,6 +201,12 @@ void goby::acomms::ModemDriverBase::modem_start(const protobuf::DriverConfig& cf
                 throw(ModemDriverException("Modem physical connection failed to startup.",
                                            protobuf::ModemDriverStatus::STARTUP_FAILED));
         }
+    }
+    else
+    {
+        glog.is(DEBUG1) && glog << group(glog_out_group_) << warn 
+                                            << "No modem initialized"
+                                            << std::endl;
     }
 }
 

--- a/src/acomms/modemdriver/driver_base.cpp
+++ b/src/acomms/modemdriver/driver_base.cpp
@@ -147,6 +147,10 @@ void goby::acomms::ModemDriverBase::modem_start(const protobuf::DriverConfig& cf
                 modem_.reset(new util::TCPServer(cfg.tcp_port(), cfg.line_delimiter()));
         }
     }
+    else {
+        goby::glog.is(DEBUG1) && goby::glog << group(glog_out_group_)
+                                                    << "NO modem connection_type specified in your configuration file!";
+    }
 
     if (cfg.has_raw_log())
     {


### PR DESCRIPTION
benthos_atm900_driver_fsm.h issues clam_command "@Prompt=7", but the @Prompt command is not available to the modem and the software fails to progress as the command is re-attempted. 
The port must be specified as P1 or P2, this PR updates the command to the default P1 port with "@P1Prompt=7".  
With this update, the driver executes as expected and moves beyond this command. Of note, issuing this command for both P1 and P2 ports may be desired, but is not included here. 

Additionally, failing to set proper configuration parameters causes a crash with little error handling or messaging to suggest a cause. driver_base.cpp is updated to issue warnings when critical elements are not initialized properly to help guide the user in debugging.