### PR TITLE
Fix computation of buffer size in DynamicBuffer

### DIFF
--- a/src/apps/zeromq/logger/CMakeLists.txt
+++ b/src/apps/zeromq/logger/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_executable(goby_logger logger.cpp)
 target_link_libraries(goby_logger goby goby_zeromq)
+generate_middleware_interfaces(goby_logger)
+
 
 add_executable(goby_playback playback.cpp)
 target_link_libraries(goby_playback goby goby_zeromq)

--- a/src/test/acomms/dynamic_buffer1/test.cpp
+++ b/src/test/acomms/dynamic_buffer1/test.cpp
@@ -26,6 +26,7 @@
 #include <boost/test/included/unit_test.hpp>
 
 #include "goby/acomms/buffer/dynamic_buffer.h"
+#include "goby/acomms/protobuf/modem_message.pb.h" // for ModemTra...
 #include "goby/time/io.h"
 
 struct TestClock
@@ -645,4 +646,55 @@ BOOST_FIXTURE_TEST_CASE(two_destination_contest, goby::test::MultiIDDynamicBuffe
         BOOST_CHECK(buffer.erase(vp));
         BOOST_CHECK_EQUAL(buffer.size(), 1);
     }
+}
+
+BOOST_FIXTURE_TEST_CASE(check_multiframe_size, DynamicBufferFixture)
+{
+    auto now = TestClock::now();
+
+    goby::acomms::protobuf::DynamicBufferConfig cfg =
+        buffer.sub(goby::acomms::BROADCAST_ID, "A").cfg();
+    cfg.set_value_base(1000);
+    cfg.set_blackout_time(0);
+    cfg.set_max_queue(3);
+    cfg.set_ack_required(true);
+    cfg.set_newest_first(true);
+
+    buffer.replace(goby::acomms::BROADCAST_ID, "A", cfg);
+
+    buffer.push({goby::acomms::BROADCAST_ID, "A", now, std::string(133, 'A')});
+    buffer.push({goby::acomms::BROADCAST_ID, "A", now, std::string(138, 'B')});
+    buffer.push({goby::acomms::BROADCAST_ID, "A", now, std::string(29, 'C')});
+
+    goby::acomms::protobuf::ModemTransmission msg;
+    msg.set_max_num_frames(1);
+    msg.set_max_frame_bytes(250);
+    msg.set_ack_requested(true);
+
+    for (auto frame_number = msg.frame_start(),
+              total_frames = msg.max_num_frames() + msg.frame_start();
+         frame_number < total_frames; ++frame_number)
+    {
+        std::string* frame = msg.add_frame();
+
+        while (frame->size() < msg.max_frame_bytes())
+        {
+            TestClock::increment(std::chrono::milliseconds(1));
+
+            try
+            {
+                auto buffer_value =
+                    buffer.top(goby::acomms::BROADCAST_ID, msg.max_frame_bytes() - frame->size(),
+                               std::chrono::milliseconds(1000));
+                *frame += buffer_value.data.data();
+            }
+            catch (goby::acomms::DynamicBufferNoDataException&)
+            {
+                break;
+            }
+        }
+    }
+    BOOST_CHECK_EQUAL(msg.frame_size(), 1);
+    BOOST_CHECK_EQUAL(msg.frame(0).size(), 29 + 138);
+    BOOST_CHECK_EQUAL(msg.frame(0), std::string(29, 'C') + std::string(138, 'B'));
 }


### PR DESCRIPTION
Bug: if a DynamicSubBuffer contains several messages of different sizes, and one or more of them has been requested but the ack timeout has not been exceeded, the computation of the next message size is incorrect.

e.g. SubBuffer "A" has messages of 30, 40, and 50 bytes. If the 30 byte message has been accessed (via top()) the next call to top_value would use 30 bytes (not 40 bytes) as the size to check when ensuring the next message isn't too long. In this case (where the next message is larger than the first), it is possible to incorrectly return a value when it actually exceeds the max_bytes requested.

This PR fixes this bug by correctly computing the size of the next message in the same fashion as it is accessed, using a new top_size() method.