### PR TITLE
Add optional log rotation on a fixed time to glog files

### DIFF
--- a/src/util/debug_logger/flex_ostream.h
+++ b/src/util/debug_logger/flex_ostream.h
@@ -100,6 +100,12 @@ class FlexOstream : public std::ostream
         sb_.add_stream(static_cast<logger::Verbosity>(verbosity), os);
     }
 
+    void remove_stream(std::ostream* os = nullptr)
+    {
+        std::lock_guard<std::recursive_mutex> l(goby::util::logger::mutex);
+        sb_.remove_stream(os);
+    }
+
     const FlexOStreamBuf& buf() { return sb_; }
 
     //@}

--- a/src/util/debug_logger/flex_ostreambuf.cpp
+++ b/src/util/debug_logger/flex_ostreambuf.cpp
@@ -115,6 +115,19 @@ void goby::util::FlexOStreamBuf::add_stream(logger::Verbosity verbosity, std::os
     }
 }
 
+void goby::util::FlexOStreamBuf::remove_stream(std::ostream* os)
+{
+    streams_.erase(std::remove_if(streams_.begin(), streams_.end(),
+                                  [&os](const StreamConfig& sc) { return sc.os() == os; }));
+
+    highest_verbosity_ = logger::QUIET;
+    for (auto stream : streams_)
+    {
+        if (stream.verbosity() > highest_verbosity_)
+            highest_verbosity_ = stream.verbosity();
+    }
+}
+
 void goby::util::FlexOStreamBuf::enable_gui()
 {
 #ifdef HAS_NCURSES

--- a/src/util/debug_logger/flex_ostreambuf.h
+++ b/src/util/debug_logger/flex_ostreambuf.h
@@ -102,6 +102,9 @@ class FlexOStreamBuf : public std::streambuf
     /// add a stream to the logger
     void add_stream(logger::Verbosity verbosity, std::ostream* os);
 
+    /// remove a stream from the logger
+    void remove_stream(std::ostream* os);
+
     /// do all attached streams have Verbosity == quiet?
     bool is_quiet() const { return highest_verbosity_ == logger::QUIET; }
 

--- a/src/util/protobuf/debug_logger.proto
+++ b/src/util/protobuf/debug_logger.proto
@@ -1,10 +1,12 @@
 syntax = "proto2";
 import "goby/protobuf/option_extensions.proto";
+import "dccl/option_extensions.proto";
 
 package goby.util.protobuf;
 
 message GLogConfig
 {
+    option (dccl.msg).unit_system = "si";
     enum Verbosity
     {
         QUIET = 1;
@@ -45,10 +47,15 @@ message GLogConfig
             default = VERBOSE,
             (goby.field).description = "Verbosity for this file log"
         ];
+
+        optional uint32 log_rotate_sec = 4 [
+            (goby.field).description =
+                "How often to rotate the glog file, in seconds.",
+            (dccl.field).units.base_dimensions = "T"
+        ];
     }
     optional FileLog file_log = 3
-        [(goby.field).description =
-             "Open a file for (debug) logging."];
-    
+        [(goby.field).description = "Open a file for (debug) logging."];
+
     optional bool show_dccl_log = 4 [default = false];
 }


### PR DESCRIPTION
- Add remove_stream to FlexOstream/FlexOstreamBuf
- Add new field to glog protobuf config `log_rotate_sec`: how often (in seconds) to rotate the log
- Update goby::middleware::Application to actually rotate the log by removing the old one and opening a new one