### PR TITLE
Improve compilation when DCCL is not built with Base64 support

### DIFF
--- a/src/acomms/modemdriver/mm_driver.cpp
+++ b/src/acomms/modemdriver/mm_driver.cpp
@@ -1464,7 +1464,14 @@ void goby::acomms::MMDriver::cardp(const NMEASentence& nmea, protobuf::ModemTran
         {
             if (mm_driver_cfg().use_base64_fdp())
             {
+#if DCCL_HAS_B64
                 frame += dccl::b64_decode(frames[f * num_fields + DATA]);
+#else
+                glog.is_die() &&
+                    glog << "DCCL compiled without Base64 support. Either set use_base64_fdp = "
+                            "false, or you can recompile DCCL and then Goby with Base64 support"
+                         << std::endl;
+#endif
             }
             else
             {

--- a/src/apps/moos/pAcommsHandler/pAcommsHandler.cpp
+++ b/src/apps/moos/pAcommsHandler/pAcommsHandler.cpp
@@ -53,17 +53,17 @@
 #include <google/protobuf/descriptor.h>            // for Descri...
 #include <google/protobuf/message.h>               // for Message
 
-#include "goby/acomms/acomms_constants.h"                     // for BROADC...
-#include "goby/acomms/bind.h"                                 // for bind
-#include "goby/acomms/connect.h"                              // for connect
-#include "goby/acomms/dccl/dccl.h"                            // for DCCLCodec
-#include "goby/acomms/modemdriver/abc_driver.h"               // for ABCDriver
-#include "goby/acomms/modemdriver/benthos_atm900_driver.h"    // for Bentho...
-#include "goby/acomms/modemdriver/driver_exception.h"         // for ModemD...
-#include "goby/acomms/modemdriver/iridium_driver.h"           // for Iridiu...
-#include "goby/acomms/modemdriver/iridium_shore_driver.h"     // for Iridiu...
-#include "goby/acomms/modemdriver/mm_driver.h"                // for MMDriver
-#include "goby/acomms/modemdriver/popoto_driver.h"            // for Popoto...
+#include "goby/acomms/acomms_constants.h"                  // for BROADC...
+#include "goby/acomms/bind.h"                              // for bind
+#include "goby/acomms/connect.h"                           // for connect
+#include "goby/acomms/dccl/dccl.h"                         // for DCCLCodec
+#include "goby/acomms/modemdriver/abc_driver.h"            // for ABCDriver
+#include "goby/acomms/modemdriver/benthos_atm900_driver.h" // for Bentho...
+#include "goby/acomms/modemdriver/driver_exception.h"      // for ModemD...
+#include "goby/acomms/modemdriver/iridium_driver.h"        // for Iridiu...
+#include "goby/acomms/modemdriver/iridium_shore_driver.h"  // for Iridiu...
+#include "goby/acomms/modemdriver/mm_driver.h"             // for MMDriver
+#include "goby/acomms/modemdriver/popoto_driver.h"         // for Popoto...
 #include "goby/acomms/modemdriver/store_server_driver.h"
 #include "goby/acomms/modemdriver/udp_driver.h"               // for UDPDriver
 #include "goby/acomms/modemdriver/udp_multicast_driver.h"     // for UDPMul...
@@ -92,7 +92,7 @@
 #include "goby/util/debug_logger.h"                           // for operat...
 #include "goby/util/protobuf/io.h"                            // for operat...
 #ifdef ENABLE_JANUS_ACOMMS
-#include "goby/acomms/modemdriver/janus_driver.h"             // for Janus...
+#include "goby/acomms/modemdriver/janus_driver.h" // for Janus...
 #endif
 
 #include "pAcommsHandler.h"
@@ -383,8 +383,12 @@ void goby::apps::moos::CpAcommsHandler::handle_flush_queue(const CMOOSMsg& msg)
 
 void goby::apps::moos::CpAcommsHandler::handle_config_file_request(const CMOOSMsg&)
 {
+#if DCCL_HAS_B64
     publish(cfg_.moos_var().prefix() + cfg_.moos_var().config_file(),
             dccl::b64_encode(cfg_.SerializeAsString()));
+#else
+#error DCCL must be compiled with Base64 support to compile pAcommsHandler.
+#endif
 }
 
 void goby::apps::moos::CpAcommsHandler::handle_driver_reset(const CMOOSMsg& /*msg*/)
@@ -681,16 +685,16 @@ void goby::apps::moos::CpAcommsHandler::create_driver(
             case goby::acomms::protobuf::DRIVER_UDP:
                 driver.reset(new goby::acomms::UDPDriver);
                 break;
-            #ifdef ENABLE_POPOTO_ACOMMS
+#ifdef ENABLE_POPOTO_ACOMMS
             case goby::acomms::protobuf::DRIVER_POPOTO:
                 driver.reset(new goby::acomms::PopotoDriver);
                 break;
-            #endif
-            #ifdef ENABLE_JANUS_ACOMMS
+#endif
+#ifdef ENABLE_JANUS_ACOMMS
             case goby::acomms::protobuf::DRIVER_JANUS:
                 driver.reset(new goby::acomms::JanusDriver);
                 break;
-            #endif
+#endif
             case goby::acomms::protobuf::DRIVER_UDP_MULTICAST:
                 driver.reset(new goby::acomms::UDPMulticastDriver);
                 break;

--- a/src/middleware/frontseat/bluefin/bluefin.cpp
+++ b/src/middleware/frontseat/bluefin/bluefin.cpp
@@ -386,10 +386,18 @@ void goby::middleware::frontseat::Bluefin::send_data_to_frontseat(const gpb::Int
 
     if (data.has_dccl_message())
     {
+#if DCCL_HAS_B64
         NMEASentence nmea("$BPDCL", NMEASentence::IGNORE);
         nmea.push_back(unix_time2nmea_time(gtime::SystemClock::now()));
         nmea.push_back(boost::trim_copy(dccl::b64_encode(data.dccl_message())));
         append_to_write_queue(nmea);
+#else
+        glog.is_die() &&
+            glog << "DCCL compiled without Base64 support, which is required for the $BPDCL "
+                    "message. To use the the $BPDCL message recompile DCCL and then Goby with "
+                    "Base64 support"
+                 << std::endl;
+#endif
     }
 
     if (data.HasExtension(gpb::bluefin_data))


### PR DESCRIPTION
When DCCL doesn't have Base64 support:

- Anything except pAcommsHandler will compile but we lose a bit of functionality:
  - Bluefin driver can't use $BPDCL
  - MicroModem driver can't use Base64 FDP.
 
- pAcommsHandler will give a friendly error.

This issue will go away entirely when we implement https://github.com/GobySoft/dccl/issues/142

Closes #86 