### PR TITLE
Add --omit-interthread option to goby_clang_tool. 

### DIFF
--- a/src/apps/middleware/clang_tool/actions.h
+++ b/src/apps/middleware/clang_tool/actions.h
@@ -54,6 +54,7 @@ struct VisualizeParameters
     std::string dot_splines;
     std::string omit_group_regex;
     std::string omit_node_regex;
+    bool omit_interthread;
 };
 
 int visualize(const std::vector<std::string>& ymls, const VisualizeParameters& params);

--- a/src/apps/middleware/clang_tool/pubsub_entry.h
+++ b/src/apps/middleware/clang_tool/pubsub_entry.h
@@ -291,7 +291,7 @@ struct Thread
                                            most_derived_name());
     }
 
-    std::string most_derived_name()
+    std::string most_derived_name() const
     {
         if (parent)
             return parent->most_derived_name();

--- a/src/apps/middleware/clang_tool/tool.cpp
+++ b/src/apps/middleware/clang_tool/tool.cpp
@@ -76,6 +76,10 @@ static cl::opt<bool> OmitDisconnected(
              "or subscribers without publishers"),
     cl::cat(Goby3ToolCategory));
 
+static cl::opt<bool> OmitInterThread("omit-interthread",
+                                     cl::desc("For '-viz', do not display interthread connections"),
+                                     cl::cat(Goby3ToolCategory));
+
 static cl::opt<std::string> OmitGroupRegex("omit-group-regex",
                                            cl::desc("Regex of groups to omit for '-viz' action"),
                                            cl::value_desc("foo.*"), cl::cat(Goby3ToolCategory));
@@ -104,7 +108,8 @@ static cl::opt<bool>
 int main(int argc, const char** argv)
 {
     llvm::Expected<clang::tooling::CommonOptionsParser> SharedOptionsParser =
-        clang::tooling::CommonOptionsParser::create(argc, argv, Goby3ToolCategory, llvm::cl::OneOrMore);
+        clang::tooling::CommonOptionsParser::create(argc, argv, Goby3ToolCategory,
+                                                    llvm::cl::OneOrMore);
 
     if (Generate)
     {
@@ -128,7 +133,8 @@ int main(int argc, const char** argv)
                                                 IncludeAll,
                                                 DotSplines,
                                                 OmitGroupRegex,
-                                                OmitNodeRegex};
+                                                OmitNodeRegex,
+                                                OmitInterThread};
 
         return goby::clang::visualize(SharedOptionsParser->getSourcePathList(), params);
     }

--- a/src/apps/middleware/clang_tool/visualize.cpp
+++ b/src/apps/middleware/clang_tool/visualize.cpp
@@ -249,6 +249,43 @@ struct Application
     std::set<PubSubEntry> intervehicle_subscribes;
 };
 
+bool is_thread_included(const Application& application, const viz::Thread& thread)
+{
+    if (g_params.omit_interthread)
+    {
+        auto check_for_non_interthread_pubsub =
+            [&thread](const std::set<PubSubEntry>& pubsubs) -> bool
+        {
+            for (const auto& entry : pubsubs)
+            {
+                if (entry.thread == thread.most_derived_name())
+                {
+                    std::cout << "Entry: " << entry << "\n thread: " << thread << std::endl;
+                    return true;
+                }
+            }
+            return false;
+        };
+
+        if (check_for_non_interthread_pubsub(application.interprocess_publishes))
+            return true;
+        if (check_for_non_interthread_pubsub(application.interprocess_subscribes))
+            return true;
+        if (check_for_non_interthread_pubsub(application.intermodule_publishes))
+            return true;
+        if (check_for_non_interthread_pubsub(application.intermodule_subscribes))
+            return true;
+        if (check_for_non_interthread_pubsub(application.intervehicle_publishes))
+            return true;
+        if (check_for_non_interthread_pubsub(application.intervehicle_subscribes))
+            return true;
+
+        return false;
+    }
+
+    return true;
+}
+
 inline bool operator<(const Application& a, const Application& b) { return a.name < b.name; }
 
 inline std::ostream& operator<<(std::ostream& os, const Application& a)
@@ -557,6 +594,9 @@ void write_thread_connections(std::ofstream& ofs, const viz::Platform& platform,
                               const viz::Module& module, const viz::Application& application,
                               const viz::Thread& thread, std::set<PubSubEntry>& disconnected_subs)
 {
+    if (g_params.omit_interthread)
+        return;
+
     std::set<PubSubEntry> disconnected_pubs;
     for (const auto& pub : thread.interthread_publishes)
     {
@@ -1001,6 +1041,9 @@ int goby::clang::visualize(const std::vector<std::string>& yamls, const Visualiz
                     const auto& thread = thread_p.second;
 
                     if (!is_node_included(thread->most_derived_name()))
+                        continue;
+
+                    if (!is_thread_included(application.second, *thread))
                         continue;
 
                     write_thread_connections(ofs, platform, module, application.second, *thread,


### PR DESCRIPTION
Use `goby_clang_tool --viz --omit-interthread` to omit the interthread pub/sub lines for a cleaner look at interprocess/intervehicle only.

Fixes #300 