### PR TITLE
Resolve Goby's proto directory when a Python application is declared

### DIFF
--- a/cmake_modules/GobyPython.cmake
+++ b/cmake_modules/GobyPython.cmake
@@ -80,12 +80,18 @@ find_program(GOBY_PROTOC_EXECUTABLE NAMES protoc)
 # AppConfig imports dccl/option_extensions.proto, so any application configuration needs it
 find_path(GOBY_DCCL_PROTO_DIR dccl/option_extensions.proto)
 
-# The include directory holding Goby's own .proto files, in this project or in a consumer of it
-if(goby_INC_DIR)
-  set(GOBY_PROTO_DIR "${goby_INC_DIR}")
-elseif(GOBY_INCLUDE_DIR)
-  set(GOBY_PROTO_DIR "${GOBY_INCLUDE_DIR}")
-endif()
+# The include directory holding Goby's own .proto files, in this project or in a consumer of it.
+# Resolved when an application is declared rather than here: neither variable is necessarily set
+# by the time this module is included.
+function(GOBY_RESOLVE_PROTO_DIR out_var)
+  if(GOBY_PROTO_DIR)
+    set(${out_var} "${GOBY_PROTO_DIR}" PARENT_SCOPE)
+  elseif(goby_INC_DIR)
+    set(${out_var} "${goby_INC_DIR}" PARENT_SCOPE)
+  else()
+    set(${out_var} "${GOBY_INCLUDE_DIR}" PARENT_SCOPE)
+  endif()
+endfunction()
 
 function(GOBY_ADD_PYTHON_APP)
   set(options)
@@ -174,10 +180,16 @@ function(GOBY_ADD_PYTHON_APP)
   set(_proto_dir "${_out_dir}/proto")
 
   if(GAPA_PYTHON_PROTOS)
+    goby_resolve_proto_dir(_goby_proto_dir)
+    if(NOT _goby_proto_dir)
+      message(FATAL_ERROR "goby_add_python_app: cannot find Goby's .proto files, which every "
+        "application configuration imports. Set GOBY_PROTO_DIR to the directory holding them.")
+    endif()
+
     file(MAKE_DIRECTORY "${_proto_dir}")
 
     # the caller's directories first: they decide the module paths
-    set(_import_dirs ${GAPA_PROTO_IMPORT_DIRS} ${GOBY_PROTO_DIR} ${GOBY_DCCL_PROTO_DIR})
+    set(_import_dirs ${GAPA_PROTO_IMPORT_DIRS} ${_goby_proto_dir} ${GOBY_DCCL_PROTO_DIR})
     set(_import_args)
     set(_seen_dirs)
     foreach(_dir ${_import_dirs})

--- a/src/goby-config.cmake.in
+++ b/src/goby-config.cmake.in
@@ -37,6 +37,8 @@ find_dependency(DCCL)
 find_dependency(Protobuf)
 endif()
 
+get_target_property(GOBY_INCLUDE_DIR goby INTERFACE_INCLUDE_DIRECTORIES)
+
 # so that a consumer can include(GobyJulia), which defines targets and so is not automatic
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
 
@@ -52,8 +54,6 @@ if(EXISTS ${CMAKE_CURRENT_LIST_DIR}/GobyPython.cmake)
   endif()
   include(${CMAKE_CURRENT_LIST_DIR}/GobyPython.cmake)
 endif()
-
-get_target_property(GOBY_INCLUDE_DIR goby INTERFACE_INCLUDE_DIRECTORIES)
 
 # goby_clang_tool interfaces files
 get_filename_component(GOBY_INTERFACES_DIR ${GOBY_INCLUDE_DIR}/../share/goby/interfaces ABSOLUTE)


### PR DESCRIPTION
`GobyPython.cmake` computed `GOBY_PROTO_DIR` at include time, where neither `goby_INC_DIR` (set later in Goby's own `CMakeLists.txt`) nor `GOBY_INCLUDE_DIR` (set later in `goby-config.cmake`) exists yet, so it was always empty. protoc then had no import path for the `goby/` .proto files that every application configuration imports, and building a Python application in a downstream project fails:

```
config.proto:2:1: Import "goby/middleware/protobuf/app_config.proto" was not found or had errors.
config.proto:3:1: Import "goby/zeromq/protobuf/interprocess_config.proto" was not found or had errors.
```

Two things hid this:

- Goby's own test app passes `PROTO_IMPORT_DIRS ${goby_INC_DIR}`, which happens to cover it.
- Against an installed Goby, `GOBY_DCCL_PROTO_DIR` resolves to `/usr/include`, which also holds the goby protos — so it works by accident at the default prefix and breaks anywhere else.

`goby_add_python_app()` now resolves the directory itself, where both variables are set, and says so when it cannot find one instead of leaving it to protoc. `goby-config.cmake` also sets `GOBY_INCLUDE_DIR` before the modules that want it are included.

### Verification

Built goby3 and goby3-examples (`-Dbuild_python=ON -Denable_julia_examples=ON`, `GOBY_DIR` pointing at an uninstalled Goby build) to completion, and ran both examples against `gobyd`:

| | result |
|---|---|
| `goby_test_python_unit`, `goby_test_python_app` | pass |
| Python publisher → Python subscriber | 237 messages |
| Python publisher → C++ `basic_interprocess_subscriber` | 237 messages |
| Julia publisher → Julia subscriber | 233 messages |

---
_Generated by [Claude Code](https://claude.ai/code/session_016nsf4QMNTfUxkyWh4xGaok)_