### PR TITLE
3.0 fix compile warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,7 @@ add_custom_command(OUTPUT ShareLink COMMAND ${CMAKE_COMMAND} -E create_symlink $
 add_custom_target(share_link ALL DEPENDS ShareLink)
 
 
-set(GOBY_DEBUG_OPTIONS -Wall -Werror -Wno-sign-compare -Wno-unknown-warning-option -Wno-vla-cxx-extension)
+set(GOBY_DEBUG_OPTIONS -Wall -Werror -Wno-sign-compare -Wno-unknown-warning-option)
 add_compile_options("$<$<CONFIG:DEBUG>:${GOBY_DEBUG_OPTIONS}>")
 add_compile_options("$<$<CXX_COMPILER_ID:Clang>:-Wdocumentation>")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -277,6 +277,7 @@ if(enable_janus_acomms)
     fftw3
     asound
     pulse-simple
+    pulse
     ${JANUS_ROOT_DIR}/build/libplugin_016_00.so
     ${JANUS_ROOT_DIR}/build/libplugin_016_01.so
   )

--- a/src/acomms/protobuf/amac.proto
+++ b/src/acomms/protobuf/amac.proto
@@ -1,5 +1,4 @@
 syntax = "proto2";
-import "goby/protobuf/option_extensions.proto";
 import "dccl/option_extensions.proto";
 import "goby/acomms/protobuf/modem_message.proto";
 

--- a/src/acomms/protobuf/file_transfer.proto
+++ b/src/acomms/protobuf/file_transfer.proto
@@ -1,5 +1,4 @@
 syntax = "proto2";
-import "goby/protobuf/option_extensions.proto";
 import "dccl/option_extensions.proto";
 
 package goby.acomms.protobuf;

--- a/src/acomms/protobuf/iridium_driver.proto
+++ b/src/acomms/protobuf/iridium_driver.proto
@@ -1,5 +1,4 @@
 syntax = "proto2";
-import "goby/protobuf/option_extensions.proto";
 import "goby/acomms/protobuf/driver_base.proto";
 import "goby/acomms/protobuf/modem_message.proto";
 import "dccl/option_extensions.proto";

--- a/src/acomms/protobuf/iridium_shore_driver.proto
+++ b/src/acomms/protobuf/iridium_shore_driver.proto
@@ -1,5 +1,4 @@
 syntax = "proto2";
-import "goby/protobuf/option_extensions.proto";
 import "goby/acomms/protobuf/driver_base.proto";
 import "goby/acomms/protobuf/iridium_driver.proto";
 

--- a/src/acomms/protobuf/janus_driver.proto
+++ b/src/acomms/protobuf/janus_driver.proto
@@ -4,7 +4,6 @@ syntax = "proto2";
 import "goby/protobuf/option_extensions.proto";
 import "dccl/option_extensions.proto";
 import "goby/acomms/protobuf/driver_base.proto"; // load up message DriverBaseConfig
-import "goby/acomms/protobuf/modem_message.proto";
 
 package goby.acomms.janus.protobuf;
 message Config

--- a/src/acomms/protobuf/modem_driver_status.proto
+++ b/src/acomms/protobuf/modem_driver_status.proto
@@ -1,5 +1,4 @@
 syntax = "proto2";
-import "goby/protobuf/option_extensions.proto";
 import "dccl/option_extensions.proto";
 
 package goby.acomms.protobuf;

--- a/src/acomms/protobuf/mosh_packet.proto
+++ b/src/acomms/protobuf/mosh_packet.proto
@@ -1,5 +1,4 @@
 syntax = "proto2";
-import "goby/protobuf/option_extensions.proto";
 import "dccl/option_extensions.proto";
 
 package goby.acomms.protobuf;

--- a/src/acomms/protobuf/network_ack.proto
+++ b/src/acomms/protobuf/network_ack.proto
@@ -1,5 +1,4 @@
 syntax = "proto2";
-import "goby/protobuf/option_extensions.proto";
 import "dccl/option_extensions.proto";
 
 package goby.acomms.protobuf;

--- a/src/acomms/protobuf/route.proto
+++ b/src/acomms/protobuf/route.proto
@@ -1,5 +1,4 @@
 syntax = "proto2";
-import "goby/protobuf/option_extensions.proto";
 import "dccl/option_extensions.proto";
 
 package goby.acomms.protobuf;

--- a/src/acomms/protobuf/store_server_config.proto
+++ b/src/acomms/protobuf/store_server_config.proto
@@ -1,4 +1,5 @@
-import "goby/protobuf/option_extensions.proto";
+syntax = "proto2";
+
 import "goby/middleware/protobuf/app_config.proto";
 import "dccl/option_extensions.proto";
 import "goby/middleware/protobuf/tcp_config.proto";

--- a/src/acomms/protobuf/store_server_driver.proto
+++ b/src/acomms/protobuf/store_server_driver.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 import "goby/acomms/protobuf/driver_base.proto"; 
 import "goby/acomms/protobuf/modem_message.proto";
 

--- a/src/acomms/protobuf/time_update.proto
+++ b/src/acomms/protobuf/time_update.proto
@@ -1,5 +1,4 @@
 syntax = "proto2";
-import "goby/protobuf/option_extensions.proto";
 import "dccl/option_extensions.proto";
 
 package goby.acomms.protobuf;

--- a/src/apps/zeromq/geov/geov.cpp
+++ b/src/apps/zeromq/geov/geov.cpp
@@ -391,9 +391,9 @@ std::string goby::apps::zeromq::GEOVInterface::escape(const std::string& s)
 {
     unsigned long l = s.length();
 
-    char c[l * 2 + 1];
-    mysql_real_escape_string(core_connection_, c, s.c_str(), l);
-    return c;
+    std::vector<char> c(l*2+1, 0);
+    mysql_real_escape_string(core_connection_, c.data(), s.c_str(), l);
+    return std::string(c.begin(), c.end());
 }
 
 void goby::apps::zeromq::GEOVInterface::print_error(MYSQL* conn, const char* message)

--- a/src/apps/zeromq/liaison/liaison.cpp
+++ b/src/apps/zeromq/liaison/liaison.cpp
@@ -210,28 +210,19 @@ goby::apps::zeromq::Liaison::Liaison()
 
         std::string static_resources = "/css,/fonts,/images,/resources";
 
-        // create a set of fake argc / argv for Wt::WServer
         std::vector<std::string> wt_argv_vec;
-        std::string str = cfg().app().name() + " --docroot " + doc_root + ";" + static_resources +
-                          " --http-port " + goby::util::as<std::string>(cfg().http_port()) +
-                          " --http-address " + cfg().http_address() + " " +
-                          cfg().additional_wt_http_params();
+        std::string str = " --docroot " + doc_root + ";" + static_resources + " --http-port " +
+                          goby::util::as<std::string>(cfg().http_port()) + " --http-address " +
+                          cfg().http_address() + " " + cfg().additional_wt_http_params();
         boost::split(wt_argv_vec, str, boost::is_any_of(" "));
-
-        char* wt_argv[wt_argv_vec.size()];
 
         glog.is(DEBUG1) && glog << "setting Wt cfg to: " << std::flush;
         for (int i = 0, n = wt_argv_vec.size(); i < n; ++i)
         {
-            wt_argv[i] = new char[wt_argv_vec[i].size() + 1];
-            strcpy(wt_argv[i], wt_argv_vec[i].c_str());
-            glog.is(DEBUG1) && glog << "\t" << wt_argv[i] << std::endl;
+            glog.is(DEBUG1) && glog << "\t" << wt_argv_vec[i] << std::endl;
         }
 
-        wt_server_.setServerConfiguration(wt_argv_vec.size(), wt_argv);
-
-        // delete our fake argv
-        for (int i = 0, n = wt_argv_vec.size(); i < n; ++i) delete[] wt_argv[i];
+        wt_server_.setServerConfiguration(cfg().app().name(), wt_argv_vec);
 
         wt_server_.addEntryPoint(
             Wt::EntryPointType::Application,

--- a/src/middleware/frontseat/simulator/basic/basic_simulator_frontseat_driver_config.proto
+++ b/src/middleware/frontseat/simulator/basic/basic_simulator_frontseat_driver_config.proto
@@ -1,6 +1,5 @@
 syntax = "proto2";
 import "goby/middleware/protobuf/frontseat_config.proto";
-import "goby/protobuf/option_extensions.proto";
 
 package goby.middleware.frontseat.protobuf;
 

--- a/src/middleware/frontseat/waveglider/waveglider_sv2_frontseat_driver_config.proto
+++ b/src/middleware/frontseat/waveglider/waveglider_sv2_frontseat_driver_config.proto
@@ -1,6 +1,5 @@
 syntax = "proto2";
 import "goby/middleware/protobuf/frontseat_config.proto";
-import "goby/protobuf/option_extensions.proto";
 
 package goby.middleware.frontseat.protobuf;
 

--- a/src/middleware/transport/detail/subscription_store.h
+++ b/src/middleware/transport/detail/subscription_store.h
@@ -222,7 +222,7 @@ template <typename Data> class SubscriptionStore : public SubscriptionStoreBase
                 // between _poll_all() and wait(), where the condition variable
                 // signal would be lost
 
-                std::lock_guard<std::timed_mutex>(*data_protection.poller_mutex);
+                std::lock_guard<std::timed_mutex> l(*data_protection.poller_mutex);
             }
             data_protection.poller_cv->notify_all();
         }

--- a/src/moos/protobuf/bluefin_driver.proto
+++ b/src/moos/protobuf/bluefin_driver.proto
@@ -1,6 +1,5 @@
 syntax = "proto2";
 import "goby/acomms/protobuf/driver_base.proto";
-import "dccl/option_extensions.proto";
 
 package goby.moos.bluefin.protobuf;
 

--- a/src/moos/transitional/dccl_constants.h
+++ b/src/moos/transitional/dccl_constants.h
@@ -195,14 +195,14 @@ inline bool hex_string2char_array(unsigned char* c, const std::string& s, const 
 /// \brief return a string represented the binary value of `l` for `bits` number of bits which reads MSB -> LSB
 inline std::string long2binary_string(unsigned long l, unsigned short bits)
 {
-    char s[bits + 1];
+    std::string s(bits + 1, '\0');
     for (unsigned int i = 0; i < bits; i++)
     {
         s[bits - i - 1] = (l & 1) ? '1' : '0';
         l >>= 1;
     }
     s[bits] = '\0';
-    return (std::string)s;
+    return s;
 }
 
 /// \brief converts a binary string ("1000101010101010") into a hex string ("8AAA")
@@ -210,7 +210,7 @@ inline std::string binary_string2hex_string(const std::string& bs)
 {
     std::string hs;
     auto bytes = (unsigned int)(std::ceil(bs.length() / 8.0));
-    unsigned char c[bytes];
+    std::vector<unsigned char> c(bytes, 0);
 
     for (size_t i = 0; i < bytes; ++i)
     {
@@ -218,7 +218,7 @@ inline std::string binary_string2hex_string(const std::string& bs)
         c[i] = (char)b.to_ulong();
     }
 
-    char_array2hex_string(c, hs, bytes);
+    char_array2hex_string(c.data(), hs, bytes);
 
     return hs;
 }
@@ -229,9 +229,9 @@ inline std::string binary_string2hex_string(const std::string& bs)
 inline std::string hex_string2binary_string(const std::string& bs)
 {
     int bytes = bs.length() / 2;
-    unsigned char c[bytes];
+    std::vector<unsigned char> c(bytes, 0);
 
-    hex_string2char_array(c, bs, bytes);
+    hex_string2char_array(c.data(), bs, bytes);
 
     std::string hs;
 

--- a/src/test/acomms/dccl3/header.proto
+++ b/src/test/acomms/dccl3/header.proto
@@ -1,5 +1,4 @@
 syntax = "proto2";
-import "goby/protobuf/option_extensions.proto";
 import "dccl/option_extensions.proto";
 
 package goby.test.acomms.protobuf;

--- a/src/test/acomms/dccl3/test.proto
+++ b/src/test/acomms/dccl3/test.proto
@@ -1,5 +1,4 @@
 syntax = "proto2";
-import "goby/protobuf/option_extensions.proto";
 import "dccl/option_extensions.proto";
 import "goby/test/acomms/dccl3/header.proto";
 

--- a/src/test/acomms/route1/test.proto
+++ b/src/test/acomms/route1/test.proto
@@ -1,6 +1,5 @@
 syntax = "proto2";
 import "dccl/option_extensions.proto";
-import "goby/protobuf/option_extensions.proto";
 
 package goby.test.acomms.protobuf;
 

--- a/src/test/zeromq/middleware_interprocess_forwarder/test.proto
+++ b/src/test/zeromq/middleware_interprocess_forwarder/test.proto
@@ -1,5 +1,4 @@
 syntax = "proto2";
-import "dccl/option_extensions.proto";
 
 package goby.test.zeromq.protobuf;
 

--- a/src/test/zeromq/middleware_regex/test.proto
+++ b/src/test/zeromq/middleware_regex/test.proto
@@ -1,5 +1,4 @@
 syntax = "proto2";
-import "dccl/option_extensions.proto";
 
 package goby.test.zeromq.protobuf;
 

--- a/src/test/zeromq/multi_thread_app1/test.proto
+++ b/src/test/zeromq/multi_thread_app1/test.proto
@@ -1,5 +1,4 @@
 syntax = "proto2";
-import "dccl/option_extensions.proto";
 import "goby/middleware/protobuf/app_config.proto";
 import "goby/zeromq/protobuf/interprocess_config.proto";
 

--- a/src/test/zeromq/multi_thread_app2/test.proto
+++ b/src/test/zeromq/multi_thread_app2/test.proto
@@ -1,5 +1,4 @@
 syntax = "proto2";
-import "dccl/option_extensions.proto";
 import "goby/middleware/protobuf/app_config.proto";
 import "goby/zeromq/protobuf/interprocess_config.proto";
 

--- a/src/test/zeromq/single_thread_app1/test.proto
+++ b/src/test/zeromq/single_thread_app1/test.proto
@@ -1,5 +1,4 @@
 syntax = "proto2";
-import "dccl/option_extensions.proto";
 import "goby/middleware/protobuf/app_config.proto";
 import "goby/zeromq/protobuf/interprocess_config.proto";
 

--- a/src/test/zeromq/zeromq_portal_without_interthread/test.proto
+++ b/src/test/zeromq/zeromq_portal_without_interthread/test.proto
@@ -1,6 +1,4 @@
 syntax = "proto2";
-import "dccl/option_extensions.proto";
-
 package goby.test.zeromq.protobuf;
 
 

--- a/src/util/protobuf/linebasedcomms.proto
+++ b/src/util/protobuf/linebasedcomms.proto
@@ -1,5 +1,4 @@
 syntax = "proto2";
-import "goby/protobuf/option_extensions.proto";
 
 package goby.util.protobuf;
 

--- a/src/zeromq/protobuf/bridge_config.proto
+++ b/src/zeromq/protobuf/bridge_config.proto
@@ -2,7 +2,6 @@ syntax = "proto2";
 import "goby/protobuf/option_extensions.proto";
 import "goby/middleware/protobuf/app_config.proto";
 import "goby/zeromq/protobuf/interprocess_config.proto";
-import "dccl/option_extensions.proto";
 
 import "goby/acomms/protobuf/queue.proto";
 import "goby/acomms/protobuf/route.proto";

--- a/src/zeromq/protobuf/file_transfer_config.proto
+++ b/src/zeromq/protobuf/file_transfer_config.proto
@@ -3,7 +3,6 @@ syntax = "proto2";
 import "goby/protobuf/option_extensions.proto";
 import "goby/middleware/protobuf/app_config.proto";
 import "goby/zeromq/protobuf/interprocess_config.proto";
-import "dccl/option_extensions.proto";
 
 package goby.apps.zeromq.acomms.protobuf;
 

--- a/src/zeromq/protobuf/ip_gateway_config.proto
+++ b/src/zeromq/protobuf/ip_gateway_config.proto
@@ -2,7 +2,6 @@ syntax = "proto2";
 import "goby/protobuf/option_extensions.proto";
 import "goby/middleware/protobuf/app_config.proto";
 import "goby/zeromq/protobuf/interprocess_config.proto";
-import "dccl/option_extensions.proto";
 
 import "goby/acomms/protobuf/amac_config.proto";
 import "goby/acomms/protobuf/modem_message.proto";

--- a/src/zeromq/protobuf/modemdriver_config.proto
+++ b/src/zeromq/protobuf/modemdriver_config.proto
@@ -2,7 +2,6 @@ syntax = "proto2";
 import "goby/protobuf/option_extensions.proto";
 import "goby/middleware/protobuf/app_config.proto";
 import "goby/zeromq/protobuf/interprocess_config.proto";
-import "dccl/option_extensions.proto";
 import "goby/acomms/protobuf/driver_base.proto";
 
 package goby.apps.zeromq.acomms.protobuf;

--- a/src/zeromq/protobuf/mosh_relay_config.proto
+++ b/src/zeromq/protobuf/mosh_relay_config.proto
@@ -2,7 +2,6 @@ syntax = "proto2";
 import "goby/protobuf/option_extensions.proto";
 import "goby/middleware/protobuf/app_config.proto";
 import "goby/zeromq/protobuf/interprocess_config.proto";
-import "dccl/option_extensions.proto";
 
 package goby.apps.zeromq.acomms.protobuf;
 


### PR DESCRIPTION
- Fixes #322
- Removes protoc warnings about unused imports.
- Fixes linking of janus library with lld (clang)