### PR TITLE
Update CircleCI config to version 2.1 and normalize job names

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,7 @@ job-template-deb-amd64: &job-template-deb-amd64
     - run: &run-import-gpg
         name: Import GPG key
         command: echo -e "$GPG_KEY" | gpg --import
-    - attach-workspace: &attach-src-workspace
+    - attach_workspace: &attach-src-workspace
         at: /root/src
     - run: &run-extract-src
         name: Extract the original source tarball
@@ -673,9 +673,9 @@ jobs:
           fingerprints:
             - "cd:15:c9:43:48:20:c9:56:58:9e:91:01:74:0d:fe:d2"
       - run: *run-import-gpg
-      - attach-workspace:
+      - attach_workspace:
           at: /root/deb
-      - attach-workspace: *attach-src-workspace
+      - attach_workspace: *attach-src-workspace
       - run:
           name: Move original source into output directory
           command: mv /root/src/* /root/deb

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,14 +230,13 @@ filter-template-non-master: &filter-template-non-master
         - "3.0"
         
 ## Begin actual config
-version: 2
+version: 2.1
 workflows:
-  version: 2
   commit:
     jobs:
 
 
-      - amd64+tsan-build:
+      - amd64-tsan-build:
           <<: *filter-template-non-master
       - amd64-bookworm-build:        
           <<: *filter-template-non-master
@@ -361,13 +360,13 @@ workflows:
             - arm64-resolute-deb-build
             - armhf-resolute-deb-build
             
-      - amd64+scan-build:
+      - amd64-scan-build:
           <<: *filter-template-non-master
-      - amd64+asan-build:
+      - amd64-asan-build:
           <<: *filter-template-master-only
 
 
-#      - amd64+ubsan-build:
+#      - amd64-ubsan-build:
 #          <<: *filter-template-master-only          
           
 jobs:
@@ -577,7 +576,7 @@ jobs:
       <<: *environment-template-resolute
       <<: *environment-template-armhf
       
-  amd64+scan-build:
+  amd64-scan-build:
     <<: *job-template-sanitizers
     steps:
       - checkout
@@ -596,7 +595,7 @@ jobs:
       - store_artifacts:
           path: /tmp/scan-build.tar.gz
           when: on_fail
-  amd64+asan-build:
+  amd64-asan-build:
     <<: *job-template-sanitizers
     steps:
       - checkout
@@ -608,7 +607,7 @@ jobs:
       - run: &run-tests-sanitizers
           name: Run tests
           command: cd build && ctest --output-on-failure
-  amd64+tsan-build:
+  amd64-tsan-build:
     # Use machine executor (not Docker) so we can set sysctl for ThreadSanitizer
     machine:
       image: ubuntu-2404:current
@@ -651,7 +650,7 @@ jobs:
       - run:
           name: Run tests
           command: docker exec tsan-build bash -c "cd /root/goby3/build && ctest --output-on-failure"
-  amd64+ubsan-build:
+  amd64-ubsan-build:
     <<: *job-template-sanitizers
     steps:
       - checkout


### PR DESCRIPTION
Updates the CircleCI configuration to use version 2.1 and standardizes job naming conventions by replacing `+` with `-` as a separator.

**Changes:**
- Upgraded CircleCI config version from 2 to 2.1
- Removed redundant `version: 2` from workflows section (implicit in 2.1)
- Renamed sanitizer build jobs to use consistent naming:
  - `amd64+tsan-build` → `amd64-tsan-build`
  - `amd64+scan-build` → `amd64-scan-build`
  - `amd64+asan-build` → `amd64-asan-build`
  - `amd64+ubsan-build` → `amd64-ubsan-build` (including commented-out job)

This standardizes the job naming scheme across the CI pipeline and enables use of CircleCI 2.1 features.

https://claude.ai/code/session_015SD1Ud7bMri611NooK88Z4