### PR TITLE
Keep protobuf import directories that the build has yet to create

### DIFF
--- a/cmake_modules/GobyPython.cmake
+++ b/cmake_modules/GobyPython.cmake
@@ -188,13 +188,18 @@ function(GOBY_ADD_PYTHON_APP)
 
     file(MAKE_DIRECTORY "${_proto_dir}")
 
-    # the caller's directories first: they decide the module paths
+    # the caller's directories first: they decide the module paths. Existence is deliberately not
+    # checked: these are usually build tree directories that nothing has written to yet when the
+    # application is declared, and dropping one silently moves the module protoc writes.
     set(_import_dirs ${GAPA_PROTO_IMPORT_DIRS} ${_goby_proto_dir} ${GOBY_DCCL_PROTO_DIR})
     set(_import_args)
     set(_seen_dirs)
     foreach(_dir ${_import_dirs})
+      if("${_dir}" STREQUAL "" OR "${_dir}" MATCHES "NOTFOUND$")
+        continue()
+      endif()
       get_filename_component(_abs_dir "${_dir}" ABSOLUTE)
-      if(IS_DIRECTORY "${_abs_dir}" AND NOT "${_abs_dir}" IN_LIST _seen_dirs)
+      if(NOT "${_abs_dir}" IN_LIST _seen_dirs)
         list(APPEND _seen_dirs "${_abs_dir}")
         list(APPEND _import_args -I "${_abs_dir}")
       endif()


### PR DESCRIPTION
`goby_add_python_app()` filtered its protobuf import directories through `IS_DIRECTORY` at the point the application is declared. But `goby_INC_DIR` is a build tree directory that nothing has written to yet — `add_subdirectory(src)` (line 225) runs before the `configure_file()` calls that populate it (lines 246-248). On a build tree that configures from scratch it was therefore dropped from every call, leaving protoc without the `goby/` imports:

```
goby/middleware/protobuf/app_config.proto: File not found.
test.proto:2:1: Import "goby/middleware/protobuf/app_config.proto" was not found or had errors.
```

The generated command shows the directory simply absent — only DCCL's `/usr/include` and the .proto's own directory (which is added unconditionally, and is why the parent looked like it existed):

```
protoc --python_out .../goby_test_python_app/proto \
       -I /usr/include -I .../include/goby/test/python \
       .../include/goby/test/python/test.proto
```

The same list also drives the module path derived for each .proto, so even where protoc succeeded the module moved: `goby/test/python/test_pb2.py` became a flat `test_pb2.py`, which `PROTO_MODULES goby.test.python.test_pb2` could then not import.

An existing build tree hid this, which is why it showed up on builds that configure from scratch rather than on incremental ones. The fix drops the existence check — protoc only warns about an import directory that does not exist, and by the time the command runs it does — and skips only empty and `NOTFOUND` entries.

### Verification

Reproduced and fixed against a scratch build tree (`-Dbuild_python=ON -Denable_testing=ON`):

| | import dirs passed to protoc | module written |
|---|---|---|
| before | `-I /usr/include -I .../include/goby/test/python` | `test_pb2.py` |
| after | `-I .../include -I /usr/include -I .../include/goby/test/python` | `goby/test/python/test_pb2.py` |

`goby_test_python_unit` and `goby_test_python_app` both pass in that clean tree.

---
_Generated by [Claude Code](https://claude.ai/code/session_016nsf4QMNTfUxkyWh4xGaok)_