### PR TITLE
Implement Python interthread layer and thread support

### DIFF
--- a/src/doc/markdown/doc250_languages.md
+++ b/src/doc/markdown/doc250_languages.md
@@ -104,7 +104,7 @@ goby.run(PythonDemo, argv=["python_demo", "-v"])       # an explicit command lin
 An invalid configuration is reported the way a C++ application reports it, and `goby.run()`
 returns a non-zero value rather than raising or exiting.
 
-### Threads, signals and the GIL
+### Signals and the GIL
 
 The Goby event loop runs in C++ with the Python global interpreter lock (GIL) released, and each callback into Python reacquires
 it. While the loop is running, Goby installs its own `SIGINT`/`SIGTERM` handlers in place of the
@@ -113,7 +113,75 @@ interpreter's, so that Ctrl-C asks the application to quit cleanly rather than r
 (no loop frequency, nothing arriving) will not notice the request until something wakes it; a
 second Ctrl-C restores the default handler and terminates the process.
 
-Multi-threaded Python applications are not yet supported; use `SingleThreadApplication`.
+### Threads
+
+An application launches threads written in Python, mirroring how a C++ application launches
+`SimpleThread`s. `Thread` comes from the generated module, alongside the application class:
+
+```python
+from python_demo_goby import SingleThreadApplication, Thread, groups
+
+
+class Reporter(Thread):
+    def __init__(self):
+        super().__init__(loop_frequency_hertz=1)
+        self.interthread().subscribe(groups.status, self.on_status)
+
+    def on_status(self, status) -> None:
+        self.interprocess().publish(groups.report, to_report(status))
+
+
+class PythonDemo(SingleThreadApplication):
+    def __init__(self):
+        super().__init__(loop_frequency_hertz=10)
+        self.launch_thread(Reporter)
+
+        self.interthread().publish(groups.status, {"ready": True})
+```
+
+The class is constructed on its own thread, so what it subscribes to in its constructor is
+delivered there, and `initialize()`, `loop()` and `finalize()` run there too. `index=` launches
+several threads of one class, and `join_thread()` stops one; the rest are stopped when the
+application exits.
+
+The interthread layer is implemented in Python rather than through the C++
+`InterThreadTransporter`. Nothing crosses the language boundary, so an interthread message is any
+Python object rather than only a protobuf message, and an interthread group is any string,
+whether or not it is declared in `interface.yml`. The generated C++ has no case for the layer,
+which is why an application does not need `MultiThreadApplication` to use it. Every subscriber is
+handed the same object, so a message must not be modified after it is published — the rule that
+applies to the C++ `shared_ptr` publish.
+
+The outer layers still belong to the C++ application, which lives on the main thread. A
+publication or subscription from any other thread is handed to it through a mailbox, which is
+what a C++ thread's `InterProcessForwarder` does with its inner interthread transporter, and
+messages are delivered back to the thread that subscribed.
+
+```
+       main thread                                  launched thread
+  +---------------------+       interthread      +---------------------+
+  |     application     | <--------------------> |       Thread        |
+  +---------------------+   (Python objects)     +---------------------+
+            |                                              |
+            | interprocess, intermodule                    | mailbox
+            v                                              |
+  +---------------------+                                  |
+  |     C++ portal      | <--------------------------------+
+  +---------------------+
+```
+
+The application picks that work up in its `loop()`, so its loop rate bounds how long a thread's
+interprocess publication waits before it goes out. Launching a thread raises the C++ loop rate to
+`interthread_poll_frequency_hertz` (10 Hz by default) when the application asked for a slower one,
+without changing how often the application's own `loop()` is called:
+
+```python
+super().__init__(loop_frequency_hertz=1, interthread_poll_frequency_hertz=100)
+```
+
+Python threads are Python threads: the GIL interleaves them rather than running them in parallel,
+so they buy independent loop rates and separation of concerns, not throughput. A thread that
+raises prints its traceback and stops the application.
 
 ### Building
 

--- a/src/python/README.md
+++ b/src/python/README.md
@@ -36,11 +36,41 @@ if __name__ == "__main__":
 | File | Purpose |
 |------|---------|
 | `goby/__init__.py` | The public API: `run`, `ApplicationMixin`, `Transporter`, the layer and scheme constants. |
-| `goby/_application.py` | The Python side of an application: layer accessors, publish/subscribe, configuration. |
+| `goby/_application.py` | The Python side of an application: layer accessors, publish/subscribe, configuration, threads. |
+| `goby/_interthread.py` | The interthread layer, implemented in Python, and the threads that use it. |
 | `goby/_schemes.py` | Layer and marshalling scheme constants, mirroring the C++ enumerations. |
 | `goby/gen.py` | Code generator. Reads `interface.yml` and writes the C++ glue plus the Python module that application code imports. Installed as the `goby_gen_cpp` command. |
 | `goby/schema/` | The machine-readable definition of the `interface.yml` format. |
 | `tests/` | Unit tests for the generator and the constants; not installed. |
+
+## Threads
+
+Threads are written in Python and launched by the application, mirroring how a C++ application
+launches `SimpleThread`s:
+
+```python
+from python_demo_goby import SingleThreadApplication, Thread, groups
+
+
+class Reporter(Thread):
+    def __init__(self):
+        super().__init__(loop_frequency_hertz=1)
+        self.interthread().subscribe(groups.status, self.on_status)
+
+    def on_status(self, status) -> None:
+        self.interprocess().publish(groups.report, to_report(status))
+
+
+class PythonDemo(SingleThreadApplication):
+    def __init__(self):
+        super().__init__(loop_frequency_hertz=10)
+        self.launch_thread(Reporter)
+```
+
+The interthread layer is implemented in Python, so an interthread message is any Python object
+and an interthread group is any string. The outer layers belong to the C++ application, which
+lives on the main thread; a thread's publications and subscriptions are handed to it and
+delivered back. See `doc250_languages.md` for the details and the costs.
 
 ## `interface.yml`
 

--- a/src/python/goby/__init__.py
+++ b/src/python/goby/__init__.py
@@ -48,6 +48,22 @@ A Goby Python application is written as a subclass of the application class gene
     if __name__ == "__main__":
         sys.exit(goby.run(PythonDemo))
 
+Threads are written in Python too, and launched by the application::
+
+    class Reporter(Thread):
+        def __init__(self):
+            super().__init__(loop_frequency_hertz=1)
+            self.interthread().subscribe(groups.status, self.on_status)
+
+    class PythonDemo(SingleThreadApplication):
+        def __init__(self):
+            super().__init__(loop_frequency_hertz=10)
+            self.launch_thread(Reporter)
+
+The interthread layer is implemented in Python rather than through the C++
+``InterThreadTransporter``, so an interthread message is any Python object and an interthread
+group is any string.
+
 See ``share/goby/interface/README.md`` for the ``interface.yml`` format, which is shared with the
 Julia bindings.
 """
@@ -67,6 +83,7 @@ from ._application import (
     message_type,
     run,
 )
+from ._interthread import Thread
 from ._schemes import (
     ALL_SCHEMES,
     CSTR,
@@ -100,6 +117,7 @@ __all__ = [
     "NULL_SCHEME",
     "PROTOBUF",
     "PubSubLayer",
+    "Thread",
     "Transporter",
     "__version__",
     "message_type",

--- a/src/python/goby/_application.py
+++ b/src/python/goby/_application.py
@@ -28,11 +28,14 @@ each application from its ``interface.yml``, which is why the ``goby`` package i
 architecture-independent.
 """
 
+import functools
 import inspect
 import sys
+import time
 import typing
 
-from ._schemes import PROTOBUF, MarshallingScheme, PubSubLayer
+from . import _interthread
+from ._schemes import INTERTHREAD, PROTOBUF
 
 
 class ConfigError(Exception):
@@ -63,8 +66,12 @@ def message_type(full_name):
         ) from None
 
 
-def _callback_message_type(callback):
-    """Infers the protobuf message type a callback expects, from its type annotation."""
+def _callback_message_type(callback, required=True):
+    """Infers the message type a callback expects, from its type annotation.
+
+    ``required`` is false on the interthread layer, where a subscription without a type takes
+    everything published on the group.
+    """
     try:
         signature = inspect.signature(callback)
     except (TypeError, ValueError):
@@ -88,7 +95,7 @@ def _callback_message_type(callback):
         hints = {}
 
     annotation = hints.get(parameters[0].name)
-    if annotation is None:
+    if annotation is None and required:
         raise TypeError(
             f"Could not infer the message type for {getattr(callback, '__qualname__', callback)!r}. "
             f"Annotate its argument with the message type, or pass the type explicitly: "
@@ -106,16 +113,16 @@ def _check_message_type(message_type_):
 
 
 class Transporter:
-    """Publishes and subscribes on one layer of one application.
+    """Publishes and subscribes on one layer of one application or thread.
 
-    Returned by the layer accessors on the application class -- ``self.interprocess()`` and
-    friends -- mirroring the C++ transporter accessors.
+    Returned by the layer accessors -- ``self.interprocess()`` and friends -- mirroring the C++
+    transporter accessors.
     """
 
-    __slots__ = ("_app", "_name", "_layer")
+    __slots__ = ("_owner", "_name", "_layer")
 
-    def __init__(self, app, name, layer):
-        self._app = app
+    def __init__(self, owner, name, layer):
+        self._owner = owner
         self._name = name
         self._layer = int(layer)
 
@@ -130,13 +137,19 @@ class Transporter:
     def publish(self, group, message):
         """Publishes ``message`` to ``group`` on this layer.
 
-        The publication must be declared in the application's ``interface.yml``.
+        On the interthread layer the message is any Python object and the group is any string.
+        On the other layers the message is a protobuf message and the publication must be
+        declared in the application's ``interface.yml``.
 
         :param group: the group, e.g. ``groups.modem_tx``
-        :param message: a protobuf message
+        :param message: the message to publish
         """
+        if self._layer == INTERTHREAD:
+            _interthread.bus.publish(str(group), message)
+            return
+
         _check_message_type(type(message))
-        self._app._publish(
+        self._owner._goby_cxx_publish(
             self._layer,
             message.DESCRIPTOR.name,
             int(PROTOBUF),
@@ -158,24 +171,38 @@ class Transporter:
 
             self.interprocess().subscribe(groups.modem_rx, self.on_rx)
 
-        The subscription must be declared in the application's ``interface.yml``.
+        On the interthread layer the type may be omitted entirely, and the subscription then
+        takes every object published on the group. On the other layers the subscription must be
+        declared in the application's ``interface.yml``.
+
+        The callback runs on the thread that subscribed.
         """
         if callback is None:
             callback = message_type_
             if callback is None:
                 raise TypeError("subscribe() requires a callback")
-            message_type_ = _callback_message_type(callback)
+            message_type_ = _callback_message_type(
+                callback, required=self._layer != INTERTHREAD
+            )
 
-        _check_message_type(message_type_)
         if not callable(callback):
             raise TypeError(f"{callback!r} is not callable")
+
+        if self._layer == INTERTHREAD:
+            self._owner._goby_service_required()
+            _interthread.bus.subscribe(
+                str(group), message_type_, callback, self._owner._goby_mailbox
+            )
+            return
+
+        _check_message_type(message_type_)
 
         def _on_bytes(data):
             message = message_type_()
             message.ParseFromString(data)
             callback(message)
 
-        self._app._subscribe(
+        self._owner._goby_cxx_subscribe(
             self._layer,
             message_type_.DESCRIPTOR.name,
             int(PROTOBUF),
@@ -194,6 +221,49 @@ class ApplicationMixin:
     # both are set by the generated module
     _goby_ext = None
     _goby_config_type = None
+
+    _goby_has_user_loop = False
+
+    def __init__(self, loop_frequency_hertz=0, interthread_poll_frequency_hertz=10):
+        """
+        :param loop_frequency_hertz: frequency at which to call loop(); zero means never
+        :param interthread_poll_frequency_hertz: lower bound on how often the application picks
+            up work from its threads, which bounds the latency of anything they send it
+        """
+        self._goby_loop_frequency_hertz = float(loop_frequency_hertz)
+        self._goby_interthread_poll_frequency_hertz = float(interthread_poll_frequency_hertz)
+        self._goby_mailbox = _interthread.Mailbox()
+        self._goby_threads = {}
+        self._goby_serviced = False
+        self._goby_loop_period = None
+        self._goby_loop_next = 0.0
+        super().__init__(loop_frequency_hertz)
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+
+        user_loop = cls.__dict__.get("loop")
+        if user_loop is None or getattr(user_loop, "_goby_services_threads", False):
+            return
+
+        # the C++ loop runs at whichever is faster, the application's rate or the thread poll
+        # rate, so the application's own loop() is called on the schedule it asked for
+        @functools.wraps(user_loop)
+        def loop(self):
+            if getattr(self, "_goby_in_loop", False):
+                user_loop(self)
+                return
+            self._goby_in_loop = True
+            try:
+                self._goby_service()
+                if self._goby_loop_due():
+                    user_loop(self)
+            finally:
+                self._goby_in_loop = False
+
+        loop._goby_services_threads = True
+        cls.loop = loop
+        cls._goby_has_user_loop = True
 
     @property
     def cfg(self):
@@ -214,6 +284,54 @@ class ApplicationMixin:
         self._goby_cfg_cached = config
         return config
 
+    def interthread(self):
+        """The interthread transporter."""
+        return self._goby_transporter("interthread", INTERTHREAD)
+
+    def loop(self):
+        """Override to do work at loop_frequency_hertz."""
+        self._goby_service()
+        if self._goby_has_user_loop or self._goby_loop_frequency_hertz <= 0:
+            return
+        # the diagnostic the C++ ApplicationWrapper gives, which servicing threads displaces
+        raise RuntimeError("loop() must be overridden when loop_frequency is non-zero")
+
+    def launch_thread(self, thread_class, index=None, *args, **kwargs):
+        """Starts ``thread_class`` on a thread of its own, mirroring C++ ``launch_thread()``.
+
+        The class is constructed on the new thread, so anything it subscribes to in its
+        constructor is delivered there.
+
+        :param thread_class: a ``goby.Thread`` subclass
+        :param index: distinguishes several threads of the same class, as it does in C++
+        """
+        if not (isinstance(thread_class, type) and issubclass(thread_class, _interthread.Thread)):
+            raise TypeError(f"{thread_class!r} is not a goby.Thread subclass")
+
+        key = (thread_class, index)
+        running = self._goby_threads.get(key)
+        if running is not None and running.is_alive():
+            raise RuntimeError(
+                f"A thread of type {thread_class.__name__} and index {index} is already running"
+            )
+
+        self._goby_service_required()
+        runner = _interthread.ThreadRunner(self, thread_class, index, args, kwargs)
+        self._goby_threads[key] = runner
+        runner.start()
+
+    def join_thread(self, thread_class, index=None, timeout=None):
+        """Asks the thread to stop and waits for it, mirroring C++ ``join_thread()``."""
+        runner = self._goby_threads.pop((thread_class, index), None)
+        if runner is None:
+            raise RuntimeError(
+                f"No thread of type {thread_class.__name__} and index {index} to join"
+            )
+        self._goby_stop(runner, timeout)
+
+    def running_thread_count(self):
+        return sum(1 for runner in self._goby_threads.values() if runner.is_alive())
+
     def _goby_transporter(self, name, layer):
         cache = getattr(self, "_goby_transporters", None)
         if cache is None:
@@ -222,6 +340,71 @@ class ApplicationMixin:
         if name not in cache:
             cache[name] = Transporter(self, name, layer)
         return cache[name]
+
+    def _goby_cxx_publish(self, layer, type_name, scheme, group, data):
+        self._publish(layer, type_name, scheme, group, data)
+
+    def _goby_cxx_subscribe(self, layer, type_name, scheme, group, on_bytes):
+        self._subscribe(layer, type_name, scheme, group, on_bytes)
+
+    def _goby_service(self):
+        """Runs the work the application's threads have handed it."""
+        self._goby_mailbox.service()
+
+    def _goby_loop_due(self):
+        period = self._goby_loop_period
+        if period is None:
+            return True
+        if period == 0:
+            return False
+
+        now = time.monotonic()
+        if now < self._goby_loop_next:
+            return False
+        self._goby_loop_next = max(now, self._goby_loop_next + period)
+        return True
+
+    def _goby_service_required(self):
+        """Raises the C++ loop rate so the application picks up its threads' work often enough."""
+        if self._goby_serviced:
+            return
+        self._goby_serviced = True
+
+        poll = self._goby_interthread_poll_frequency_hertz
+        if poll <= self._goby_loop_frequency_hertz:
+            return
+
+        self._set_loop_frequency_hertz(poll)
+        self._goby_loop_period = (
+            1.0 / self._goby_loop_frequency_hertz
+            if self._goby_loop_frequency_hertz > 0
+            else 0.0
+        )
+        self._goby_loop_next = time.monotonic() + self._goby_loop_period
+
+    def _goby_thread_failed(self, name, formatted_traceback):
+        """Called from a thread that stopped; the application is quit from its own thread."""
+
+        def report():
+            _interthread.report_failure(name, formatted_traceback)
+            self.quit(1)
+
+        self._goby_mailbox.post(report)
+
+    def _goby_join_all_threads(self, timeout=5):
+        for runner in list(self._goby_threads.values()):
+            self._goby_stop(runner, timeout)
+        self._goby_threads.clear()
+
+    @staticmethod
+    def _goby_stop(runner, timeout):
+        runner.mailbox.request_shutdown()
+        runner.join(timeout)
+        if runner.is_alive():
+            print(
+                f"Goby: thread {runner.name} did not stop when asked; abandoning it",
+                file=sys.stderr,
+            )
 
 
 def run(application_class, argv=None, config=None, config_text=None):
@@ -267,4 +450,7 @@ def run(application_class, argv=None, config=None, config_text=None):
         return 1
 
     application = application_class()
-    return application._run()
+    try:
+        return application._run()
+    finally:
+        application._goby_join_all_threads()

--- a/src/python/goby/_interthread.py
+++ b/src/python/goby/_interthread.py
@@ -1,0 +1,325 @@
+# Copyright 2026:
+#   GobySoft, LLC (2013-)
+#   Community contributors (see AUTHORS file)
+# File authors:
+#   Toby Schneider <toby@gobysoft.org>
+#
+#
+# This file is part of the Goby Underwater Autonomy Project Libraries
+# ("The Goby Libraries").
+#
+# The Goby Libraries are free software: you can redistribute them and/or modify
+# them under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# The Goby Libraries are distributed in the hope that they will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Goby.  If not, see <http://www.gnu.org/licenses/>.
+
+"""The interthread layer, and the Python threads that use it.
+
+The C++ interthread layer carries C++ objects between C++ threads. The threads of a Python
+application are Python threads, so the layer is implemented here rather than through
+``InterThreadTransporter``: nothing crosses the language boundary and nothing is marshalled, so
+an interthread message is any Python object and an interthread group is any string.
+
+The outer layers still belong to the C++ application, which lives on the main thread. A
+publication or subscription from any other thread is handed to it through that thread's mailbox,
+which is what a C++ thread's ``InterProcessForwarder`` does with its inner interthread
+transporter.
+"""
+
+import functools
+import queue
+import sys
+import threading
+import time
+import traceback
+
+from ._schemes import INTERTHREAD
+
+_SHUTDOWN = object()
+
+
+class _Shutdown(Exception):
+    """Raised out of Mailbox.service() when the thread has been asked to stop."""
+
+
+class Mailbox:
+    """The work queue for one thread.
+
+    Every item is a callable that runs on the thread owning the mailbox; that is how a message
+    published by another thread reaches the callback that asked for it.
+    """
+
+    def __init__(self):
+        self._queue = queue.Queue()
+
+    def post(self, work):
+        self._queue.put(work)
+
+    def request_shutdown(self):
+        self._queue.put(_SHUTDOWN)
+
+    def service(self, timeout=0):
+        """Runs the queued work, waiting up to ``timeout`` seconds (``None`` blocks) for the first item."""
+        # only the work already queued is run, so that a callback publishing to its own thread
+        # is picked up by the next service rather than looping here; a C++ poll takes the same
+        # snapshot of its queue before running any callback
+        queued = self._queue.qsize()
+
+        try:
+            if timeout is None or timeout > 0:
+                self._run(self._queue.get(timeout=timeout))
+            else:
+                self._run(self._queue.get_nowait())
+        except queue.Empty:
+            return
+
+        for _ in range(max(queued - 1, 0)):
+            try:
+                self._run(self._queue.get_nowait())
+            except queue.Empty:
+                return
+
+    @staticmethod
+    def _run(work):
+        if work is _SHUTDOWN:
+            raise _Shutdown()
+        work()
+
+
+class _Subscription:
+    __slots__ = ("mailbox", "message_type", "callback")
+
+    def __init__(self, mailbox, message_type, callback):
+        self.mailbox = mailbox
+        self.message_type = message_type
+        self.callback = callback
+
+
+class Bus:
+    """Interthread publish/subscribe, shared by every thread of the process."""
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._subscriptions = {}
+
+    def subscribe(self, group, message_type, callback, mailbox):
+        with self._lock:
+            self._subscriptions.setdefault(group, []).append(
+                _Subscription(mailbox, message_type, callback)
+            )
+
+    def publish(self, group, message):
+        with self._lock:
+            subscriptions = list(self._subscriptions.get(group, ()))
+
+        for subscription in subscriptions:
+            # a subscription is per type as well as per group, as it is in C++; an interthread
+            # subscription that named no type takes everything published on the group
+            if subscription.message_type is not None and not isinstance(
+                message, subscription.message_type
+            ):
+                continue
+            # every subscriber is handed the same object, so a mutation after publish is visible
+            # to all of them, exactly as it is for a C++ shared_ptr publish
+            subscription.mailbox.post(functools.partial(subscription.callback, message))
+
+    def remove(self, mailbox):
+        with self._lock:
+            for group, subscriptions in list(self._subscriptions.items()):
+                remaining = [s for s in subscriptions if s.mailbox is not mailbox]
+                if remaining:
+                    self._subscriptions[group] = remaining
+                else:
+                    del self._subscriptions[group]
+
+    def groups(self):
+        with self._lock:
+            return sorted(self._subscriptions)
+
+
+bus = Bus()
+
+
+class _Construction:
+    __slots__ = ("mailbox", "app", "index")
+
+    def __init__(self, mailbox, app, index):
+        self.mailbox = mailbox
+        self.app = app
+        self.index = index
+
+
+_construction = threading.local()
+
+
+class Thread:
+    """Base class for a Goby thread written in Python.
+
+    Mirrors the C++ ``SimpleThread``: the thread is constructed on its own thread, subscribes in
+    its constructor, and has ``initialize()``, ``loop()`` and ``finalize()`` called there too::
+
+        class Reporter(Thread):
+            def __init__(self):
+                super().__init__(loop_frequency_hertz=1)
+                self.interthread().subscribe(groups.status, self.on_status)
+
+            def on_status(self, status):
+                self.interprocess().publish(groups.report, to_report(status))
+
+    Started with ``Application.launch_thread(Reporter)``.
+    """
+
+    def __init__(self, loop_frequency_hertz=0):
+        context = getattr(_construction, "context", None)
+        if context is None:
+            raise RuntimeError(
+                "A goby.Thread must be started with the application's launch_thread(), which "
+                "constructs it on the thread it runs on."
+            )
+
+        self._goby_mailbox = context.mailbox
+        self._goby_app = context.app
+        self._goby_index = context.index
+        self._goby_loop_frequency_hertz = float(loop_frequency_hertz)
+        self._goby_transporters = {}
+
+    @property
+    def index(self):
+        """The index this thread was launched with, or None."""
+        return self._goby_index
+
+    @property
+    def cfg(self):
+        """The configuration the application was started with, as a protobuf message."""
+        return self._goby_app.cfg
+
+    @property
+    def loop_frequency_hertz(self):
+        return self._goby_loop_frequency_hertz
+
+    def app_name(self):
+        return self._goby_app.app_name()
+
+    def interthread(self):
+        """The interthread transporter."""
+        return self._goby_transporter("interthread", INTERTHREAD)
+
+    def loop(self):
+        """Override to do work at loop_frequency_hertz."""
+
+    def initialize(self):
+        """Override for work that can't be done in the constructor."""
+
+    def finalize(self):
+        """Override for cleanup just before the thread exits."""
+
+    def quit(self, return_value=0):
+        """Asks the application to exit cleanly."""
+        self._goby_app._goby_mailbox.post(
+            functools.partial(self._goby_app.quit, return_value)
+        )
+
+    def _goby_service_required(self):
+        """The runner always services the mailbox, so nothing has to be arranged."""
+
+    def _goby_transporter(self, name, layer):
+        from ._application import Transporter  # deferred: _application imports this module
+
+        if name not in self._goby_transporters:
+            self._goby_transporters[name] = Transporter(self, name, layer)
+        return self._goby_transporters[name]
+
+    def _goby_cxx_publish(self, layer, type_name, scheme, group, data):
+        app = self._goby_app
+        app._goby_mailbox.post(
+            functools.partial(app._publish, layer, type_name, scheme, group, data)
+        )
+
+    def _goby_cxx_subscribe(self, layer, type_name, scheme, group, on_bytes):
+        app = self._goby_app
+        mailbox = self._goby_mailbox
+
+        def deliver(data):
+            mailbox.post(functools.partial(on_bytes, data))
+
+        app._goby_mailbox.post(
+            functools.partial(app._subscribe, layer, type_name, scheme, group, deliver)
+        )
+
+
+class ThreadRunner(threading.Thread):
+    """Runs one goby.Thread: constructs it, services its mailbox, and calls its loop()."""
+
+    def __init__(self, app, thread_class, index, args, kwargs):
+        super().__init__(name=thread_name(thread_class, index), daemon=True)
+        self.mailbox = Mailbox()
+        self._app = app
+        self._thread_class = thread_class
+        self._index = index
+        self._args = args
+        self._kwargs = kwargs
+
+    def run(self):
+        thread = None
+        try:
+            _construction.context = _Construction(self.mailbox, self._app, self._index)
+            try:
+                thread = self._thread_class(*self._args, **self._kwargs)
+            finally:
+                _construction.context = None
+
+            thread.initialize()
+            self._service(thread)
+        except _Shutdown:
+            pass
+        except BaseException:
+            self._app._goby_thread_failed(self.name, traceback.format_exc())
+        finally:
+            bus.remove(self.mailbox)
+            if thread is not None:
+                self._finalize(thread)
+
+    def _service(self, thread):
+        period = (
+            1.0 / thread.loop_frequency_hertz if thread.loop_frequency_hertz > 0 else None
+        )
+        if period is None:
+            while True:
+                self.mailbox.service(timeout=None)
+
+        next_loop = time.monotonic() + period
+        while True:
+            self.mailbox.service(timeout=max(0.0, next_loop - time.monotonic()))
+            now = time.monotonic()
+            if now >= next_loop:
+                next_loop = max(now, next_loop + period)
+                thread.loop()
+
+    def _finalize(self, thread):
+        try:
+            thread.finalize()
+        except BaseException:
+            self._app._goby_thread_failed(self.name, traceback.format_exc())
+
+
+def thread_name(thread_class, index):
+    name = getattr(thread_class, "__qualname__", thread_class.__name__)
+    return name if index is None else "{}/{}".format(name, index)
+
+
+def report_failure(name, formatted_traceback):
+    """Prints what stopped a thread, in the form the C++ side reports an uncaught exception."""
+    print(
+        "Goby: thread {} stopped and the application cannot continue:\n{}".format(
+            name, formatted_traceback
+        ),
+        file=sys.stderr,
+    )

--- a/src/python/goby/gen.py
+++ b/src/python/goby/gen.py
@@ -96,6 +96,14 @@ class Interface:
         return self.publishes + self.subscribes
 
     @property
+    def cpp_publishes(self) -> List[Entry]:
+        return [entry for entry in self.publishes if entry.layer != "interthread"]
+
+    @property
+    def cpp_subscribes(self) -> List[Entry]:
+        return [entry for entry in self.subscribes if entry.layer != "interthread"]
+
+    @property
     def groups(self) -> Dict[str, str]:
         """Unambiguous trailing group name -> full group expression.
 
@@ -276,7 +284,10 @@ def load(path: str) -> Interface:
 
 
 def generate_cpp(interface: Interface, includes: Sequence[str], module: str, source: str) -> str:
-    """Returns the C++ glue code implementing the declared interface."""
+    """Returns the C++ glue code implementing the declared interface.
+
+    The interthread layer is left out: it is implemented in Python and never crosses into C++.
+    """
     lines = [
         "// ########################",
         "// #   Goby <--> Python   #",
@@ -303,7 +314,7 @@ def generate_cpp(interface: Interface, includes: Sequence[str], module: str, sou
         "    void publish(goby::middleware::python::Identifier id, const std::string& data)",
         "    {",
     ]
-    for entry in interface.publishes:
+    for entry in interface.cpp_publishes:
         lines.append(
             '        GOBY_PYTHON_IF_PUBLICATION({}, {}, {}, {}, "{}", {})'.format(
                 entry.scheme,
@@ -322,7 +333,7 @@ def generate_cpp(interface: Interface, includes: Sequence[str], module: str, sou
         "    void subscribe(goby::middleware::python::Identifier id, pybind11::object callback)",
         "    {",
     ]
-    for entry in interface.subscribes:
+    for entry in interface.cpp_subscribes:
         lines.append(
             '        GOBY_PYTHON_IF_SUBSCRIPTION({}, {}, {}, {}, "{}", {})'.format(
                 entry.scheme,
@@ -424,17 +435,15 @@ def generate_python(
         "    _goby_config_type = CONFIG_TYPE",
         "",
     ]
+    lines += _accessor_lines(interface)
 
-    if interface.accessors:
-        for accessor, layer in interface.accessors.items():
-            lines += [
-                f"    def {accessor}(self):",
-                f'        """The {layer} transporter."""',
-                f'        return self._goby_transporter("{accessor}", goby.{layer.upper()})',
-                "",
-            ]
-    else:
-        lines += ["    pass", ""]
+    lines += [
+        "",
+        "class Thread(goby.Thread):",
+        f'    """Base class for a thread of the {interface.name} Goby application."""',
+        "",
+    ]
+    lines += _accessor_lines(interface)
 
     lines += [
         "",
@@ -442,6 +451,22 @@ def generate_python(
         "",
     ]
     return "\n".join(lines)
+
+
+def _accessor_lines(interface: Interface) -> List[str]:
+    """One accessor per declared portal, named for the layer unless an alias was declared."""
+    if not interface.accessors:
+        return ["    pass", ""]
+
+    lines = []
+    for accessor, layer in interface.accessors.items():
+        lines += [
+            f"    def {accessor}(self):",
+            f'        """The {layer} transporter."""',
+            f'        return self._goby_transporter("{accessor}", goby.{layer.upper()})',
+            "",
+        ]
+    return lines
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:

--- a/src/python/tests/test_gen.py
+++ b/src/python/tests/test_gen.py
@@ -36,6 +36,28 @@ interprocess:
 """
 
 
+INTERTHREAD_AND_INTERPROCESS = """
+application:
+  name: PythonDemo
+  cpp_type: goby::zeromq::SingleThreadApplication
+  config:
+    scheme: PROTOBUF
+    type: project.config.protobuf.PythonDemoConfig
+
+interthread:
+  publishes:
+    - group: project::groups::status
+      scheme: PROTOBUF
+      type: project.protobuf.Status
+
+interprocess:
+  publishes:
+    - group: project::groups::modem_tx
+      scheme: PROTOBUF
+      type: project.protobuf.CommsTx
+"""
+
+
 def parse_yaml(text):
     import yaml
 
@@ -187,6 +209,16 @@ class GenerateCppTest(unittest.TestCase):
     def test_defines_the_module(self):
         self.assertIn("GOBY_PYTHON_DEFINE_MODULE(APPLICATION_NAME, _python_demo_goby)", self.cpp)
 
+    def test_interthread_is_left_out(self):
+        # the layer is implemented in Python and never crosses into C++, so the glue has no case
+        # for it -- and needs no interthread() accessor on the application class
+        cpp = gen.generate_cpp(
+            parse_yaml(INTERTHREAD_AND_INTERPROCESS), [], "_python_demo_goby", "interface.yml"
+        )
+        self.assertNotIn("INTERTHREAD", cpp)
+        self.assertNotIn("project::groups::status", cpp)
+        self.assertIn("INTERPROCESS", cpp)
+
     def test_macro_parameter_names_match_the_generated_signatures(self):
         # the macros refer to 'data' and 'callback' by name
         self.assertIn(
@@ -226,6 +258,19 @@ class GeneratePythonTest(unittest.TestCase):
     def test_emits_layer_accessors(self):
         self.assertIn("def interprocess(self):", self.module)
         self.assertIn('self._goby_transporter("interprocess", goby.INTERPROCESS)', self.module)
+
+    def test_emits_a_thread_base_class(self):
+        self.assertIn("class Thread(goby.Thread):", self.module)
+        # the same accessors as the application, so a thread publishes the same way it does
+        self.assertEqual(self.module.count("def interprocess(self):"), 2)
+
+    def test_interthread_groups_are_still_named(self):
+        module = gen.generate_python(
+            parse_yaml(INTERTHREAD_AND_INTERPROCESS), "_python_demo_goby", [], "interface.yml"
+        )
+        compile(module, "python_demo_goby.py", "exec")
+        self.assertIn('status = "project::groups::status"', module)
+        self.assertIn('self._goby_transporter("interthread", goby.INTERTHREAD)', module)
 
     def test_resolves_the_config_type(self):
         self.assertIn(

--- a/src/python/tests/test_interthread.py
+++ b/src/python/tests/test_interthread.py
@@ -1,0 +1,564 @@
+"""Unit tests for the interthread layer and the Python threads that use it.
+
+Everything here runs without the compiled extension module: the application base class the
+generated module would supply is stood in for by FakeBase, which records what the C++ side would
+have been asked to do. That is enough to test the parts that are implemented in Python -- the
+interthread bus, the mailbox each thread services, and the forwarding of the outer layers to the
+thread that owns the application.
+
+Run with `python3 -m unittest discover -s tests` from src/python, or through CTest as the
+goby_test_python_unit test.
+"""
+
+import os
+import sys
+import threading
+import time
+import types
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import goby  # noqa: E402
+from goby import _interthread  # noqa: E402
+
+TIMEOUT = 5
+
+
+class Message:
+    """Stands in for a protobuf message on the layers that marshal one."""
+
+    DESCRIPTOR = types.SimpleNamespace(name="Message")
+
+    def __init__(self, value=b""):
+        self.value = value
+
+    def SerializeToString(self):
+        return self.value
+
+    def ParseFromString(self, data):
+        self.value = data
+
+
+class OtherMessage:
+    DESCRIPTOR = types.SimpleNamespace(name="OtherMessage")
+
+    def __init__(self, value=b""):
+        self.value = value
+
+
+class FakeBase:
+    """The compiled _ApplicationBase, reduced to what the Python side calls."""
+
+    def __init__(self, loop_frequency_hertz=0):
+        self.loop_frequency_hertz = float(loop_frequency_hertz)
+        self.published = []
+        self.subscriptions = []
+        self.quit_values = []
+
+    def _publish(self, layer, type_name, scheme, group, data):
+        self.published.append((int(layer), type_name, int(scheme), group, data))
+
+    def _subscribe(self, layer, type_name, scheme, group, callback):
+        self.subscriptions.append((int(layer), type_name, int(scheme), group, callback))
+
+    def _set_loop_frequency_hertz(self, loop_frequency_hertz):
+        self.loop_frequency_hertz = float(loop_frequency_hertz)
+
+    def quit(self, return_value=0):
+        self.quit_values.append(return_value)
+
+    def app_name(self):
+        return "fake_app"
+
+
+class FakeApp(goby.ApplicationMixin, FakeBase):
+    def interprocess(self):
+        return self._goby_transporter("interprocess", goby.INTERPROCESS)
+
+
+class FakeThread(goby.Thread):
+    def interprocess(self):
+        return self._goby_transporter("interprocess", goby.INTERPROCESS)
+
+
+class BusTest(unittest.TestCase):
+    """The bus itself: what is delivered, to which mailbox, and when it stops being delivered."""
+
+    def setUp(self):
+        self.bus = _interthread.Bus()
+        self.mailbox = _interthread.Mailbox()
+        self.received = []
+
+    def test_delivers_to_the_subscribers_mailbox(self):
+        self.bus.subscribe("group", None, self.received.append, self.mailbox)
+        self.bus.publish("group", "anything at all")
+
+        # the callback runs when the owning thread services its mailbox, not at publish
+        self.assertEqual(self.received, [])
+        self.mailbox.service()
+        self.assertEqual(self.received, ["anything at all"])
+
+    def test_carries_any_python_object(self):
+        self.bus.subscribe("group", None, self.received.append, self.mailbox)
+        for message in ({"a": 1}, [1, 2, 3], 42, None, Message(b"x")):
+            self.bus.publish("group", message)
+        self.mailbox.service()
+
+        self.assertEqual(len(self.received), 5)
+        self.assertIs(self.received[0].__class__, dict)
+        self.assertIsNone(self.received[3])
+
+    def test_hands_every_subscriber_the_same_object(self):
+        other = _interthread.Mailbox()
+        elsewhere = []
+        self.bus.subscribe("group", None, self.received.append, self.mailbox)
+        self.bus.subscribe("group", None, elsewhere.append, other)
+
+        published = {"count": 0}
+        self.bus.publish("group", published)
+        self.mailbox.service()
+        other.service()
+
+        self.assertIs(self.received[0], published)
+        self.assertIs(elsewhere[0], published)
+
+    def test_a_subscription_with_a_type_takes_only_that_type(self):
+        self.bus.subscribe("group", Message, self.received.append, self.mailbox)
+        self.bus.publish("group", OtherMessage(b"no"))
+        self.bus.publish("group", "not a message either")
+        self.bus.publish("group", Message(b"yes"))
+        self.mailbox.service()
+
+        self.assertEqual([message.value for message in self.received], [b"yes"])
+
+    def test_other_groups_are_not_delivered(self):
+        self.bus.subscribe("group", None, self.received.append, self.mailbox)
+        self.bus.publish("another group", "message")
+        self.mailbox.service()
+
+        self.assertEqual(self.received, [])
+
+    def test_publishing_with_no_subscriber_is_not_an_error(self):
+        self.bus.publish("nobody is listening", "message")
+
+    def test_removing_a_mailbox_ends_its_subscriptions(self):
+        self.bus.subscribe("group", None, self.received.append, self.mailbox)
+        self.bus.remove(self.mailbox)
+        self.bus.publish("group", "message")
+        self.mailbox.service()
+
+        self.assertEqual(self.received, [])
+        self.assertEqual(self.bus.groups(), [])
+
+
+class MailboxTest(unittest.TestCase):
+    def setUp(self):
+        self.mailbox = _interthread.Mailbox()
+
+    def test_service_runs_everything_queued(self):
+        ran = []
+        for index in range(3):
+            self.mailbox.post(lambda index=index: ran.append(index))
+        self.mailbox.service()
+
+        self.assertEqual(ran, [0, 1, 2])
+
+    def test_service_returns_when_there_is_nothing_to_do(self):
+        self.mailbox.service()
+
+    def test_shutdown_stops_the_service_loop(self):
+        ran = []
+        self.mailbox.post(lambda: ran.append("before"))
+        self.mailbox.request_shutdown()
+        self.mailbox.post(lambda: ran.append("after"))
+
+        with self.assertRaises(_interthread._Shutdown):
+            self.mailbox.service()
+        self.assertEqual(ran, ["before"])
+
+    def test_a_callback_posting_to_its_own_mailbox_does_not_loop(self):
+        ran = []
+
+        def republish():
+            ran.append(len(ran))
+            self.mailbox.post(republish)
+
+        self.mailbox.post(republish)
+        self.mailbox.service()
+
+        # the work it posted is left for the next service, as a C++ poll leaves it for the next
+        self.assertEqual(ran, [0])
+        self.mailbox.service()
+        self.assertEqual(ran, [0, 1])
+
+    def test_service_waits_for_work(self):
+        def post_soon():
+            time.sleep(0.05)
+            self.mailbox.post(lambda: None)
+
+        threading.Thread(target=post_soon, daemon=True).start()
+        started = time.monotonic()
+        self.mailbox.service(timeout=TIMEOUT)
+
+        self.assertLess(time.monotonic() - started, TIMEOUT)
+
+
+class ApplicationInterthreadTest(unittest.TestCase):
+    """The application's own end of the layer, with no thread launched."""
+
+    def setUp(self):
+        self.original_bus = _interthread.bus
+        _interthread.bus = _interthread.Bus()
+        self.app = FakeApp()
+
+    def tearDown(self):
+        _interthread.bus = self.original_bus
+
+    def test_publish_and_subscribe_within_the_application(self):
+        received = []
+        self.app.interthread().subscribe("group", received.append)
+        self.app.interthread().publish("group", {"value": 7})
+        self.app.loop()
+
+        self.assertEqual(received, [{"value": 7}])
+
+    def test_interthread_never_reaches_the_cxx_side(self):
+        self.app.interthread().subscribe("group", lambda message: None)
+        self.app.interthread().publish("group", "message")
+        self.app.loop()
+
+        self.assertEqual(self.app.published, [])
+        self.assertEqual(self.app.subscriptions, [])
+
+    def test_a_callback_annotation_still_filters_by_type(self):
+        received = []
+
+        def on_message(message: Message):
+            received.append(message)
+
+        self.app.interthread().subscribe("group", on_message)
+        self.app.interthread().publish("group", "not a Message")
+        self.app.interthread().publish("group", Message(b"kept"))
+        self.app.loop()
+
+        self.assertEqual([message.value for message in received], [b"kept"])
+
+    def test_outer_layers_still_go_straight_to_cxx(self):
+        self.app.interprocess().publish("group", Message(b"payload"))
+
+        self.assertEqual(
+            self.app.published,
+            [(int(goby.INTERPROCESS), "Message", int(goby.PROTOBUF), "group", b"payload")],
+        )
+
+
+class LaunchThreadTest(unittest.TestCase):
+    """Threads: construction on their own thread, message flow, and shutdown."""
+
+    def setUp(self):
+        self.original_bus = _interthread.bus
+        _interthread.bus = _interthread.Bus()
+
+    def tearDown(self):
+        _interthread.bus = self.original_bus
+
+    def run_until(self, app, predicate):
+        """Stands in for the C++ event loop, which calls loop() at the application's rate."""
+        deadline = time.monotonic() + TIMEOUT
+        while time.monotonic() < deadline:
+            app.loop()
+            if predicate():
+                return True
+            time.sleep(0.005)
+        return False
+
+    def test_a_thread_is_constructed_on_its_own_thread(self):
+        app = FakeApp()
+        constructed = {}
+
+        class Recorder(goby.Thread):
+            def __init__(self):
+                super().__init__()
+                constructed["thread"] = threading.current_thread()
+                constructed["index"] = self.index
+
+        app.launch_thread(Recorder, index=3)
+        self.assertTrue(self.run_until(app, lambda: "thread" in constructed))
+
+        self.assertIsNot(constructed["thread"], threading.current_thread())
+        self.assertEqual(constructed["index"], 3)
+        app.join_thread(Recorder, index=3)
+
+    def test_a_thread_cannot_be_constructed_outside_launch_thread(self):
+        with self.assertRaisesRegex(RuntimeError, "launch_thread"):
+            goby.Thread()
+
+    def test_round_trip_between_the_application_and_a_thread(self):
+        app = FakeApp()
+        replies = []
+
+        class Echo(goby.Thread):
+            def __init__(self):
+                super().__init__()
+                self.interthread().subscribe("request", self.on_request)
+
+            def on_request(self, request):
+                self.interthread().publish("reply", {"echoed": request})
+
+        app.interthread().subscribe("reply", replies.append)
+        app.launch_thread(Echo)
+
+        # the subscription is made on the thread, so wait for it before publishing
+        self.assertTrue(self.run_until(app, lambda: "request" in _interthread.bus.groups()))
+        app.interthread().publish("request", "hello")
+
+        self.assertTrue(self.run_until(app, lambda: replies))
+        self.assertEqual(replies, [{"echoed": "hello"}])
+        app.join_thread(Echo)
+
+    def test_a_threads_loop_runs_at_its_own_frequency(self):
+        app = FakeApp()
+        ticks = []
+
+        class Ticker(goby.Thread):
+            def __init__(self):
+                super().__init__(loop_frequency_hertz=100)
+
+            def loop(self):
+                self.interthread().publish("tick", len(ticks))
+
+        app.interthread().subscribe("tick", ticks.append)
+        app.launch_thread(Ticker)
+
+        self.assertTrue(self.run_until(app, lambda: len(ticks) >= 3))
+        app.join_thread(Ticker)
+
+    def test_initialize_and_finalize_run_on_the_thread(self):
+        app = FakeApp()
+        calls = []
+
+        class Lifecycle(goby.Thread):
+            def initialize(self):
+                calls.append(("initialize", threading.current_thread()))
+
+            def finalize(self):
+                calls.append(("finalize", threading.current_thread()))
+
+        app.launch_thread(Lifecycle)
+        self.assertTrue(self.run_until(app, lambda: calls))
+        app.join_thread(Lifecycle)
+
+        self.assertEqual([call[0] for call in calls], ["initialize", "finalize"])
+        self.assertIs(calls[0][1], calls[1][1])
+        self.assertIsNot(calls[0][1], threading.current_thread())
+
+    def test_launching_the_same_thread_twice_is_an_error(self):
+        app = FakeApp()
+
+        class Once(goby.Thread):
+            pass
+
+        app.launch_thread(Once)
+        with self.assertRaisesRegex(RuntimeError, "already running"):
+            app.launch_thread(Once)
+
+        # an index distinguishes them, as it does in C++
+        app.launch_thread(Once, index=1)
+        app._goby_join_all_threads()
+
+    def test_launch_thread_rejects_anything_else(self):
+        app = FakeApp()
+        with self.assertRaisesRegex(TypeError, "goby.Thread"):
+            app.launch_thread(threading.Thread)
+
+    def test_a_thread_that_raises_stops_the_application(self):
+        app = FakeApp()
+
+        class Doomed(goby.Thread):
+            def initialize(self):
+                raise ValueError("thread went wrong")
+
+        app.launch_thread(Doomed)
+        stderr, sys.stderr = sys.stderr, open(os.devnull, "w")
+        try:
+            self.assertTrue(self.run_until(app, lambda: app.quit_values))
+        finally:
+            sys.stderr.close()
+            sys.stderr = stderr
+
+        self.assertEqual(app.quit_values, [1])
+        app._goby_join_all_threads()
+
+    def test_join_all_threads_stops_everything(self):
+        app = FakeApp()
+
+        class Idle(goby.Thread):
+            pass
+
+        app.launch_thread(Idle, index=0)
+        app.launch_thread(Idle, index=1)
+        self.assertTrue(self.run_until(app, lambda: app.running_thread_count() == 2))
+
+        app._goby_join_all_threads()
+        self.assertEqual(app.running_thread_count(), 0)
+
+
+class ThreadForwardingTest(unittest.TestCase):
+    """The outer layers belong to the application's thread, so a thread's calls are handed to it."""
+
+    def setUp(self):
+        self.original_bus = _interthread.bus
+        _interthread.bus = _interthread.Bus()
+        self.app = FakeApp()
+
+    def tearDown(self):
+        _interthread.bus = self.original_bus
+        self.app._goby_join_all_threads()
+
+    def run_until(self, predicate):
+        deadline = time.monotonic() + TIMEOUT
+        while time.monotonic() < deadline:
+            self.app.loop()
+            if predicate():
+                return True
+            time.sleep(0.005)
+        return False
+
+    def test_a_publication_is_made_on_the_applications_thread(self):
+        main_thread = threading.current_thread()
+        publishing_threads = []
+
+        original_publish = self.app._publish
+
+        def record(*args):
+            publishing_threads.append(threading.current_thread())
+            original_publish(*args)
+
+        self.app._publish = record
+
+        class Publisher(FakeThread):
+            def __init__(self):
+                super().__init__()
+                self.interprocess().publish("group", Message(b"from a thread"))
+
+        self.app.launch_thread(Publisher)
+        self.assertTrue(self.run_until(lambda: self.app.published))
+
+        self.assertEqual(self.app.published[0][3:], ("group", b"from a thread"))
+        self.assertEqual(publishing_threads, [main_thread])
+
+    def test_a_subscription_is_registered_on_the_applications_thread(self):
+        main_thread = threading.current_thread()
+        subscribing_threads = []
+
+        original_subscribe = self.app._subscribe
+
+        def record(*args):
+            subscribing_threads.append(threading.current_thread())
+            original_subscribe(*args)
+
+        self.app._subscribe = record
+
+        received = []
+
+        class Subscriber(FakeThread):
+            def __init__(self):
+                super().__init__()
+                self.interprocess().subscribe("group", Message, self.on_message)
+
+            def on_message(self, message):
+                received.append((message.value, threading.current_thread()))
+
+        self.app.launch_thread(Subscriber)
+        self.assertTrue(self.run_until(lambda: self.app.subscriptions))
+        self.assertEqual(subscribing_threads, [main_thread])
+
+        # what C++ would deliver, on the application's thread
+        self.app.subscriptions[0][4](b"delivered")
+
+        self.assertTrue(self.run_until(lambda: received))
+        value, receiving_thread = received[0]
+        self.assertEqual(value, b"delivered")
+        self.assertIsNot(receiving_thread, main_thread)
+
+
+class LoopRateTest(unittest.TestCase):
+    """Servicing threads raises the C++ loop rate, without changing how often loop() is called."""
+
+    def setUp(self):
+        self.original_bus = _interthread.bus
+        _interthread.bus = _interthread.Bus()
+
+    def tearDown(self):
+        _interthread.bus = self.original_bus
+
+    class Idle(goby.Thread):
+        pass
+
+    def test_the_rate_is_untouched_without_threads(self):
+        app = FakeApp(loop_frequency_hertz=1)
+        self.assertEqual(app.loop_frequency_hertz, 1)
+
+    def test_a_slower_application_is_polled_at_the_poll_rate(self):
+        app = FakeApp(loop_frequency_hertz=1, interthread_poll_frequency_hertz=20)
+        app.launch_thread(self.Idle)
+
+        self.assertEqual(app.loop_frequency_hertz, 20)
+        app._goby_join_all_threads()
+
+    def test_a_faster_application_is_left_alone(self):
+        app = FakeApp(loop_frequency_hertz=50, interthread_poll_frequency_hertz=10)
+        app.launch_thread(self.Idle)
+
+        self.assertEqual(app.loop_frequency_hertz, 50)
+        self.assertTrue(app._goby_loop_due())
+        app._goby_join_all_threads()
+
+    def test_the_applications_loop_keeps_its_own_rate(self):
+        calls = []
+
+        class Slow(FakeApp):
+            def loop(self):
+                calls.append(time.monotonic())
+
+        app = Slow(loop_frequency_hertz=10, interthread_poll_frequency_hertz=1000)
+        app.launch_thread(self.Idle)
+
+        # the C++ side would now call loop() 1000 times a second; the application asked for 10
+        deadline = time.monotonic() + 0.5
+        ticks = 0
+        while time.monotonic() < deadline:
+            app.loop()
+            ticks += 1
+            time.sleep(0.001)
+
+        self.assertGreater(ticks, len(calls) * 2)
+        self.assertGreater(len(calls), 1)
+        app._goby_join_all_threads()
+
+    def test_an_application_with_no_loop_is_never_called(self):
+        app = FakeApp(loop_frequency_hertz=0, interthread_poll_frequency_hertz=10)
+        app.launch_thread(self.Idle)
+
+        self.assertEqual(app.loop_frequency_hertz, 10)
+        self.assertFalse(app._goby_loop_due())
+        app.loop()
+        app._goby_join_all_threads()
+
+    def test_subscribing_alone_is_enough_to_be_serviced(self):
+        # an application that only subscribes launches no thread, but still has to pick the
+        # message up from its mailbox
+        app = FakeApp(loop_frequency_hertz=0, interthread_poll_frequency_hertz=10)
+        app.interthread().subscribe("group", lambda message: None)
+
+        self.assertEqual(app.loop_frequency_hertz, 10)
+
+    def test_a_missing_loop_override_is_still_reported(self):
+        app = FakeApp(loop_frequency_hertz=10)
+        with self.assertRaisesRegex(RuntimeError, "loop\\(\\) must be overridden"):
+            app.loop()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/src/share/interface/README.md
+++ b/src/share/interface/README.md
@@ -130,12 +130,20 @@ than generating code that silently does the wrong thing.
 | Construct | Julia | Python |
 |-----------|-------|--------|
 | `interthread`, `interprocess`, `intermodule` | yes | yes |
+| `interthread` declarations are required | yes | no |
 | `scheme: PROTOBUF` | yes | yes |
 | multiple portals per layer (`alias`) | yes | yes |
 | generated module of group constants and accessors | yes | yes |
 
 Reserved for future use, and rejected by both generators today: the `intervehicle` layer, and the
 `DCCL`, `JSON`, `CSTR` and `MAVLINK` schemes.
+
+Both generators implement the `interthread` layer in their own language rather than through the
+C++ `InterThreadTransporter`, so neither generates C++ for it. The Python generator goes one step
+further and does not require the layer to be declared at all: a Python interthread group is any
+string and a Python interthread message is any Python object, so `scheme` and `type` have nothing
+to constrain. Declaring the layer is still useful — the groups become named constants in the
+generated module — and a file that declares it stays valid for both generators.
 
 An `alias` names the accessor the application calls, but only the layer crosses into C++, so it
 cannot distinguish two portals on the same layer that declare the same scheme, type and group.

--- a/src/test/python/interface.yml
+++ b/src/test/python/interface.yml
@@ -1,5 +1,7 @@
 # Interface for the Python bindings compile test. Deliberately exercises both a publication and
-# a subscription, so that both generated macros are compiled.
+# a subscription, so that both generated macros are compiled, and an interthread portal, whose
+# group is deliberately one no C++ header declares: the layer is implemented in Python, so
+# nothing is generated for it.
 application:
   name: GobyPythonTestApp
   cpp_type: goby::zeromq::SingleThreadApplication
@@ -14,5 +16,15 @@ interprocess:
       type: goby.test.python.protobuf.CommsTx
   subscribes:
     - group: goby::test::python::groups::rx
+      scheme: PROTOBUF
+      type: goby.test.python.protobuf.CommsRx
+
+interthread:
+  publishes:
+    - group: thread_status
+      scheme: PROTOBUF
+      type: goby.test.python.protobuf.CommsTx
+  subscribes:
+    - group: thread_request
       scheme: PROTOBUF
       type: goby.test.python.protobuf.CommsRx

--- a/src/test/python/test_app.py
+++ b/src/test/python/test_app.py
@@ -23,6 +23,12 @@ class GeneratedModuleTest(unittest.TestCase):
         self.assertEqual(app_module.groups.tx, "goby::test::python::groups::tx")
         self.assertEqual(app_module.groups.rx, "goby::test::python::groups::rx")
 
+    def test_interthread_groups_need_no_cxx_declaration(self):
+        # the layer never crosses into C++, so its groups are strings the application chooses
+        # rather than groups declared in a header
+        self.assertEqual(app_module.groups.thread_status, "thread_status")
+        self.assertEqual(app_module.groups.thread_request, "thread_request")
+
     def test_resolves_the_config_type(self):
         self.assertIs(app_module.CONFIG_TYPE, test_pb2.TestConfig)
 
@@ -33,8 +39,62 @@ class GeneratedModuleTest(unittest.TestCase):
     def test_base_class_mixes_in_the_python_api(self):
         base = app_module.SingleThreadApplication
         self.assertTrue(issubclass(base, goby.ApplicationMixin))
-        for method in ("loop", "initialize", "finalize", "quit", "app_name", "interprocess"):
+        for method in (
+            "loop",
+            "initialize",
+            "finalize",
+            "quit",
+            "app_name",
+            "interprocess",
+            "interthread",
+            "launch_thread",
+            "join_thread",
+        ):
             self.assertTrue(callable(getattr(base, method)), method)
+
+    def test_thread_base_class_has_the_same_accessors(self):
+        self.assertTrue(issubclass(app_module.Thread, goby.Thread))
+        for method in ("loop", "initialize", "finalize", "interprocess", "interthread"):
+            self.assertTrue(callable(getattr(app_module.Thread, method)), method)
+
+
+class InterthreadTest(unittest.TestCase):
+    """The interthread layer is pure Python, so it works with no portal and no application."""
+
+    def setUp(self):
+        from goby import _interthread
+
+        self.interthread = _interthread
+        self.original_bus = _interthread.bus
+        _interthread.bus = _interthread.Bus()
+
+    def tearDown(self):
+        self.interthread.bus = self.original_bus
+
+    def test_carries_a_protobuf_message_unmarshalled(self):
+        received = []
+        mailbox = self.interthread.Mailbox()
+        published = test_pb2.CommsTx(request_id=42)
+
+        self.interthread.bus.subscribe(
+            app_module.groups.thread_status, None, received.append, mailbox
+        )
+        self.interthread.bus.publish(app_module.groups.thread_status, published)
+        mailbox.service()
+
+        # the same object, not a copy parsed back from bytes
+        self.assertEqual(len(received), 1)
+        self.assertIs(received[0], published)
+
+    def test_carries_anything_else_too(self):
+        received = []
+        mailbox = self.interthread.Mailbox()
+
+        self.interthread.bus.subscribe("any_group", None, received.append, mailbox)
+        self.interthread.bus.publish("any_group", {"not": "a protobuf message"})
+        mailbox.service()
+
+        self.assertEqual(received, [{"not": "a protobuf message"}])
 
 
 class ConfigureTest(unittest.TestCase):


### PR DESCRIPTION
Adds a pure-Python implementation of the interthread layer and support for launching Python threads in Goby applications, mirroring the C++ `SimpleThread` API.

## Summary

The interthread layer is now implemented entirely in Python rather than through the C++ `InterThreadTransporter`. This allows Python threads to communicate with the application and each other using any Python object as a message, without marshalling or crossing the language boundary. Threads are launched with `Application.launch_thread()` and run their own event loop, with `initialize()`, `loop()`, and `finalize()` called on the thread they run on.

## Key Changes

- **New `_interthread.py` module**: Implements `Bus` (publish/subscribe), `Mailbox` (per-thread work queue), and `Thread` (base class for user threads). `ThreadRunner` manages the lifecycle of each thread.
- **Thread lifecycle**: Threads are constructed on their own thread, allowing subscriptions in `__init__`. The runner services the mailbox and calls `loop()` at the requested frequency.
- **Application integration**: `ApplicationMixin` gains `launch_thread()`, `join_thread()`, and `interthread()` accessor. The application's mailbox is serviced at a configurable poll rate when threads are running.
- **Layer forwarding**: Publications and subscriptions from threads on outer layers (interprocess, etc.) are forwarded to the application's thread via its mailbox, preserving the C++ semantics that outer layers belong to the application.
- **Code generation**: The C++ glue code skips the interthread layer entirely, since it never crosses into C++. Interthread groups need no `interface.yml` declaration.
- **Documentation and tests**: Comprehensive unit tests in `test_interthread.py` covering the bus, mailbox, thread lifecycle, message flow, and loop rate management. Updated user-facing documentation with thread examples.

## Implementation Details

- The interthread `Bus` is a module-level singleton shared by all threads, protected by a lock.
- Each thread has a `Mailbox` that queues work as callables; `service()` runs queued work without looping, matching C++ poll semantics.
- Thread construction context is stored in thread-local storage to enforce that `Thread.__init__()` is only called from `launch_thread()`.
- The application's loop is wrapped to service threads at the poll rate while respecting the application's own loop frequency.
- Callbacks from outer layers are wrapped to deliver messages on the thread that subscribed, not the application thread.

https://claude.ai/code/session_01D97Q5zTpLKwkDTYQzPRiCX