### PR TITLE
3.0 fix dynamic buffer bugs

### DIFF
--- a/src/acomms/buffer/dynamic_buffer.h
+++ b/src/acomms/buffer/dynamic_buffer.h
@@ -223,15 +223,18 @@ template <typename T, typename Clock = goby::time::SteadyClock> class DynamicSub
               size_type max_bytes = std::numeric_limits<size_type>::max(),
               typename Clock::duration ack_timeout = std::chrono::microseconds(0)) const
     {
-        if (empty())
+        // this order matters - some checks depend on previous checks
+        if (empty()) // no messages at all
             return std::make_pair(-std::numeric_limits<double>::infinity(), ValueResult::EMPTY);
-        else if (in_blackout(reference))
+        else if (in_blackout(reference)) // in blackout
             return std::make_pair(-std::numeric_limits<double>::infinity(),
                                   ValueResult::IN_BLACKOUT);
-        else if (all_waiting_for_ack(reference, ack_timeout))
+        else if (all_waiting_for_ack(reference, ack_timeout)) // all messages waiting for ack
             return std::make_pair(-std::numeric_limits<double>::infinity(),
                                   ValueResult::ALL_MESSAGES_WAITING_FOR_ACK);
-        else if (top_size(reference, ack_timeout) > max_bytes)
+        else if (
+            top_size(reference, ack_timeout) >
+            max_bytes) // check if the top message size is greater than max_bytes - assumes !ALL_MESSAGES_WAITING_FOR_ACK so must go after that check
             return std::make_pair(-std::numeric_limits<double>::infinity(),
                                   ValueResult::NEXT_MESSAGE_TOO_LARGE);
 

--- a/src/acomms/buffer/dynamic_buffer.h
+++ b/src/acomms/buffer/dynamic_buffer.h
@@ -142,6 +142,10 @@ template <typename T, typename Clock = goby::time::SteadyClock> class DynamicSub
             cfg_.set_ttl(ttl_sum / ttl_divisor);
         if (value_base_divisor > 0)
             cfg_.set_value_base(value_base_sum / value_base_divisor);
+
+        // avoid first access being in blackout
+        last_access_ -=
+            goby::time::convert_duration<typename Clock::duration>(cfg_.blackout_time_with_units());
     }
 
     /// \brief Return the aggregate configuration

--- a/src/middleware/transport/intervehicle/driver_thread.cpp
+++ b/src/middleware/transport/intervehicle/driver_thread.cpp
@@ -440,8 +440,9 @@ void goby::middleware::intervehicle::ModemDriverThread::_data_request(
                     pending_ack_[frame_number].push_back(buffer_value);
                 }
             }
-            catch (goby::acomms::DynamicBufferNoDataException&)
+            catch (goby::acomms::DynamicBufferNoDataException& e)
             {
+                glog.is_debug1() && glog << group(glog_group_) << e.what() << std::endl;
                 break;
             }
         }


### PR DESCRIPTION
Major:
- Fixes regression introduced in #292 (Goby 3.0.17) where any queue with ack_wait would throw a DynamicBufferNoDataException and abort the priority contest, thus providing no data at all.

Minor:
- Fix first queue request not returning data due to blackout. Now the first request will return data before triggering the blackout window.