### PR TITLE
Brace-initialize Identifier in the Julia bindings

### DIFF
--- a/src/middleware/languages/julia/application.h
+++ b/src/middleware/languages/julia/application.h
@@ -80,13 +80,13 @@ template <typename App> class ApplicationWrapper
     void publish(PubSubLayer layer, std::string type_name, int scheme, std::string group,
                  const std::vector<std::uint8_t>& bytes)
     {
-        app_ptr_->publish(Identifier(layer, type_name, scheme, group), bytes);
+        app_ptr_->publish(Identifier{layer, type_name, scheme, group}, bytes);
     }
 
     void subscribe(PubSubLayer layer, std::string type_name, int scheme, std::string group,
                    std::string func, std::string module)
     {
-        app_ptr_->subscribe(Identifier(layer, type_name, scheme, group), func, module);
+        app_ptr_->subscribe(Identifier{layer, type_name, scheme, group}, func, module);
     }
 
     void set_loop_frequency_hertz(double freq) { app_ptr_->set_loop_frequency_hertz(freq); }
@@ -144,9 +144,9 @@ inline void define_julia_module(jlcxx::Module& types, const std::string& app_nam
     }
 
 #define GOBY_JULIA_IF_SUBSCRIPTION(SCHEME, LAYER_ENUM, LAYER_FUNCTION, GROUP, TYPE)             \
-    if (id == goby::middleware::julia::Identifier(                                              \
+    if (id == goby::middleware::julia::Identifier{                                              \
                   goby::middleware::julia::PubSubLayer::LAYER_ENUM, TYPE::descriptor()->name(), \
-                  goby::middleware::MarshallingScheme::SCHEME, GROUP))                          \
+                  goby::middleware::MarshallingScheme::SCHEME, GROUP})                          \
     {                                                                                           \
         LAYER_FUNCTION().subscribe<GROUP>(                                                      \
             [=](const TYPE& pb)                                                                 \


### PR DESCRIPTION
`Identifier` is an aggregate with no user-declared constructors, so `Identifier(layer, type_name, scheme, group)` is parenthesized aggregate initialization — C++20 (P0960), and only from clang 16. Goby builds at C++17, where it is not valid at all:

```
/usr/include/goby/middleware/languages/julia/application.h:83:27: error: no matching constructor
for initialization of 'goby::middleware::languages::Identifier'
        app_ptr_->publish(Identifier(layer, type_name, scheme, group), bytes);
```

GCC accepts it as an extension, which is why it went unnoticed. The three affected sites are the `publish` and `subscribe` wrappers and the `GOBY_JULIA_IF_SUBSCRIPTION` macro; the Python bindings already brace-initialize, which is why every Python target builds under the same compiler.

This is pre-existing rather than a regression — the same parenthesized form is in `74e83a3`, before the language-bindings work. It simply had nothing compiling it: goby3-examples did not build its Julia examples in CI until [goby3-examples#44](https://github.com/GobySoft/goby3-examples/pull/44) added them, which is where this surfaced.

### Verification

Compiled the generated Julia bridge for both goby3-examples applications with `clang++ -std=c++17 -fsyntax-only`, against the installed headers and then against these:

| generated file | installed headers | with this change |
|---|---|---|
| `basic_julia_subscriber.cpp` | 3 errors | clean |
| `basic_julia_publisher.cpp` | 2 errors | clean |

The subscriber's 3 errors are exactly the "3 errors generated" in the failing goby3-examples job.

---
_Generated by [Claude Code](https://claude.ai/code/session_016nsf4QMNTfUxkyWh4xGaok)_