### PR TITLE
Remove stale bare boost library names from goby link interface

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -256,9 +256,6 @@ target_link_libraries(goby
   dccl
   dccl_arithmetic
   ${Boost_LIBRARIES}
-  boost_filesystem
-  boost_program_options
-  boost_date_time
   protobuf::libprotobuf
   ${PROJ_LIBRARY}
   )


### PR DESCRIPTION
## Problem

`target_link_libraries(goby ...)` in `src/CMakeLists.txt` listed three bare boost library names alongside `${Boost_LIBRARIES}`:

```cmake
${Boost_LIBRARIES}
boost_filesystem
boost_program_options
boost_date_time
```

`${Boost_LIBRARIES}` already expands to the `Boost::date_time` and `Boost::program_options` imported targets found by the `goby_find_required_package` call at `src/CMakeLists.txt:222`, so `boost_program_options` and `boost_date_time` were exact duplicates.

`boost_filesystem` was worse than redundant. Goby no longer uses `boost::filesystem` anywhere:

- no `boost/filesystem` includes remain in the installed headers
- no `libgoby*.so` has a single undefined `boost::filesystem` symbol
- `filesystem` is not in `BOOST_COMPONENTS`, so `src/goby-config.cmake.in:33` never searches for it via `find_dependency`

Despite never being searched for, the bare name was exported verbatim into `goby_core-config.cmake`'s `INTERFACE_LINK_LIBRARIES`, which CMake passes through to the linker as `-lboost_filesystem`. Every downstream consumer therefore needed `libboost-filesystem-dev` installed purely to satisfy a link flag for a library nothing calls into.

The goby packages pull in the *runtime* `libboost_filesystem.so.1.83.0` as a transitive dependency, but nothing installs the `-dev` package that provides the `.so` symlink. On such a system every downstream link fails:

```
/usr/bin/ld: cannot find -lboost_filesystem
```

This is easy to miss in CI because GitHub's `ubuntu-24.04` runner image and the `gobysoft/goby3-*-build-base` images all ship boost dev packages preinstalled.

Bare names also bypass `find_package` entirely, so they resolve only when the matching `-dev` symlinks happen to be present.

## Change

Deletes the three bare names. `${Boost_LIBRARIES}` and its imported targets carry the correct link information on their own.

## Verification

Both `libboost_filesystem.so` and `libboost_filesystem.a` were removed from the system so that `-lboost_filesystem` was genuinely unresolvable, leaving only the versioned runtime `libboost_filesystem.so.1.83.0`. Then:

- **goby3** configured and built to 100% with this change, all apps linked. Built with `-Dbuild_moos=OFF`, so the MOOS targets were not exercised.
- **goby3-examples** built to 100% against it via `GOBY_DIR`, producing all 36 binaries; `goby3_example_basic_interthread --help` runs. The system's stale `goby_core-config.cmake` was restored to its packaged state first, so this exercises the source fix rather than a hand-patched config.
- `boost_filesystem` no longer appears in any generated `.cmake` export.
- `libgoby.so` still correctly lists `libboost_program_options.so.1.83.0` in its `NEEDED` entries, confirming the imported targets from `${Boost_LIBRARIES}` provide the real link information.

## Notes

`src/moos/CMakeLists.txt:48` and the four `src/apps/moos/*/CMakeLists.txt` files also link `${Boost_LIBRARIES}`, but they use the variable correctly with no bare names, so they need no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EHzWpMsnphbjjE51kvAYgJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01EHzWpMsnphbjjE51kvAYgJ)_