### PR TITLE
Update Subscription DCCL message to fill full uint32 (with varint) now that Group using uint32 group sizes. Also switch dccl_id to default id codec

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ set(GOBY_VERSION_MAJOR "3")
 set(GOBY_VERSION_MINOR "0")
 set(GOBY_VERSION_PATCH "17")
 
+
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
    message(STATUS "Compiling in Git source tree.")
    include(today)
@@ -94,6 +95,9 @@ set(GOBY_VERSION "${GOBY_VERSION_MAJOR}.${GOBY_VERSION_MINOR}.${GOBY_VERSION_PAT
 
 # give Goby 1 series a few more soversions
 set(GOBY_SOVERSION "30")
+
+# Increment on changes to internal DCCL messages
+set(GOBY_INTERVEHICLE_API_VERSION "1")
 
 # create variables for various directories
 get_filename_component(goby_SRC_DIR src ABSOLUTE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -230,7 +230,6 @@ add_library(goby
 target_link_libraries(goby
   dccl
   dccl_arithmetic
-  dccl_native_protobuf
   ${Boost_LIBRARIES}
   ${PROTOBUF_LIBRARY}
   ${PROJ_LIBRARY}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -230,6 +230,7 @@ add_library(goby
 target_link_libraries(goby
   dccl
   dccl_arithmetic
+  dccl_native_protobuf
   ${Boost_LIBRARIES}
   ${PROTOBUF_LIBRARY}
   ${PROJ_LIBRARY}

--- a/src/acomms/buffer/dynamic_buffer.h
+++ b/src/acomms/buffer/dynamic_buffer.h
@@ -503,9 +503,11 @@ template <typename T, typename Clock = goby::time::SteadyClock> class DynamicBuf
     {
         using goby::glog;
 
-        glog.is_debug1() && glog << group(glog_priority_group_)
-                                 << "Starting priority contest (dest: " << dest_id
-                                 << ", max_bytes: " << max_bytes << "):" << std::endl;
+        glog.is_debug1() &&
+            glog << group(glog_priority_group_) << "Starting priority contest (dest: "
+                 << (dest_id == goby::acomms::QUERY_DESTINATION_ID ? std::string("?")
+                                                                   : std::to_string(dest_id))
+                 << ", max_bytes: " << max_bytes << "):" << std::endl;
 
         typename std::unordered_map<subbuffer_id_type, DynamicSubBuffer<T, Clock>>::iterator
             winning_sub;

--- a/src/middleware/common.h
+++ b/src/middleware/common.h
@@ -105,6 +105,7 @@ inline std::string full_process_and_thread_id(std::thread::id i = std::this_thre
 {
     return full_process_id() + "-t" + thread_id(i);
 }
+
 } // namespace middleware
 } // namespace goby
 

--- a/src/middleware/marshalling/detail/dccl_serializer_parser.cpp
+++ b/src/middleware/marshalling/detail/dccl_serializer_parser.cpp
@@ -100,9 +100,10 @@ void check_subscription_version(unsigned dccl_id, const google::protobuf::Messag
         {
             glog.is_warn() &&
                 glog << "Received subscription forwarding subscription with incompatible "
-                        "GOBY_INTERVEHICLE_API_VERSION (this system: "
+                        "GOBY_INTERVEHICLE_API_VERSION (this system: GOBY_INTERVEHICLE_API_VERSION="
                      << GOBY_INTERVEHICLE_API_VERSION << ", remote system (modem id) "
-                     << subscription.header().src() << ": " << subscription.api_version() << ")"
+                     << subscription.header().src()
+                     << ": GOBY_INTERVEHICLE_API_VERSION=" << subscription.api_version() << ")"
                      << std::endl;
 
             if (subscription.api_version() > GOBY_INTERVEHICLE_API_VERSION)

--- a/src/middleware/marshalling/detail/dccl_serializer_parser.cpp
+++ b/src/middleware/marshalling/detail/dccl_serializer_parser.cpp
@@ -92,9 +92,11 @@ void check_subscription_version(unsigned dccl_id, const google::protobuf::Messag
     {
         goby::middleware::intervehicle::protobuf::Subscription subscription;
         subscription.CopyFrom(msg);
-        if (subscription.dccl_id() ==
-                goby::middleware::intervehicle::protobuf::Subscription::DCCL_ID &&
-            subscription.group() != GOBY_INTERVEHICLE_API_VERSION)
+
+        glog.is_warn() && glog << "Checking subscription: " << subscription.ShortDebugString()
+                               << std::endl;
+
+        if (subscription.api_version() != GOBY_INTERVEHICLE_API_VERSION)
         {
             glog.is_warn() &&
                 glog << "Received subscription forwarding subscription with incompatible "
@@ -103,7 +105,7 @@ void check_subscription_version(unsigned dccl_id, const google::protobuf::Messag
                      << subscription.header().src() << ": " << subscription.group() << ")"
                      << std::endl;
 
-            if (subscription.group() > GOBY_INTERVEHICLE_API_VERSION)
+            if (subscription.api_version() > GOBY_INTERVEHICLE_API_VERSION)
             {
                 glog.is_warn() &&
                     glog << "Please update the version of Goby on this system in order "

--- a/src/middleware/marshalling/detail/dccl_serializer_parser.cpp
+++ b/src/middleware/marshalling/detail/dccl_serializer_parser.cpp
@@ -102,7 +102,7 @@ void check_subscription_version(unsigned dccl_id, const google::protobuf::Messag
                 glog << "Received subscription forwarding subscription with incompatible "
                         "GOBY_INTERVEHICLE_API_VERSION (this system: "
                      << GOBY_INTERVEHICLE_API_VERSION << ", remote system (modem id) "
-                     << subscription.header().src() << ": " << subscription.group() << ")"
+                     << subscription.header().src() << ": " << subscription.api_version() << ")"
                      << std::endl;
 
             if (subscription.api_version() > GOBY_INTERVEHICLE_API_VERSION)

--- a/src/middleware/marshalling/detail/dccl_serializer_parser.cpp
+++ b/src/middleware/marshalling/detail/dccl_serializer_parser.cpp
@@ -33,8 +33,11 @@
 #include "goby/util/debug_logger/flex_ostreambuf.h"             // for DEBUG3
 #include "goby/util/debug_logger/logger_manipulators.h"         // for oper...
 #include "goby/util/debug_logger/term_color.h"                  // for Colors
+#include "goby/version.h"
 
 #include "dccl_serializer_parser.h"
+
+using goby::glog;
 
 namespace google
 {
@@ -77,9 +80,44 @@ void goby::middleware::detail::DCCLSerializerParserHelperBase::load_metadata(
         if (auto* desc = dccl::DynamicProtobufManager::find_descriptor(meta.protobuf_name()))
             check_load(desc);
         else
-            goby::glog.is(goby::util::logger::DEBUG3) &&
-                goby::glog << "Failed to load DCCL message via metadata: " << meta.protobuf_name()
-                           << std::endl;
+            glog.is(goby::util::logger::DEBUG3) &&
+                glog << "Failed to load DCCL message via metadata: " << meta.protobuf_name()
+                     << std::endl;
+    }
+}
+
+void check_subscription_version(unsigned dccl_id, const google::protobuf::Message& msg)
+{
+    if (dccl_id == goby::middleware::intervehicle::protobuf::SUBSCRIPTION_DCCL_ID__GOBY_3_1)
+    {
+        goby::middleware::intervehicle::protobuf::Subscription subscription;
+        subscription.CopyFrom(msg);
+        if (subscription.dccl_id() ==
+                goby::middleware::intervehicle::protobuf::Subscription::DCCL_ID &&
+            subscription.group() != GOBY_INTERVEHICLE_API_VERSION)
+        {
+            glog.is_warn() &&
+                glog << "Received subscription forwarding subscription with incompatible "
+                        "GOBY_INTERVEHICLE_API_VERSION (this system: "
+                     << GOBY_INTERVEHICLE_API_VERSION << ", remote system (modem id) "
+                     << subscription.header().src() << ": " << subscription.group() << ")"
+                     << std::endl;
+
+            if (subscription.group() > GOBY_INTERVEHICLE_API_VERSION)
+            {
+                glog.is_warn() &&
+                    glog << "Please update the version of Goby on this system in order "
+                            "to communication over intervehicle() with the remote system"
+                         << std::endl;
+            }
+            else
+            {
+                glog.is_warn() &&
+                    glog << "Please update the version of Goby on the remote system in "
+                            "order to communication over intervehicle() with this system"
+                         << std::endl;
+            }
+        }
     }
 }
 
@@ -100,11 +138,21 @@ goby::middleware::detail::DCCLSerializerParserHelperBase::unpack(const std::stri
 
         std::string::const_iterator next_frame_it;
 
-        if (codec().loaded().count(dccl_id) == INVALID_DCCL_ID)
+        // check for old Subscription message and give warning
+        if (dccl_id == goby::middleware::intervehicle::protobuf::SUBSCRIPTION_DCCL_ID__GOBY_3_0)
         {
-            goby::glog.is_debug1() &&
-                goby::glog << "DCCL ID " << dccl_id
-                           << " is not loaded. Discarding remainder of the message." << std::endl;
+            glog.is_warn() &&
+                glog << "Received Subscription from old Goby version 3.0 which is not "
+                        "compatible with this newer version of Goby. Update the sender to "
+                        "Goby 3.1 or newer to use intervehicle comms with this system."
+                     << std::endl;
+        }
+
+        if (codec().loaded().count(dccl_id) == 0)
+        {
+            glog.is_debug1() && glog << "DCCL ID " << dccl_id
+                                     << " is not loaded. Discarding remainder of the message."
+                                     << std::endl;
             packets.mutable_frame()->RemoveLast();
             return packets;
         }
@@ -113,9 +161,25 @@ goby::middleware::detail::DCCLSerializerParserHelperBase::unpack(const std::stri
         auto msg = dccl::DynamicProtobufManager::new_protobuf_message<
             std::unique_ptr<google::protobuf::Message>>(desc);
 
-        next_frame_it = codec().decode(frame_it, frame_end, msg.get());
-        packet.set_data(std::string(frame_it, next_frame_it));
+        try
+        {
+            next_frame_it = codec().decode(frame_it, frame_end, msg.get());
+            check_subscription_version(dccl_id, *msg);
+        }
+        catch (const std::exception& e)
+        {
+            glog.is_debug1() &&
+                glog << "Failed to decode message (DCCL ID " << dccl_id
+                     << "). Discarding remainder of the message. Reason: " << e.what() << std::endl;
 
+            // check partial decode of Subscription message for incompatible version
+            check_subscription_version(dccl_id, *msg);
+
+            packets.mutable_frame()->RemoveLast();
+            return packets;
+        }
+
+        packet.set_data(std::string(frame_it, next_frame_it));
         frame_it = next_frame_it;
     }
 
@@ -132,39 +196,35 @@ void goby::middleware::detail::DCCLSerializerParserHelperBase::setup_dlog()
 
         glog.add_group(glog_dccl_group, util::Colors::lt_magenta);
 
-        auto dlog_lambda = [=](const std::string& msg, dccl::logger::Verbosity vrb,
-                               dccl::logger::Group /*grp*/) {
+        auto dlog_lambda =
+            [=](const std::string& msg, dccl::logger::Verbosity vrb, dccl::logger::Group /*grp*/)
+        {
             switch (vrb)
             {
                 case dccl::logger::WARN:
-                    goby::glog.is_warn() && goby::glog << group(glog_dccl_group) << msg
-                                                       << std::endl;
+                    glog.is_warn() && glog << group(glog_dccl_group) << msg << std::endl;
                     break;
 
                 case dccl::logger::INFO:
-                    goby::glog.is_verbose() && goby::glog << group(glog_dccl_group) << msg
-                                                          << std::endl;
+                    glog.is_verbose() && glog << group(glog_dccl_group) << msg << std::endl;
                     break;
 
                 default:
                 case dccl::logger::DEBUG1:
-                    goby::glog.is_debug1() && goby::glog << group(glog_dccl_group) << msg
-                                                         << std::endl;
+                    glog.is_debug1() && glog << group(glog_dccl_group) << msg << std::endl;
                     break;
 
                 case dccl::logger::DEBUG2:
-                    goby::glog.is_debug2() && goby::glog << group(glog_dccl_group) << msg
-                                                         << std::endl;
+                    glog.is_debug2() && glog << group(glog_dccl_group) << msg << std::endl;
                     break;
 
                 case dccl::logger::DEBUG3:
-                    goby::glog.is_debug3() && goby::glog << group(glog_dccl_group) << msg
-                                                         << std::endl;
+                    glog.is_debug3() && glog << group(glog_dccl_group) << msg << std::endl;
                     break;
             }
         };
 
-        switch (goby::glog.buf().highest_verbosity())
+        switch (glog.buf().highest_verbosity())
         {
             default:
             case goby::util::logger::QUIET: break;

--- a/src/middleware/protobuf/intervehicle.proto
+++ b/src/middleware/protobuf/intervehicle.proto
@@ -72,17 +72,30 @@ message Status
     required int32 tx_queue_size = 1;
 }
 
+enum SubscriptionDCCLID
+{
+    SUBSCRIPTION_DCCL_ID__GOBY_3_0 = 2;
+    SUBSCRIPTION_DCCL_ID__GOBY_3_1 = 3;
+}
+
+// when this changes, update GOBY_INTERVEHICLE_API_VERSION in goby3/CMakeLists.txt
 message Subscription
 {
     option (dccl.msg) = {
         codec_version: 3
-        id: 2
+        id: 3 // SUBSCRIPTION_DCCL_ID__GOBY_3_1
         max_bytes: 32
         unit_system: "si"
     };
 
-    required Header header = 1;
-    optional uint64 time = 2 [(dccl.field) = {
+    // put dccl_id and group first so we can detect any other future changes to Subscription
+    // using the group (that is, GOBY_INTERVEHICLE_API_VERSION)
+    required uint32 dccl_id = 1 [(dccl.field) = { codec: "dccl.default.id" }]; // 2-byte varint
+    required uint32 group = 2 [(dccl.field) = { min: 0 max: 4294967295 }];  // 4-byte
+    // now followed by rest of the fields
+    
+    required Header header = 3;
+    optional uint64 time = 4 [(dccl.field) = {
         omit: true
         units { prefix: "micro" base_dimensions: "T" }
     }];
@@ -92,12 +105,9 @@ message Subscription
         SUBSCRIBE = 1;
         UNSUBSCRIBE = 2;
     }
-    required Action action = 3;
-
-    required uint32 dccl_id = 5 [(dccl.field) = { codec: "dccl.default.id" }]; // 2-byte varint
-    required uint32 group = 6 [(dccl.field) = { codec: "dccl.native_protobuf" }]; // 4-byte varint
+    required Action action = 5;
     optional TransporterConfig intervehicle = 10;
-    optional goby.middleware.protobuf.SerializerProtobufMetadata metadata = 20;
+    optional goby.middleware.protobuf.SerializerProtobufMetadata metadata = 20 [(dccl.field).omit = true];
 }
 
 message Header

--- a/src/middleware/protobuf/intervehicle.proto
+++ b/src/middleware/protobuf/intervehicle.proto
@@ -89,9 +89,10 @@ message Subscription
         unit_system: "si"
     };
 
-    // must be first to allow us to decode this field regardless of other message changes
-    // so we can warn when its incompatible
-    required uint32 api_version = 1 [(dccl.field) = { min: 1 max: 16 }];
+    // must be first to allow us to decode this field regardless of other
+    // message changes so we can warn when its incompatible
+    required uint32 api_version = 1
+        [(dccl.field) = { min: 1 max: 16 in_head: true }];
 
     required Header header = 2;
     optional uint64 time = 3 [(dccl.field) = {

--- a/src/middleware/protobuf/intervehicle.proto
+++ b/src/middleware/protobuf/intervehicle.proto
@@ -94,8 +94,8 @@ message Subscription
     }
     required Action action = 3;
 
-    required uint32 dccl_id = 5 [(dccl.field) = { min: 1 max: 32767 }];
-    required uint32 group = 6 [(dccl.field) = { min: 0 max: 255 }];
+    required uint32 dccl_id = 5 [(dccl.field) = { codec: "dccl.default.id" }]; // 2-byte varint
+    required uint32 group = 6 [(dccl.field) = { codec: "dccl.native_protobuf" }]; // 4-byte varint
     optional TransporterConfig intervehicle = 10;
     optional goby.middleware.protobuf.SerializerProtobufMetadata metadata = 20;
 }

--- a/src/middleware/protobuf/intervehicle.proto
+++ b/src/middleware/protobuf/intervehicle.proto
@@ -78,24 +78,23 @@ enum SubscriptionDCCLID
     SUBSCRIPTION_DCCL_ID__GOBY_3_1 = 3;
 }
 
-// when this changes, update GOBY_INTERVEHICLE_API_VERSION in goby3/CMakeLists.txt
+// when this changes, update GOBY_INTERVEHICLE_API_VERSION in
+// goby3/CMakeLists.txt
 message Subscription
 {
     option (dccl.msg) = {
         codec_version: 3
-        id: 3 // SUBSCRIPTION_DCCL_ID__GOBY_3_1
+        id: 3  // SUBSCRIPTION_DCCL_ID__GOBY_3_1
         max_bytes: 32
         unit_system: "si"
     };
 
-    // put dccl_id and group first so we can detect any other future changes to Subscription
-    // using the group (that is, GOBY_INTERVEHICLE_API_VERSION)
-    required uint32 dccl_id = 1 [(dccl.field) = { codec: "dccl.default.id" }]; // 2-byte varint
-    required uint32 group = 2 [(dccl.field) = { min: 0 max: 4294967295 }];  // 4-byte
-    // now followed by rest of the fields
-    
-    required Header header = 3;
-    optional uint64 time = 4 [(dccl.field) = {
+    // must be first to allow us to decode this field regardless of other message changes
+    // so we can warn when its incompatible
+    required uint32 api_version = 1 [(dccl.field) = { min: 1 max: 16 }];
+
+    required Header header = 2;
+    optional uint64 time = 3 [(dccl.field) = {
         omit: true
         units { prefix: "micro" base_dimensions: "T" }
     }];
@@ -105,9 +104,16 @@ message Subscription
         SUBSCRIBE = 1;
         UNSUBSCRIBE = 2;
     }
-    required Action action = 5;
+    required Action action = 4;
+
+    required uint32 dccl_id = 5
+        [(dccl.field) = { codec: "dccl.default.id" }];  // 2-byte varint
+    required uint32 group = 6
+        [(dccl.field) = { min: 0 max: 4294967295 }];  // 4-byte
+
     optional TransporterConfig intervehicle = 10;
-    optional goby.middleware.protobuf.SerializerProtobufMetadata metadata = 20 [(dccl.field).omit = true];
+    optional goby.middleware.protobuf.SerializerProtobufMetadata metadata = 20
+        [(dccl.field).omit = true];
 }
 
 message Header

--- a/src/middleware/transport/intervehicle.h
+++ b/src/middleware/transport/intervehicle.h
@@ -451,6 +451,7 @@ class InterVehicleTransporterBase
         for (auto id : subscriber.cfg().intervehicle().publisher_id())
             dccl_subscription->mutable_header()->add_dest(id);
 
+        dccl_subscription->set_api_version(GOBY_INTERVEHICLE_API_VERSION);
         dccl_subscription->set_dccl_id(dccl_id);
         dccl_subscription->set_group(group.numeric());
         dccl_subscription->set_time_with_units(

--- a/src/middleware/transport/intervehicle.h
+++ b/src/middleware/transport/intervehicle.h
@@ -92,7 +92,8 @@ class InterVehicleTransporterBase
         this->inner()
             .template subscribe<intervehicle::groups::metadata_request,
                                 protobuf::SerializerMetadataRequest>(
-                [this](const protobuf::SerializerMetadataRequest& request) {
+                [this](const protobuf::SerializerMetadataRequest& request)
+                {
                     glog.is_debug3() && glog << "Received DCCL metadata request: "
                                              << request.ShortDebugString() << std::endl;
 
@@ -586,21 +587,18 @@ class InterVehicleForwarder
         this->inner()
             .template subscribe<intervehicle::groups::modem_data_in,
                                 intervehicle::protobuf::DCCLForwardedData>(
-                [this](const intervehicle::protobuf::DCCLForwardedData& msg) {
-                    this->_receive(msg);
-                });
+                [this](const intervehicle::protobuf::DCCLForwardedData& msg)
+                { this->_receive(msg); });
 
         using ack_pair_type = intervehicle::protobuf::AckMessagePair;
         this->inner().template subscribe<intervehicle::groups::modem_ack_in, ack_pair_type>(
-            [this](const ack_pair_type& ack_pair) {
-                this->template _handle_ack_or_expire<0>(ack_pair);
-            });
+            [this](const ack_pair_type& ack_pair)
+            { this->template _handle_ack_or_expire<0>(ack_pair); });
 
         using expire_pair_type = intervehicle::protobuf::ExpireMessagePair;
         this->inner().template subscribe<intervehicle::groups::modem_expire_in, expire_pair_type>(
-            [this](const expire_pair_type& expire_pair) {
-                this->template _handle_ack_or_expire<1>(expire_pair);
-            });
+            [this](const expire_pair_type& expire_pair)
+            { this->template _handle_ack_or_expire<1>(expire_pair); });
     }
 
     virtual ~InterVehicleForwarder() = default;
@@ -722,7 +720,8 @@ class InterVehiclePortal
         // then re-publish to driver threads
         {
             using intervehicle::protobuf::Subscription;
-            auto subscribe_lambda = [=](std::shared_ptr<const Subscription> d) {
+            auto subscribe_lambda = [=](std::shared_ptr<const Subscription> d)
+            {
                 this->innermost()
                     .template publish<intervehicle::groups::modem_subscription_forward_rx,
                                       intervehicle::protobuf::Subscription,
@@ -738,28 +737,26 @@ class InterVehiclePortal
         }
 
         this->innermost().template subscribe<intervehicle::groups::modem_data_in>(
-            [this](const intervehicle::protobuf::DCCLForwardedData& msg) {
-                received_.push_back(msg);
-            });
+            [this](const intervehicle::protobuf::DCCLForwardedData& msg)
+            { received_.push_back(msg); });
 
         // a message requiring ack can be disposed by either [1] ack, [2] expire (TTL exceeded), [3] having no subscribers, [4] queue size exceeded.
         // post the correct callback (ack for [1] and expire for [2-4])
         // and remove the pending ack message
         using ack_pair_type = intervehicle::protobuf::AckMessagePair;
         this->innermost().template subscribe<intervehicle::groups::modem_ack_in, ack_pair_type>(
-            [this](const ack_pair_type& ack_pair) {
-                this->template _handle_ack_or_expire<0>(ack_pair);
-            });
+            [this](const ack_pair_type& ack_pair)
+            { this->template _handle_ack_or_expire<0>(ack_pair); });
 
         using expire_pair_type = intervehicle::protobuf::ExpireMessagePair;
         this->innermost()
             .template subscribe<intervehicle::groups::modem_expire_in, expire_pair_type>(
-                [this](const expire_pair_type& expire_pair) {
-                    this->template _handle_ack_or_expire<1>(expire_pair);
-                });
+                [this](const expire_pair_type& expire_pair)
+                { this->template _handle_ack_or_expire<1>(expire_pair); });
 
         this->innermost().template subscribe<intervehicle::groups::modem_driver_ready, bool>(
-            [this](const bool& ready) {
+            [this](const bool& ready)
+            {
                 goby::glog.is_debug1() && goby::glog << "Received driver ready" << std::endl;
                 ++drivers_ready_;
             });
@@ -778,20 +775,22 @@ class InterVehiclePortal
             modem_drivers_.emplace_back(new ModemDriverData);
             ModemDriverData& data = *modem_drivers_.back();
 
-            data.underlying_thread.reset(new std::thread([&data, link]() {
-                try
+            data.underlying_thread.reset(new std::thread(
+                [&data, link]()
                 {
-                    data.modem_driver_thread.reset(new intervehicle::ModemDriverThread(*link));
-                    data.modem_driver_thread->run(data.driver_thread_alive);
-                }
-                catch (std::exception& e)
-                {
-                    goby::glog.is_warn() &&
-                        goby::glog << "Modem driver thread had uncaught exception: " << e.what()
-                                   << std::endl;
-                    throw;
-                }
-            }));
+                    try
+                    {
+                        data.modem_driver_thread.reset(new intervehicle::ModemDriverThread(*link));
+                        data.modem_driver_thread->run(data.driver_thread_alive);
+                    }
+                    catch (std::exception& e)
+                    {
+                        goby::glog.is_warn() &&
+                            goby::glog << "Modem driver thread had uncaught exception: " << e.what()
+                                       << std::endl;
+                        throw;
+                    }
+                }));
 
             if (goby::glog.buf().is_gui())
                 // allows for visual grouping of each link in the NCurses gui
@@ -868,7 +867,8 @@ class InterVehiclePortal
         remove(persist_sub_file_name_.c_str());
 
         this->innermost().template subscribe<intervehicle::groups::subscription_report>(
-            [this](const intervehicle::protobuf::SubscriptionReport& report) {
+            [this](const intervehicle::protobuf::SubscriptionReport& report)
+            {
                 goby::glog.is_debug1() && goby::glog << "Received subscription report: "
                                                      << report.ShortDebugString() << std::endl;
                 sub_reports_[report.link_modem_id()] = report;

--- a/src/middleware/transport/intervehicle/driver_thread.cpp
+++ b/src/middleware/transport/intervehicle/driver_thread.cpp
@@ -138,21 +138,18 @@ goby::middleware::intervehicle::ModemDriverThread::ModemDriverThread(
     this->set_transporter(interprocess_.get());
 
     interprocess_->subscribe<groups::modem_data_out, SerializerTransporterMessage>(
-        [this](std::shared_ptr<const SerializerTransporterMessage> msg) {
-            _buffer_message(std::move(msg));
-        });
+        [this](std::shared_ptr<const SerializerTransporterMessage> msg)
+        { _buffer_message(std::move(msg)); });
 
     interprocess_->subscribe<groups::modem_subscription_forward_tx,
                              intervehicle::protobuf::Subscription, MarshallingScheme::PROTOBUF>(
-        [this](const std::shared_ptr<const intervehicle::protobuf::Subscription>& subscription) {
-            _forward_subscription(*subscription);
-        });
+        [this](const std::shared_ptr<const intervehicle::protobuf::Subscription>& subscription)
+        { _forward_subscription(*subscription); });
 
     interprocess_->subscribe<groups::modem_subscription_forward_rx,
                              intervehicle::protobuf::Subscription, MarshallingScheme::PROTOBUF>(
-        [this](const std::shared_ptr<const intervehicle::protobuf::Subscription>& subscription) {
-            _accept_subscription(*subscription);
-        });
+        [this](const std::shared_ptr<const intervehicle::protobuf::Subscription>& subscription)
+        { _accept_subscription(*subscription); });
 
     if (cfg().driver().has_driver_name())
     {
@@ -225,57 +222,67 @@ goby::middleware::intervehicle::ModemDriverThread::ModemDriverThread(
         }
     }
 
-    driver_->signal_receive.connect([&](const goby::acomms::protobuf::ModemTransmission& rx_msg) {
-        protobuf::ModemTransmissionWithLinkID msg_with_id;
-        msg_with_id.set_link_modem_id(cfg().modem_id());
-        *msg_with_id.mutable_data() = rx_msg;
-        interprocess_->publish<groups::modem_receive>(msg_with_id);
-    });
+    driver_->signal_receive.connect(
+        [&](const goby::acomms::protobuf::ModemTransmission& rx_msg)
+        {
+            protobuf::ModemTransmissionWithLinkID msg_with_id;
+            msg_with_id.set_link_modem_id(cfg().modem_id());
+            *msg_with_id.mutable_data() = rx_msg;
+            interprocess_->publish<groups::modem_receive>(msg_with_id);
+        });
 
     driver_->signal_transmit_result.connect(
-        [&](const goby::acomms::protobuf::ModemTransmission& tx_msg) {
+        [&](const goby::acomms::protobuf::ModemTransmission& tx_msg)
+        {
             protobuf::ModemTransmissionWithLinkID msg_with_id;
             msg_with_id.set_link_modem_id(cfg().modem_id());
             *msg_with_id.mutable_data() = tx_msg;
             interprocess_->publish<groups::modem_transmit_result>(msg_with_id);
         });
 
-    driver_->signal_raw_incoming.connect([&](const goby::acomms::protobuf::ModemRaw& msg) {
-        protobuf::ModemRawWithLinkID msg_with_id;
-        msg_with_id.set_link_modem_id(cfg().modem_id());
-        *msg_with_id.mutable_data() = msg;
-        interprocess_->publish<groups::modem_raw_incoming>(msg_with_id);
-    });
+    driver_->signal_raw_incoming.connect(
+        [&](const goby::acomms::protobuf::ModemRaw& msg)
+        {
+            protobuf::ModemRawWithLinkID msg_with_id;
+            msg_with_id.set_link_modem_id(cfg().modem_id());
+            *msg_with_id.mutable_data() = msg;
+            interprocess_->publish<groups::modem_raw_incoming>(msg_with_id);
+        });
 
-    driver_->signal_raw_outgoing.connect([&](const goby::acomms::protobuf::ModemRaw& msg) {
-        protobuf::ModemRawWithLinkID msg_with_id;
-        msg_with_id.set_link_modem_id(cfg().modem_id());
-        *msg_with_id.mutable_data() = msg;
-        interprocess_->publish<groups::modem_raw_outgoing>(msg_with_id);
-    });
+    driver_->signal_raw_outgoing.connect(
+        [&](const goby::acomms::protobuf::ModemRaw& msg)
+        {
+            protobuf::ModemRawWithLinkID msg_with_id;
+            msg_with_id.set_link_modem_id(cfg().modem_id());
+            *msg_with_id.mutable_data() = msg;
+            interprocess_->publish<groups::modem_raw_outgoing>(msg_with_id);
+        });
 
-    driver_->signal_receive.connect(
-        [&](const goby::acomms::protobuf::ModemTransmission& rx_msg) { _receive(rx_msg); });
+    driver_->signal_receive.connect([&](const goby::acomms::protobuf::ModemTransmission& rx_msg)
+                                    { _receive(rx_msg); });
 
-    driver_->signal_data_request.connect(
-        [&](goby::acomms::protobuf::ModemTransmission* msg) { this->_data_request(msg); });
+    driver_->signal_data_request.connect([&](goby::acomms::protobuf::ModemTransmission* msg)
+                                         { this->_data_request(msg); });
 
     goby::acomms::bind(mac_, *driver_);
 
     mac_.signal_initiate_transmission.connect(
-        [&](const goby::acomms::protobuf::ModemTransmission& msg) {
+        [&](const goby::acomms::protobuf::ModemTransmission& msg)
+        {
             protobuf::ModemTransmissionWithLinkID msg_with_id;
             msg_with_id.set_link_modem_id(cfg().modem_id());
             *msg_with_id.mutable_data() = msg;
             interprocess_->publish<groups::mac_initiate_transmission>(msg_with_id);
         });
 
-    mac_.signal_slot_start.connect([&](const goby::acomms::protobuf::ModemTransmission& msg) {
-        protobuf::ModemTransmissionWithLinkID msg_with_id;
-        msg_with_id.set_link_modem_id(cfg().modem_id());
-        *msg_with_id.mutable_data() = msg;
-        interprocess_->publish<groups::mac_slot_start>(msg_with_id);
-    });
+    mac_.signal_slot_start.connect(
+        [&](const goby::acomms::protobuf::ModemTransmission& msg)
+        {
+            protobuf::ModemTransmissionWithLinkID msg_with_id;
+            msg_with_id.set_link_modem_id(cfg().modem_id());
+            *msg_with_id.mutable_data() = msg;
+            interprocess_->publish<groups::mac_slot_start>(msg_with_id);
+        });
 
     mac_.startup(cfg().mac());
 
@@ -285,7 +292,8 @@ goby::middleware::intervehicle::ModemDriverThread::ModemDriverThread(
 
     subscription_key_.set_marshalling_scheme(MarshallingScheme::DCCL);
     subscription_key_.set_type(intervehicle::protobuf::Subscription::descriptor()->full_name());
-    subscription_key_.set_group_numeric(Group::broadcast_group);
+    subscription_key_.set_group_numeric(
+        goby::middleware::intervehicle::groups::subscription_forward.numeric());
 
     goby::glog.is_debug1() && goby::glog << group(glog_group_) << "Driver ready" << std::endl;
     interthread_->publish<groups::modem_driver_ready, bool>(true);

--- a/src/middleware/transport/intervehicle/driver_thread.cpp
+++ b/src/middleware/transport/intervehicle/driver_thread.cpp
@@ -477,6 +477,9 @@ void goby::middleware::intervehicle::ModemDriverThread::_accept_subscription(
     if (!_dest_is_in_subnet(dest))
         return;
 
+    if (subscription.api_version() != GOBY_INTERVEHICLE_API_VERSION)
+        return;
+
     switch (subscription.action())
     {
         case protobuf::Subscription::SUBSCRIBE:

--- a/src/middleware/transport/intervehicle/groups.h
+++ b/src/middleware/transport/intervehicle/groups.h
@@ -26,6 +26,7 @@
 #define GOBY_MIDDLEWARE_TRANSPORT_INTERVEHICLE_GROUPS_H
 
 #include "goby/middleware/group.h"
+#include "goby/version.h"
 
 namespace goby
 {
@@ -35,8 +36,9 @@ namespace intervehicle
 {
 namespace groups
 {
-constexpr Group subscription_forward{"goby::middleware::intervehicle::subscription_forward",
-                                     Group::broadcast_group};
+constexpr Group subscription_forward{
+    "goby::middleware::intervehicle::subscription_forward",
+    GOBY_INTERVEHICLE_API_VERSION}; // increment the subscription forward numeric group whenever we change the Subscription DCCL message
 
 constexpr Group modem_data_out{"goby::middleware::intervehicle::modem_data_out"};
 constexpr Group modem_data_in{"goby::middleware::intervehicle::modem_data_in"};

--- a/src/version.h
+++ b/src/version.h
@@ -28,9 +28,12 @@
 #include <sstream>
 #include <string>
 
+// clang-format off
 #define GOBY_VERSION_MAJOR @GOBY_VERSION_MAJOR@
 #define GOBY_VERSION_MINOR @GOBY_VERSION_MINOR@
 #define GOBY_VERSION_PATCH @GOBY_VERSION_PATCH@
+#define GOBY_INTERVEHICLE_API_VERSION @GOBY_INTERVEHICLE_API_VERSION@
+// clang-format on
 
 namespace goby
 {


### PR DESCRIPTION
Update Subscription DCCL message to have an API version and fix group / dccl_id codecs to allow full use of uint32 groups. The API version provides a mechanism for future releases to warn about incompatible Goby releases.

Will be release 3.1.
