### PR TITLE
'goby' tool additions

### DIFF
--- a/src/apps/middleware/goby_tool/CMakeLists.txt
+++ b/src/apps/middleware/goby_tool/CMakeLists.txt
@@ -1,3 +1,14 @@
-add_executable(goby_tool goby_tool.cpp unified_log_tool.cpp)
+protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS
+  marshalling/protobuf.proto
+  tool.proto
+  log.proto
+  )
+
+add_executable(goby_tool
+  goby_tool.cpp
+  unified_log_tool.cpp
+  marshalling/protobuf.cpp
+  ${PROTO_SRCS} ${PROTO_HDRS}
+  )
 target_link_libraries(goby_tool goby)
 set_target_properties(goby_tool PROPERTIES OUTPUT_NAME goby)

--- a/src/apps/middleware/goby_tool/goby_tool.cpp
+++ b/src/apps/middleware/goby_tool/goby_tool.cpp
@@ -1,8 +1,10 @@
 #include "goby/middleware/application/configuration_reader.h"
 #include "goby/middleware/application/interface.h"
 #include "goby/middleware/application/tool.h"
-#include "goby/middleware/protobuf/goby_tool_config.pb.h"
 
+#include "goby/apps/middleware/goby_tool/log.pb.h"
+#include "goby/apps/middleware/goby_tool/tool.pb.h"
+#include "marshalling/protobuf.h"
 #include "unified_log_tool.h"
 
 using goby::glog;
@@ -51,8 +53,6 @@ int main(int argc, char* argv[])
 
 goby::apps::middleware::GobyTool::GobyTool()
 {
-    //    std::cout << app_cfg().DebugString() << std::endl;
-
     goby::middleware::ToolHelper tool_helper(
         app_cfg().app().binary(), app_cfg().app().tool_cfg(),
         goby::apps::middleware::protobuf::GobyToolConfig::Action_descriptor());
@@ -71,7 +71,9 @@ goby::apps::middleware::GobyTool::GobyTool()
                             tool_helper.help<goby::apps::middleware::UnifiedLogTool>(
                                 action_for_help);
                             break;
-
+                        case goby::apps::middleware::protobuf::GobyToolConfig::protobuf:
+                            tool_helper.help<goby::apps::middleware::ProtobufTool>(action_for_help);
+                            break;
                         default:
                             throw(goby::Exception(
                                 "Help was expected to be handled by external tool"));
@@ -82,6 +84,10 @@ goby::apps::middleware::GobyTool::GobyTool()
 
             case goby::apps::middleware::protobuf::GobyToolConfig::log:
                 tool_helper.run_subtool<goby::apps::middleware::UnifiedLogTool>();
+                break;
+
+            case goby::apps::middleware::protobuf::GobyToolConfig::protobuf:
+                tool_helper.run_subtool<goby::apps::middleware::ProtobufTool>();
                 break;
 
             default:

--- a/src/apps/middleware/goby_tool/log.proto
+++ b/src/apps/middleware/goby_tool/log.proto
@@ -1,0 +1,36 @@
+syntax = "proto2";
+import "goby/middleware/protobuf/app_config.proto";
+import "goby/protobuf/option_extensions.proto";
+
+package goby.apps.middleware.protobuf;
+
+message UnifiedLogToolConfig
+{
+    option (goby.msg).cfg.tool = {
+        is_tool: true
+        has_subtools: true
+        has_help_action: true
+    };
+
+    optional goby.middleware.protobuf.AppConfig app = 1
+        [(goby.field) = { cfg { action: DEVELOPER } }];
+
+    enum Action
+    {
+        help = 0 [(goby.ev).cfg = {
+            short_help_msg: "Print usage information",
+            full_help_msg: "Usage: \"goby log help [action]\""
+        }];
+        convert = 1 [(goby.ev).cfg = {
+            short_help_msg: "Convert .goby log files to other formats",
+            external_command: "goby_log_tool"
+        }];
+    }
+    optional Action action = 2 [
+        default = help,
+        (goby.field) = {
+            description: "The action this tool should take [can omit --action if 1st parameter]",
+            cfg { position: { enable: true }, cli_short: "A", action: HIDDEN }
+        }
+    ];
+}

--- a/src/apps/middleware/goby_tool/marshalling/protobuf.cpp
+++ b/src/apps/middleware/goby_tool/marshalling/protobuf.cpp
@@ -1,0 +1,75 @@
+#include <dccl/dynamic_protobuf_manager.h>
+
+#include "goby/middleware/application/tool.h"
+
+#include "protobuf.h"
+
+using goby::glog;
+
+goby::apps::middleware::ProtobufTool::ProtobufTool()
+{
+    goby::middleware::ToolHelper tool_helper(
+        app_cfg().app().binary(), app_cfg().app().tool_cfg(),
+        goby::apps::middleware::protobuf::ProtobufToolConfig::Action_descriptor());
+
+    if (!tool_helper.perform_action(app_cfg().action()))
+    {
+        switch (app_cfg().action())
+        {
+            case goby::apps::middleware::protobuf::ProtobufToolConfig::help:
+                int action_for_help;
+                if (!tool_helper.help(&action_for_help))
+                {
+                    switch (action_for_help)
+                    {
+                        case goby::apps::middleware::protobuf::ProtobufToolConfig::show:
+                            tool_helper.help<goby::apps::middleware::ProtobufShowTool>(
+                                action_for_help);
+                            break;
+
+                        default:
+                            throw(goby::Exception(
+                                "Help was expected to be handled by external tool"));
+                            break;
+                    }
+                }
+                break;
+
+            case goby::apps::middleware::protobuf::ProtobufToolConfig::show:
+                tool_helper.run_subtool<goby::apps::middleware::ProtobufShowTool>();
+                break;
+
+            default:
+                throw(goby::Exception("Action was expected to be handled by external tool"));
+                break;
+        }
+    }
+
+    quit(0);
+}
+
+goby::apps::middleware::ProtobufShowTool::ProtobufShowTool()
+{
+    for (const auto& lib : app_cfg().load_shared_library())
+    {
+        void* lib_handle = dlopen(lib.c_str(), RTLD_LAZY);
+        if (!lib_handle)
+            glog.is_die() && glog << "Failed to open library: " << lib << std::endl;
+        dl_handles_.push_back(lib_handle);
+    }
+
+    const google::protobuf::Descriptor* desc =
+        dccl::DynamicProtobufManager::find_descriptor(app_cfg().name());
+
+    if (!desc)
+    {
+        goby::glog.is_die() &&
+            goby::glog << "Failed to find message " << app_cfg().name()
+                       << ". Ensure you have specified all required --load_shared_library libraries"
+                       << std::endl;
+    }
+
+    std::cout << desc->DebugString() << std::endl;
+
+    quit(0);
+}

--- a/src/apps/middleware/goby_tool/marshalling/protobuf.cpp
+++ b/src/apps/middleware/goby_tool/marshalling/protobuf.cpp
@@ -68,7 +68,7 @@ goby::apps::middleware::ProtobufShowTool::ProtobufShowTool()
         }
 
         std::cout << "============== " << goby::util::esc_lt_white << name
-                  << goby::util::esc_nocolor << "============== " << std::endl;
+                  << goby::util::esc_nocolor << " ==============" << std::endl;
         std::cout << desc->DebugString() << std::endl;
     }
 

--- a/src/apps/middleware/goby_tool/marshalling/protobuf.h
+++ b/src/apps/middleware/goby_tool/marshalling/protobuf.h
@@ -1,0 +1,70 @@
+#include "goby/middleware/application/configuration_reader.h"
+#include "goby/middleware/application/interface.h"
+
+#include "goby/apps/middleware/goby_tool/marshalling/protobuf.pb.h"
+
+namespace goby
+{
+namespace apps
+{
+namespace middleware
+{
+class ProtobufToolConfigurator
+    : public goby::middleware::ProtobufConfigurator<protobuf::ProtobufToolConfig>
+{
+  public:
+    ProtobufToolConfigurator(int argc, char* argv[])
+        : goby::middleware::ProtobufConfigurator<protobuf::ProtobufToolConfig>(argc, argv)
+    {
+        auto& cfg = mutable_cfg();
+        if (!cfg.app().glog_config().has_tty_verbosity())
+            cfg.mutable_app()->mutable_glog_config()->set_tty_verbosity(
+                goby::util::protobuf::GLogConfig::WARN);
+    }
+};
+
+class ProtobufTool : public goby::middleware::Application<protobuf::ProtobufToolConfig>
+{
+  public:
+    ProtobufTool();
+    ~ProtobufTool() override {}
+
+  private:
+    void run() override { assert(false); }
+
+  private:
+};
+
+class ProtobufShowToolConfigurator
+    : public goby::middleware::ProtobufConfigurator<protobuf::ProtobufShowToolConfig>
+{
+  public:
+    ProtobufShowToolConfigurator(int argc, char* argv[])
+        : goby::middleware::ProtobufConfigurator<protobuf::ProtobufShowToolConfig>(argc, argv)
+    {
+        auto& cfg = mutable_cfg();
+        if (!cfg.app().glog_config().has_tty_verbosity())
+            cfg.mutable_app()->mutable_glog_config()->set_tty_verbosity(
+                goby::util::protobuf::GLogConfig::WARN);
+    }
+};
+
+class ProtobufShowTool : public goby::middleware::Application<protobuf::ProtobufShowToolConfig>
+{
+  public:
+    ProtobufShowTool();
+    ~ProtobufShowTool() override
+    {
+        for (void* handle : dl_handles_) dlclose(handle);
+    }
+
+  private:
+    void run() override { assert(false); }
+
+  private:
+    std::vector<void*> dl_handles_;
+};
+
+} // namespace middleware
+} // namespace apps
+} // namespace goby

--- a/src/apps/middleware/goby_tool/marshalling/protobuf.h
+++ b/src/apps/middleware/goby_tool/marshalling/protobuf.h
@@ -49,20 +49,15 @@ class ProtobufShowToolConfigurator
     }
 };
 
-class ProtobufShowTool : public goby::middleware::Application<protobuf::ProtobufShowToolConfig>
+class ProtobufShowTool : public goby::middleware::Application<protobuf::ProtobufShowToolConfig>,
+                         public goby::middleware::ToolSharedLibraryLoader
 {
   public:
     ProtobufShowTool();
-    ~ProtobufShowTool() override
-    {
-        for (void* handle : dl_handles_) dlclose(handle);
-    }
+    ~ProtobufShowTool() override {}
 
   private:
     void run() override { assert(false); }
-
-  private:
-    std::vector<void*> dl_handles_;
 };
 
 } // namespace middleware

--- a/src/apps/middleware/goby_tool/marshalling/protobuf.proto
+++ b/src/apps/middleware/goby_tool/marshalling/protobuf.proto
@@ -1,0 +1,57 @@
+syntax = "proto2";
+import "goby/middleware/protobuf/app_config.proto";
+import "goby/protobuf/option_extensions.proto";
+
+package goby.apps.middleware.protobuf;
+
+message ProtobufToolConfig
+{
+    option (goby.msg).cfg.tool = {
+        is_tool: true
+        has_subtools: true
+        has_help_action: true
+    };
+
+    optional goby.middleware.protobuf.AppConfig app = 1
+        [(goby.field) = { cfg { action: DEVELOPER } }];
+
+    enum Action
+    {
+        help = 0 [(goby.ev).cfg = {
+            short_help_msg: "Print usage information",
+            full_help_msg: "Usage: \"goby protobuf help [action]\""
+        }];
+        show = 1 [(goby.ev).cfg = {
+            short_help_msg: "Display definition for message",
+        }];
+    }
+    optional Action action = 2 [
+        default = help,
+        (goby.field) = {
+            description: "The action this tool should take [can omit --action if 1st parameter]",
+            cfg { position: { enable: true }, cli_short: "A", action: HIDDEN }
+        }
+    ];
+}
+
+message ProtobufShowToolConfig
+{
+    option (goby.msg).cfg.tool = {
+        is_tool: true
+        has_subtools: false
+        has_help_action: false
+    };
+
+    optional goby.middleware.protobuf.AppConfig app = 1
+        [(goby.field) = { cfg { action: DEVELOPER } }];
+
+    required string name = 2 [(goby.field) = {
+        description: "Protobuf name for message to show.",
+        cfg { position: { enable: true }, cli_short: "n" }
+    }];
+
+    repeated string load_shared_library = 10 [(goby.field) = {
+        description: "Load this shared library containing compiled Protobuf/DCCL messages.",
+        cfg { cli_short: "l" }
+    }];
+}

--- a/src/apps/middleware/goby_tool/marshalling/protobuf.proto
+++ b/src/apps/middleware/goby_tool/marshalling/protobuf.proto
@@ -45,13 +45,18 @@ message ProtobufShowToolConfig
     optional goby.middleware.protobuf.AppConfig app = 1
         [(goby.field) = { cfg { action: DEVELOPER } }];
 
-    required string name = 2 [(goby.field) = {
+    repeated string name = 2 [(goby.field) = {
         description: "Protobuf name for message to show.",
-        cfg { position: { enable: true }, cli_short: "n" }
+        cfg { position: { enable: true max_count: -1 }, cli_short: "n" }
+    }];
+
+    optional string package_name = 3 [(goby.field) = {
+        description: "Common protobuf package (namespace) to prepend to 'name'",
+        cfg { cli_short: "p" }
     }];
 
     repeated string load_shared_library = 10 [(goby.field) = {
         description: "Load this shared library containing compiled Protobuf/DCCL messages.",
-        cfg { cli_short: "l" }
+        cfg { cli_short: "l" env: "GOBY_TOOL_LOAD_SHARED_LIBRARY" }
     }];
 }

--- a/src/apps/middleware/goby_tool/tool.proto
+++ b/src/apps/middleware/goby_tool/tool.proto
@@ -17,6 +17,7 @@ message GobyToolConfig
 
     enum Action
     {
+        // core tools
         help = 0 [(goby.ev).cfg = {
             short_help_msg: "Print usage information",
             full_help_msg: "Usage: \"goby help [action]\"\n"
@@ -26,48 +27,24 @@ message GobyToolConfig
                            "You can also override the help command line flag used by running, for example, \"goby help -hh log\" to pass \"-hh\" to \"goby log\" in order to show advanced command line options"
 
         }];
-        zeromq = 1 [(goby.ev).cfg = {
-            short_help_msg: "Interact with ZeroMQ Goby pub/sub",
-            external_command: "goby_zeromq_tool"
-        }];
-        log = 2 [(goby.ev).cfg = {
+        log = 1 [(goby.ev).cfg = {
             short_help_msg: "Manage goby log files",
         }];
-        launch = 3 [(goby.ev).cfg = {
+        launch = 2 [(goby.ev).cfg = {
             short_help_msg: "Launch goby *.launch files",
             external_command: "goby_launch"
             include_binary_flag: false
         }];
-    }
-    optional Action action = 2 [
-        default = help,
-        (goby.field) = {
-            description: "The action this tool should take [can omit --action if 1st parameter]",
-            cfg { position: { enable: true }, cli_short: "A", action: HIDDEN }
-        }
-    ];
-}
 
-message UnifiedLogToolConfig
-{
-    option (goby.msg).cfg.tool = {
-        is_tool: true
-        has_subtools: true
-        has_help_action: true
-    };
-
-    optional goby.middleware.protobuf.AppConfig app = 1
-        [(goby.field) = { cfg { action: DEVELOPER } }];
-
-    enum Action
-    {
-        help = 0 [(goby.ev).cfg = {
-            short_help_msg: "Print usage information",
-            full_help_msg: "Usage: \"goby log help [action]\""
+        // middleware/transport
+        zeromq = 10 [(goby.ev).cfg = {
+            short_help_msg: "Interact with ZeroMQ Goby pub/sub",
+            external_command: "goby_zeromq_tool"
         }];
-        convert = 1 [(goby.ev).cfg = {
-            short_help_msg: "Convert .goby log files to other formats",
-            external_command: "goby_log_tool"
+
+        // middleware/marshalling
+        protobuf = 20 [(goby.ev).cfg = {
+            short_help_msg: "Tools for the Google Protocol Buffers (protobuf) marshalling scheme"
         }];
     }
     optional Action action = 2 [

--- a/src/apps/middleware/goby_tool/unified_log_tool.h
+++ b/src/apps/middleware/goby_tool/unified_log_tool.h
@@ -1,8 +1,8 @@
 #ifndef GOBY_APPS_MIDDLEWARE_GOBY_TOOL_UNIFIED_LOG_TOOL_H
 #define GOBY_APPS_MIDDLEWARE_GOBY_TOOL_UNIFIED_LOG_TOOL_H
 
+#include "goby/apps/middleware/goby_tool/log.pb.h"
 #include "goby/middleware/application/interface.h"
-#include "goby/middleware/protobuf/goby_tool_config.pb.h"
 
 namespace goby
 {

--- a/src/middleware/application/configuration_reader.cpp
+++ b/src/middleware/application/configuration_reader.cpp
@@ -582,7 +582,14 @@ void goby::middleware::ConfigReader::get_protobuf_program_options(
             field_desc->options().GetExtension(goby::field).cfg();
 
         if (cfg_opts.has_env())
+        {
+            if (environmental_var_map.count(cfg_opts.env()))
+                throw(ConfigException(std::string("Environmental variable " + cfg_opts.env() +
+                                                  " is already in use by " +
+                                                  environmental_var_map[cfg_opts.env()] +
+                                                  " when trying to add it for " + cli_name)));
             environmental_var_map[cfg_opts.env()] = cli_name;
+        }
 
         if (cfg_opts.has_cli_short())
             cli_name += "," + cfg_opts.cli_short();

--- a/src/middleware/application/configuration_reader.cpp
+++ b/src/middleware/application/configuration_reader.cpp
@@ -867,8 +867,6 @@ std::string goby::middleware::ConfigReader::word_wrap(std::string s, unsigned wi
             s = s.substr(width);
         }
         out += "\n";
-
-        // std::cout << "width: " << width << " " << out << std::endl;
     }
     out += s;
 

--- a/src/middleware/application/configuration_reader.h
+++ b/src/middleware/application/configuration_reader.h
@@ -109,7 +109,8 @@ class ConfigReader
     static void set_protobuf_program_option(const boost::program_options::variables_map& vm,
                                             google::protobuf::Message& message,
                                             const std::string& full_name,
-                                            const boost::program_options::variable_value& value);
+                                            const boost::program_options::variable_value& value,
+                                            bool overwrite_if_exists);
 
     static void
     get_example_cfg_file(google::protobuf::Message* message, std::ostream* human_desc_ss,

--- a/src/middleware/application/configuration_reader.h
+++ b/src/middleware/application/configuration_reader.h
@@ -92,7 +92,8 @@ class ConfigReader
     static void get_protobuf_program_options(
         std::map<goby::GobyFieldOptions::ConfigurationOptions::ConfigAction,
                  boost::program_options::options_description>& od_map,
-        const google::protobuf::Descriptor* desc);
+        const google::protobuf::Descriptor* desc,
+        std::map<std::string, std::string>& environmental_var_map);
 
     struct PositionalOption
     {
@@ -169,14 +170,16 @@ class ConfigReader
             {
                 po_desc.add_options()(
                     name.c_str(),
-                    boost::program_options::value<std::vector<T>>()->default_value(
-                        std::vector<T>(1, default_value),
-                        goby::util::as<std::string>(default_value)),
+                    boost::program_options::value<std::vector<T>>()
+                        ->default_value(std::vector<T>(1, default_value),
+                                        goby::util::as<std::string>(default_value))
+                        ->composing(),
                     description.c_str());
             }
             else
             {
-                po_desc.add_options()(name.c_str(), boost::program_options::value<std::vector<T>>(),
+                po_desc.add_options()(name.c_str(),
+                                      boost::program_options::value<std::vector<T>>()->composing(),
                                       description.c_str());
             }
         }

--- a/src/middleware/application/tool.cpp
+++ b/src/middleware/application/tool.cpp
@@ -109,3 +109,23 @@ void goby::middleware::ToolHelper::exec_external(std::string app, std::vector<st
     std::cerr << std::endl;
     std::cerr << "Ensure that " << args[0] << " is on your path and is executable." << std::endl;
 }
+
+void goby::middleware::ToolSharedLibraryLoader::load_lib(const std::string& lib)
+{
+    std::vector<std::string> libs;
+    // allow the environmental variable entry to contain multiple libraries separated by a common delimiter
+    boost::split(libs, lib, boost::is_any_of(";:,"));
+    for (const auto& l : libs)
+    {
+        glog.is_debug2() && glog << "Loading library: " << l << std::endl;
+        void* lib_handle = dlopen(l.c_str(), RTLD_LAZY);
+        if (!lib_handle)
+            glog.is_die() && glog << "Failed to open library: " << lib << std::endl;
+        dl_handles_.push_back(lib_handle);
+    }
+}
+
+goby::middleware::ToolSharedLibraryLoader::~ToolSharedLibraryLoader()
+{
+    for (void* handle : dl_handles_) dlclose(handle);
+}

--- a/src/middleware/application/tool.cpp
+++ b/src/middleware/application/tool.cpp
@@ -62,8 +62,9 @@ bool goby::middleware::ToolHelper::help(int* action_for_help)
         if (!action_for_help_name.empty())
             std::cerr << "Action \"" << action_for_help_name << "\" does not exist.\n" << std::endl;
 
-        std::cerr << "Usage: " << name_ << " [" << name_
-                  << " options (use -h[hhh])] action [action options]\n"
+        std::cerr << "Usage: " << name_ << " [" << name_ << " options (use -h[hhh])] "
+                  << goby::util::esc_lt_white << "action" << goby::util::esc_nocolor
+                  << " [action options]\n"
                   << std::endl;
 
         std::cerr << "Available actions: " << std::endl;
@@ -72,8 +73,13 @@ bool goby::middleware::ToolHelper::help(int* action_for_help)
             const google::protobuf::EnumValueDescriptor* value_desc = action_enum_desc_->value(i);
             const goby::GobyEnumValueOptions& ev_options =
                 value_desc->options().GetExtension(goby::ev);
-            std::cerr << "  " << value_desc->name() << ": " << ev_options.cfg().short_help_msg()
-                      << std::endl;
+            std::cerr << "  " << goby::util::esc_lt_white << value_desc->name()
+                      << goby::util::esc_nocolor << ": " << ev_options.cfg().short_help_msg();
+
+            if (ev_options.cfg().has_external_command())
+                std::cerr << " (" << ev_options.cfg().external_command() << ")";
+
+            std::cerr << std::endl;
         }
         return true;
     }

--- a/src/middleware/application/tool.h
+++ b/src/middleware/application/tool.h
@@ -48,6 +48,29 @@ class ToolHelper
     const google::protobuf::EnumDescriptor* action_enum_desc_;
 };
 
+class ToolSharedLibraryLoader
+{
+  public:
+    ToolSharedLibraryLoader(const std::vector<std::string>& load_libs)
+    {
+        for (const auto& lib : load_libs) load_lib(lib);
+    }
+
+    ToolSharedLibraryLoader(const google::protobuf::RepeatedPtrField<std::string>& load_libs)
+    {
+        for (const auto& lib : load_libs) load_lib(lib);
+    }
+
+    ToolSharedLibraryLoader(const std::string& lib) { load_lib(lib); }
+    ~ToolSharedLibraryLoader();
+
+  private:
+    void load_lib(const std::string& lib);
+
+  private:
+    std::vector<void*> dl_handles_;
+};
+
 } // namespace middleware
 } // namespace goby
 

--- a/src/middleware/src.cmake
+++ b/src/middleware/src.cmake
@@ -23,7 +23,6 @@ protobuf_generate_cpp(MIDDLEWARE_PROTO_SRCS MIDDLEWARE_PROTO_HDRS
   middleware/protobuf/pty_config.proto
   middleware/protobuf/navigation.proto
   middleware/protobuf/logger.proto
-  middleware/protobuf/goby_tool_config.proto
   )
 
 set(MIDDLEWARE_SRC

--- a/src/moos/goby_moos_app.h
+++ b/src/moos/goby_moos_app.h
@@ -836,7 +836,9 @@ void goby::moos::GobyMOOSAppSelector<MOOSAppType>::read_configuration(
             std::make_pair(goby::GobyFieldOptions::ConfigurationOptions::NEVER,
                            boost::program_options::options_description(od_pb_never_desc.c_str())));
 
-        goby::middleware::ConfigReader::get_protobuf_program_options(od_map, cfg->GetDescriptor());
+        std::map<std::string, std::string> environmental_var_map;
+        goby::middleware::ConfigReader::get_protobuf_program_options(od_map, cfg->GetDescriptor(),
+                                                                     environmental_var_map);
         std::vector<goby::middleware::ConfigReader::PositionalOption> positional_options;
         goby::middleware::ConfigReader::get_positional_options(cfg->GetDescriptor(),
                                                                positional_options);
@@ -854,6 +856,19 @@ void goby::moos::GobyMOOSAppSelector<MOOSAppType>::read_configuration(
                                           .positional(p)
                                           .run(),
                                       var_map);
+
+        if (!environmental_var_map.empty())
+        {
+            boost::program_options::store(
+                boost::program_options::parse_environment(
+                    od_all,
+                    [&environmental_var_map](const std::string& i_env_var) -> std::string {
+                        return environmental_var_map.count(i_env_var)
+                                   ? environmental_var_map.at(i_env_var)
+                                   : "";
+                    }),
+                var_map);
+        }
 
         boost::program_options::notify(var_map);
 

--- a/src/moos/protobuf/moos_gateway_config.proto
+++ b/src/moos/protobuf/moos_gateway_config.proto
@@ -9,7 +9,8 @@ package goby.apps.moos.protobuf;
 message GobyMOOSGatewayConfig
 {
     optional goby.middleware.protobuf.AppConfig app = 1;
-    optional goby.zeromq.protobuf.InterProcessPortalConfig interprocess = 2;
+    optional goby.zeromq.protobuf.InterProcessPortalConfig interprocess = 2
+        [(goby.field) = { cfg { env: "GOBY_INTERPROCESS" } }];
 
     message MOOSConfig
     {

--- a/src/protobuf/option_extensions.proto
+++ b/src/protobuf/option_extensions.proto
@@ -52,6 +52,7 @@ message GobyFieldOptions
             optional int32 max_count = 2 [default = 1];
         }
         optional Position position = 3;
+        optional string env = 4;
     }
     optional ConfigurationOptions cfg = 200;
 }

--- a/src/zeromq/protobuf/coroner_config.proto
+++ b/src/zeromq/protobuf/coroner_config.proto
@@ -10,7 +10,8 @@ message CoronerConfig
 {
     option (dccl.msg).unit_system = "si";
     optional goby.middleware.protobuf.AppConfig app = 1;
-    optional goby.zeromq.protobuf.InterProcessPortalConfig interprocess = 2;
+    optional goby.zeromq.protobuf.InterProcessPortalConfig interprocess = 2        [(goby.field) = { cfg { env: "GOBY_INTERPROCESS" } }];
+
 
     repeated string expected_name = 10;
 

--- a/src/zeromq/protobuf/frontseat_interface_config.proto
+++ b/src/zeromq/protobuf/frontseat_interface_config.proto
@@ -12,7 +12,8 @@ message FrontSeatInterfaceConfig
 {
     option (dccl.msg).unit_system = "si";
     optional goby.middleware.protobuf.AppConfig app = 1;
-    optional goby.zeromq.protobuf.InterProcessPortalConfig interprocess = 2;
+    optional goby.zeromq.protobuf.InterProcessPortalConfig interprocess = 2        [(goby.field) = { cfg { env: "GOBY_INTERPROCESS" } }];
+
 
     required goby.middleware.frontseat.protobuf.Config frontseat_cfg = 10;
 

--- a/src/zeromq/protobuf/geov_config.proto
+++ b/src/zeromq/protobuf/geov_config.proto
@@ -14,7 +14,8 @@ message GEOVInterfaceConfig
     };
 
     optional goby.middleware.protobuf.AppConfig app = 1;
-    optional goby.zeromq.protobuf.InterProcessPortalConfig interprocess = 2;
+    optional goby.zeromq.protobuf.InterProcessPortalConfig interprocess = 2        [(goby.field) = { cfg { env: "GOBY_INTERPROCESS" } }];
+
 
     optional bool simulation = 3 [
         (goby.field).description =

--- a/src/zeromq/protobuf/gobyd_config.proto
+++ b/src/zeromq/protobuf/gobyd_config.proto
@@ -10,7 +10,9 @@ message GobyDaemonConfig
 {
     optional goby.middleware.protobuf.AppConfig app = 1;
     optional int32 router_threads = 2 [default = 10];
-    optional goby.zeromq.protobuf.InterProcessPortalConfig interprocess = 3;
+    optional goby.zeromq.protobuf.InterProcessPortalConfig interprocess = 3
+        [(goby.field) = { cfg { env: "GOBY_INTERPROCESS" } }];
+
     optional goby.middleware.intervehicle.protobuf.PortalConfig intervehicle =
         4;
 
@@ -22,7 +24,9 @@ message GobyDaemonConfig
 message GobyIntervehiclePortalConfig
 {
     optional goby.middleware.protobuf.AppConfig app = 1;
-    optional goby.zeromq.protobuf.InterProcessPortalConfig interprocess = 2;
+    optional goby.zeromq.protobuf.InterProcessPortalConfig interprocess = 2
+            [(goby.field) = { cfg { env: "GOBY_INTERPROCESS" } }];
+
     required goby.middleware.intervehicle.protobuf.PortalConfig intervehicle =
         3;
 }

--- a/src/zeromq/protobuf/gps_config.proto
+++ b/src/zeromq/protobuf/gps_config.proto
@@ -9,7 +9,8 @@ package goby.apps.zeromq.protobuf;
 message GPSDConfig
 {
     optional goby.middleware.protobuf.AppConfig app = 1;
-    optional goby.zeromq.protobuf.InterProcessPortalConfig interprocess = 2;
+    optional goby.zeromq.protobuf.InterProcessPortalConfig interprocess = 2        [(goby.field) = { cfg { env: "GOBY_INTERPROCESS" } }];
+
 
     required goby.middleware.protobuf.TCPClientConfig gpsd = 3;
 

--- a/src/zeromq/protobuf/interprocess_config.proto
+++ b/src/zeromq/protobuf/interprocess_config.proto
@@ -7,9 +7,10 @@ message InterProcessPortalConfig
 {
     optional string platform = 1 [
         default = "default_goby_platform",
-        (goby.field).description =
-            "Name for this platform (vehicle name, mooring name, topside name, "
-            "etc.)"
+        (goby.field) = {
+            description: "Name for this platform (vehicle name, mooring name, topside name, "
+                         "etc.)"
+        }
     ];
 
     enum Transport

--- a/src/zeromq/protobuf/liaison_config.proto
+++ b/src/zeromq/protobuf/liaison_config.proto
@@ -11,7 +11,8 @@ package goby.apps.zeromq.protobuf;
 message LiaisonConfig
 {
     optional goby.middleware.protobuf.AppConfig app = 1;
-    optional goby.zeromq.protobuf.InterProcessPortalConfig interprocess = 2;
+    optional goby.zeromq.protobuf.InterProcessPortalConfig interprocess = 2         [(goby.field) = { cfg { env: "GOBY_INTERPROCESS" } }];
+
 
     optional string http_address = 10 [
         default = "localhost",

--- a/src/zeromq/protobuf/logger_config.proto
+++ b/src/zeromq/protobuf/logger_config.proto
@@ -9,7 +9,8 @@ package goby.apps.zeromq.protobuf;
 message LoggerConfig
 {
     optional goby.middleware.protobuf.AppConfig app = 1;
-    optional goby.zeromq.protobuf.InterProcessPortalConfig interprocess = 2;
+    optional goby.zeromq.protobuf.InterProcessPortalConfig interprocess = 2        [(goby.field) = { cfg { env: "GOBY_INTERPROCESS" } }];
+
 
     required string log_dir = 3;
 
@@ -26,7 +27,8 @@ message PlaybackConfig
     option (dccl.msg).unit_system = "si";
 
     optional goby.middleware.protobuf.AppConfig app = 1;
-    optional goby.zeromq.protobuf.InterProcessPortalConfig interprocess = 2;
+    optional goby.zeromq.protobuf.InterProcessPortalConfig interprocess = 2         [(goby.field) = { cfg { env: "GOBY_INTERPROCESS" } }];
+
 
     required string input_file = 10 [(goby.field) = {
         description: "Input goby_logger file to read (e.g. 'vehicle_20200204T121314.goby')"

--- a/src/zeromq/protobuf/mavlink_gateway_config.proto
+++ b/src/zeromq/protobuf/mavlink_gateway_config.proto
@@ -3,13 +3,15 @@ import "goby/middleware/protobuf/app_config.proto";
 import "goby/middleware/protobuf/serial_config.proto";
 import "goby/middleware/protobuf/udp_config.proto";
 import "goby/zeromq/protobuf/interprocess_config.proto";
+import "goby/protobuf/option_extensions.proto";
 
 package goby.apps.zeromq.protobuf;
 
 message MAVLinkGatewayConfig
 {
     optional goby.middleware.protobuf.AppConfig app = 1;
-    optional goby.zeromq.protobuf.InterProcessPortalConfig interprocess = 2;
+    optional goby.zeromq.protobuf.InterProcessPortalConfig interprocess = 2        [(goby.field) = { cfg { env: "GOBY_INTERPROCESS" } }];
+
 
     enum ConnectionType 
     {

--- a/src/zeromq/protobuf/opencpn_config.proto
+++ b/src/zeromq/protobuf/opencpn_config.proto
@@ -5,6 +5,7 @@ import "goby/middleware/protobuf/pty_config.proto";
 import "goby/middleware/protobuf/tcp_config.proto";
 import "goby/zeromq/protobuf/interprocess_config.proto";
 import "dccl/option_extensions.proto";
+import "goby/protobuf/option_extensions.proto";
 
 package goby.apps.zeromq.protobuf;
 
@@ -15,7 +16,8 @@ message OpenCPNInterfaceConfig
     };
 
     optional goby.middleware.protobuf.AppConfig app = 1;
-    optional goby.zeromq.protobuf.InterProcessPortalConfig interprocess = 2;
+    optional goby.zeromq.protobuf.InterProcessPortalConfig interprocess = 2
+        [(goby.field) = { cfg { env: "GOBY_INTERPROCESS" } }];
 
     oneof io
     {

--- a/src/zeromq/protobuf/terminate_config.proto
+++ b/src/zeromq/protobuf/terminate_config.proto
@@ -10,7 +10,8 @@ message TerminateConfig
 {
     option (dccl.msg).unit_system = "si";
     optional goby.middleware.protobuf.AppConfig app = 1;
-    optional goby.zeromq.protobuf.InterProcessPortalConfig interprocess = 2;
+    optional goby.zeromq.protobuf.InterProcessPortalConfig interprocess = 2         [(goby.field) = { cfg { env: "GOBY_INTERPROCESS" } }];
+
     repeated string target_name = 3;
     repeated uint32 target_pid = 4;
 

--- a/src/zeromq/protobuf/tool_config.proto
+++ b/src/zeromq/protobuf/tool_config.proto
@@ -124,7 +124,7 @@ message PublishToolConfig
 
     repeated string load_shared_library = 20 [(goby.field) = {
         description: "Load this shared library containing compiled Protobuf/DCCL messages.",
-        cfg { cli_short: "l" }
+        cfg { cli_short: "l" env: "GOBY_TOOL_LOAD_SHARED_LIBRARY" }
     }];
 }
 
@@ -163,7 +163,7 @@ message SubscribeToolConfig
 
     repeated string load_shared_library = 20 [(goby.field) = {
         description: "Load this shared library containing compiled Protobuf/DCCL messages.",
-        cfg { cli_short: "l" }
+        cfg { cli_short: "l" env: "GOBY_TOOL_LOAD_SHARED_LIBRARY" }
     }];
 
     optional bool include_internal_groups = 30 [default = false];

--- a/src/zeromq/protobuf/tool_config.proto
+++ b/src/zeromq/protobuf/tool_config.proto
@@ -105,7 +105,9 @@ message PublishToolConfig
 
     optional goby.middleware.protobuf.AppConfig app = 1
         [(goby.field) = { cfg { action: DEVELOPER } }];
-    optional goby.zeromq.protobuf.InterProcessPortalConfig interprocess = 2;
+    optional goby.zeromq.protobuf.InterProcessPortalConfig interprocess = 2
+            [(goby.field) = { cfg { env: "GOBY_INTERPROCESS" } }];
+
 
     required string group = 10 [(goby.field) = {
         description: "Group as string",
@@ -138,7 +140,9 @@ message SubscribeToolConfig
 
     optional goby.middleware.protobuf.AppConfig app = 1
         [(goby.field) = { cfg { action: DEVELOPER } }];
-    optional goby.zeromq.protobuf.InterProcessPortalConfig interprocess = 2;
+    optional goby.zeromq.protobuf.InterProcessPortalConfig interprocess = 2
+            [(goby.field) = { cfg { env: "GOBY_INTERPROCESS" } }];
+
 
     optional string group_regex = 10 [
         default = ".*",

--- a/src/zeromq/protobuf/tool_config.proto
+++ b/src/zeromq/protobuf/tool_config.proto
@@ -18,6 +18,7 @@ message ZeroMQToolConfig
 
     enum Action
     {
+        // tools
         help = 0 [(goby.ev).cfg = {
             short_help_msg: "Print usage information",
             full_help_msg: "Usage: \"goby zmq help [action]\"\n"
@@ -27,7 +28,7 @@ message ZeroMQToolConfig
             external_command: "goby_terminate"
         }];
         publish = 3 [(goby.ev).cfg = {
-            short_help_msg: "Publish message (on interprocess)",
+            short_help_msg: "Publish a message (on interprocess)",
         }];
         subscribe = 4 [(goby.ev).cfg = {
             short_help_msg: "Subscribe to messages (on interprocess)",
@@ -35,6 +36,54 @@ message ZeroMQToolConfig
         playback = 5 [(goby.ev).cfg = {
             short_help_msg: "Playback .goby log files",
             external_command: "goby_playback"
+        }];
+
+        // core apps pub/sub
+        daemon = 10 [(goby.ev).cfg = {
+            short_help_msg: "Publish/subscribe broker for interprocess and, optionally, intervehicle portal",
+            external_command: "gobyd"
+        }];
+        logger = 11 [(goby.ev).cfg = {
+            short_help_msg: "Binary logger of interprocess messages",
+            external_command: "goby_logger"
+        }];
+        coroner = 12 [(goby.ev).cfg = {
+            short_help_msg: "Monitoring of process health",
+            external_command: "goby_coroner"
+        }];
+        intervehicle_portal = 13 [(goby.ev).cfg = {
+            short_help_msg: "Standalone intervehicle portal",
+            external_command: "goby_intervehicle_portal"
+        }];
+
+        // sensors
+        gps = 20 [(goby.ev).cfg = {
+            short_help_msg: "GPSD client that publishes data into Goby pub/sub",
+            external_command: "goby_gps"
+        }];
+        frontseat_interface = 21 [(goby.ev).cfg = {
+            short_help_msg: "Interface to vehicle Frontseat system (control system)",
+            external_command: "goby_frontseat_interface"
+        }];
+
+        // ui
+        geov = 30 [(goby.ev).cfg = {
+            short_help_msg: "Interface to Google Earth via GEOV (https://gobysoft.org/geov/)",
+            external_command: "goby_geov_interface"
+        }];
+        liaison = 31 [(goby.ev).cfg = {
+            short_help_msg: "Web-based UI for control/monitoring of Goby pub/sub",
+            external_command: "goby_liaison"
+        }];
+        opencpn = 32 [(goby.ev).cfg = {
+            short_help_msg: "Interface to the OpenCPN GUI",
+            external_command: "goby_opencpn_interface"
+        }];
+
+        // external
+        moos_gateway = 40 [(goby.ev).cfg = {
+            short_help_msg: "Gateway to the MOOS middleware",
+            external_command: "goby_moos_gateway"
         }];
     }
     optional Action action = 2 [


### PR DESCRIPTION
- Refactor 'goby' tool code for future expansion
- Add ability to read config from environmental variable with (goby.field).cfg.env extension
- Add 'goby protobuf show' command. Fixes #302 

```
export GOBY_TOOL_LOAD_SHARED_LIBRARY=/home/toby/opensource/goby3-examples/build/lib/libgoby3_example_messages.so

> goby protobuf show protobuf.NavigationReport
============== protobuf.NavigationReport============== 
message NavigationReport {
  enum VehicleClass {
    AUV = 1;
    USV = 2;
    SHIP = 3;
  }
  required double x = 1;
  required double y = 2;
  required double z = 3;
  optional .protobuf.NavigationReport.VehicleClass veh_class = 4;
  optional bool battery_ok = 5;
}

```