### PR TITLE
Goby Intervehicle Portal - Reattempt comm link connection feature

### DIFF
--- a/src/middleware/protobuf/intervehicle.proto
+++ b/src/middleware/protobuf/intervehicle.proto
@@ -45,6 +45,16 @@ message PortalConfig
             (goby.field).description = "Time between modem reports",
             (dccl.field) = { units { base_dimensions: "T" } }
         ];
+
+        optional bool required = 22 [
+            default = true,
+            (goby.field).description = "Specify if the modem is necessary for an application's communications archictecture."
+        ];
+    
+        optional uint32 connection_attempts = 23 [
+            default = 1,
+            (goby.field).description = "The number of times to re-attempt initialising the link. Set to 0 for infinite attempts."
+        ];
     }
 
     repeated LinkConfig link = 1;


### PR DESCRIPTION
Problem described in Issue #315

Initial proposed solution. However, changing from 

```c++
while (drivers_ready < modem_drivers_.size())
```

to

```c++
while (drivers_ready_ > 1)
```

May cause issues with subscriptions for certain drivers. Something to be investigated. 