### PR TITLE
Python API: cross-compiling, warp-aware time, health(), glog and loop-rate control

### DIFF
--- a/cmake_modules/GobyPython.cmake
+++ b/cmake_modules/GobyPython.cmake
@@ -61,9 +61,10 @@ function(GOBY_PYTHON_FIND_TARGET_DEVELOPMENT)
     return()
   endif()
 
-  # Host and target are normally the same distribution release, so the host's Python version is
-  # the best guess at the target's when several sets of headers are installed. GOBY_PYTHON_TARGET_VERSION
-  # pins it when they differ.
+  # Which version to build against is decided by what the target actually has, not by what the
+  # host runs: the two are often the same distribution release but need not be, and picking the
+  # host's version when the target has another only produces a confusing miss. The host's version
+  # is tried first all the same, to disambiguate a target carrying several.
   set(_versions 3.15 3.14 3.13 3.12 3.11 3.10 3.9 3.8)
   if(GOBY_PYTHON_TARGET_VERSION)
     set(_versions "${GOBY_PYTHON_TARGET_VERSION}")
@@ -80,53 +81,50 @@ function(GOBY_PYTHON_FIND_TARGET_DEVELOPMENT)
     endif()
   endif()
 
-  set(_header_suffixes)
+  # pyconfig.h is the architecture-dependent half, which multiarch keeps under the target triplet.
+  # Deliberately never falling back to the shared python3.X/pyconfig.h when the triplet is known:
+  # that one belongs to the host, and building against it would produce a module for the wrong
+  # ABI rather than an error. A version counts only when both halves are present.
+  set(_tried)
   foreach(_version ${_versions})
-    list(APPEND _header_suffixes "python${_version}")
+    if(CMAKE_LIBRARY_ARCHITECTURE)
+      set(_config_suffix "${CMAKE_LIBRARY_ARCHITECTURE}/python${_version}")
+    else()
+      set(_config_suffix "python${_version}")
+    endif()
+    list(APPEND _tried "${_config_suffix}")
+
+    find_path(_goby_python_h NAMES Python.h PATH_SUFFIXES "python${_version}")
+    find_path(_goby_pyconfig_h NAMES pyconfig.h PATH_SUFFIXES "${_config_suffix}")
+
+    if(_goby_python_h AND _goby_pyconfig_h)
+      set(_found_version "${_version}")
+      set(GOBY_PYTHON_TARGET_PYTHON_H_DIR "${_goby_python_h}"
+        CACHE PATH "Directory holding the target's Python.h")
+      set(GOBY_PYTHON_TARGET_PYCONFIG_H_DIR "${_goby_pyconfig_h}"
+        CACHE PATH "Directory holding the target's pyconfig.h")
+    endif()
+
+    unset(_goby_python_h CACHE)
+    unset(_goby_pyconfig_h CACHE)
+
+    if(_found_version)
+      break()
+    endif()
   endforeach()
 
-  # the version-independent headers, shared by every architecture on a multiarch system
-  find_path(GOBY_PYTHON_TARGET_PYTHON_H_DIR
-    NAMES Python.h
-    PATH_SUFFIXES ${_header_suffixes}
-    DOC "Directory holding the target's Python.h")
-
-  if(NOT GOBY_PYTHON_TARGET_PYTHON_H_DIR)
+  if(NOT _found_version)
+    string(REPLACE ";" ", " _tried_text "${_tried}")
     set(GOBY_PYTHON_TARGET_NOT_FOUND_REASON
-      "the target's Python.h was not found; install python3-dev for the target architecture"
-      PARENT_SCOPE)
+      "no target Python headers found: looked for Python.h and a matching pyconfig.h under \
+${_tried_text}. Install python3-dev for the target architecture (e.g. python3-dev:arm64), or set \
+GOBY_PYTHON_TARGET_VERSION" PARENT_SCOPE)
     return()
   endif()
 
-  get_filename_component(_python_dir_name "${GOBY_PYTHON_TARGET_PYTHON_H_DIR}" NAME)
-  if(NOT _python_dir_name MATCHES "^python([0-9]+)\\.([0-9]+)")
-    set(GOBY_PYTHON_TARGET_NOT_FOUND_REASON
-      "could not read a Python version out of ${GOBY_PYTHON_TARGET_PYTHON_H_DIR}" PARENT_SCOPE)
-    return()
-  endif()
-  set(_major ${CMAKE_MATCH_1})
-  set(_minor ${CMAKE_MATCH_2})
-
-  # pyconfig.h is the architecture-dependent half, which multiarch keeps under the target triplet.
-  # Deliberately not falling back to the shared python3.X/pyconfig.h when the triplet is known:
-  # that one belongs to the host, and building the extension against it would produce a module
-  # for the wrong ABI rather than an error.
-  if(CMAKE_LIBRARY_ARCHITECTURE)
-    set(_config_suffixes "${CMAKE_LIBRARY_ARCHITECTURE}/python${_major}.${_minor}")
-  else()
-    set(_config_suffixes "python${_major}.${_minor}")
-  endif()
-  find_path(GOBY_PYTHON_TARGET_PYCONFIG_H_DIR
-    NAMES pyconfig.h
-    PATH_SUFFIXES ${_config_suffixes}
-    DOC "Directory holding the target's pyconfig.h")
-
-  if(NOT GOBY_PYTHON_TARGET_PYCONFIG_H_DIR)
-    set(GOBY_PYTHON_TARGET_NOT_FOUND_REASON
-      "the target's pyconfig.h was not found under ${_config_suffixes}; install python3-dev for \
-the target architecture (e.g. python3-dev:arm64)" PARENT_SCOPE)
-    return()
-  endif()
+  string(REPLACE "." ";" _version_parts "${_found_version}")
+  list(GET _version_parts 0 _major)
+  list(GET _version_parts 1 _minor)
 
   set(_include_dirs "${GOBY_PYTHON_TARGET_PYTHON_H_DIR}")
   if(NOT "${GOBY_PYTHON_TARGET_PYCONFIG_H_DIR}" STREQUAL "${GOBY_PYTHON_TARGET_PYTHON_H_DIR}")

--- a/cmake_modules/GobyPython.cmake
+++ b/cmake_modules/GobyPython.cmake
@@ -36,26 +36,156 @@
 #   <TARGET>_PYTHONPATH         all of the above, and Goby's own when it is not installed
 #
 # Requires pybind11 and the goby Python package (for goby_gen_cpp).
+#
+# Cross-compiling
+# ---------------
+# Two Pythons are involved and they are not the same one. The generators (goby_gen_cpp, protoc
+# --python_out) run at build time, so they need the *host's* interpreter; the extension module is
+# loaded by the *target's* interpreter, so it is compiled against the target's python3-dev and
+# named with the target's ABI suffix. Install python3-dev for the target architecture
+# (e.g. python3-dev:arm64) and this is detected from the toolchain; override it with:
+#
+#   GOBY_PYTHON_HOST_EXECUTABLE      host interpreter that runs the generators
+#   GOBY_PYTHON_TARGET_VERSION       target Python version, e.g. 3.12 (defaults to the host's)
+#   GOBY_PYTHON_TARGET_INCLUDE_DIRS  directories holding the target's Python.h and pyconfig.h
+#   GOBY_PYTHON_TARGET_SOABI         extension suffix, e.g. cpython-312-aarch64-linux-gnu
+#
+# An extension module does not link libpython on Unix, so headers and the suffix are all that is
+# needed; pybind11 is used headers-only so that it does not run its own Python search against the
+# wrong architecture.
 
-# FindPython makes searching for the interpreter a hard error when cross-compiling without
-# CMAKE_CROSSCOMPILING_EMULATOR (CMP0190), and a Python application is built natively anyway
-if(NOT CMAKE_CROSSCOMPILING OR CMAKE_CROSSCOMPILING_EMULATOR)
-  find_package(Python3 COMPONENTS Interpreter Development.Module QUIET)
+# Locates the target's Python headers and ABI suffix, which is all an extension module needs:
+# on Unix it does not link libpython, so there is no target library to find.
+function(GOBY_PYTHON_FIND_TARGET_DEVELOPMENT)
+  if(GOBY_PYTHON_TARGET_INCLUDE_DIRS AND GOBY_PYTHON_TARGET_SOABI)
+    return()
+  endif()
 
-  if(Python3_FOUND AND NOT pybind11_DIR)
-    # a pip-installed pybind11 is somewhere CMake has no reason to look; the module knows where
-    execute_process(COMMAND ${Python3_EXECUTABLE} -m pybind11 --cmakedir
-      OUTPUT_VARIABLE PYBIND11_PYTHON_CMAKE_DIR
-      RESULT_VARIABLE PYBIND11_PYTHON_CMAKE_DIR_RESULT
+  # Host and target are normally the same distribution release, so the host's Python version is
+  # the best guess at the target's when several sets of headers are installed. GOBY_PYTHON_TARGET_VERSION
+  # pins it when they differ.
+  set(_versions 3.15 3.14 3.13 3.12 3.11 3.10 3.9 3.8)
+  if(GOBY_PYTHON_TARGET_VERSION)
+    set(_versions "${GOBY_PYTHON_TARGET_VERSION}")
+  elseif(GOBY_PYTHON_HOST_EXECUTABLE)
+    execute_process(
+      COMMAND "${GOBY_PYTHON_HOST_EXECUTABLE}" -c
+              "import sys; print('%d.%d' % sys.version_info[:2])"
+      OUTPUT_VARIABLE _host_version
       OUTPUT_STRIP_TRAILING_WHITESPACE
+      RESULT_VARIABLE _host_version_result
       ERROR_QUIET)
-    if(PYBIND11_PYTHON_CMAKE_DIR_RESULT EQUAL 0 AND IS_DIRECTORY "${PYBIND11_PYTHON_CMAKE_DIR}")
-      set(pybind11_DIR "${PYBIND11_PYTHON_CMAKE_DIR}" CACHE PATH "The directory containing a CMake configuration file for pybind11.")
+    if(_host_version_result EQUAL 0 AND _host_version)
+      list(INSERT _versions 0 "${_host_version}")
     endif()
   endif()
 
-  find_package(pybind11 QUIET)
+  set(_header_suffixes)
+  foreach(_version ${_versions})
+    list(APPEND _header_suffixes "python${_version}")
+  endforeach()
+
+  # the version-independent headers, shared by every architecture on a multiarch system
+  find_path(GOBY_PYTHON_TARGET_PYTHON_H_DIR
+    NAMES Python.h
+    PATH_SUFFIXES ${_header_suffixes}
+    DOC "Directory holding the target's Python.h")
+
+  if(NOT GOBY_PYTHON_TARGET_PYTHON_H_DIR)
+    set(GOBY_PYTHON_TARGET_NOT_FOUND_REASON
+      "the target's Python.h was not found; install python3-dev for the target architecture"
+      PARENT_SCOPE)
+    return()
+  endif()
+
+  get_filename_component(_python_dir_name "${GOBY_PYTHON_TARGET_PYTHON_H_DIR}" NAME)
+  if(NOT _python_dir_name MATCHES "^python([0-9]+)\\.([0-9]+)")
+    set(GOBY_PYTHON_TARGET_NOT_FOUND_REASON
+      "could not read a Python version out of ${GOBY_PYTHON_TARGET_PYTHON_H_DIR}" PARENT_SCOPE)
+    return()
+  endif()
+  set(_major ${CMAKE_MATCH_1})
+  set(_minor ${CMAKE_MATCH_2})
+
+  # pyconfig.h is the architecture-dependent half, which multiarch keeps under the target triplet.
+  # Deliberately not falling back to the shared python3.X/pyconfig.h when the triplet is known:
+  # that one belongs to the host, and building the extension against it would produce a module
+  # for the wrong ABI rather than an error.
+  if(CMAKE_LIBRARY_ARCHITECTURE)
+    set(_config_suffixes "${CMAKE_LIBRARY_ARCHITECTURE}/python${_major}.${_minor}")
+  else()
+    set(_config_suffixes "python${_major}.${_minor}")
+  endif()
+  find_path(GOBY_PYTHON_TARGET_PYCONFIG_H_DIR
+    NAMES pyconfig.h
+    PATH_SUFFIXES ${_config_suffixes}
+    DOC "Directory holding the target's pyconfig.h")
+
+  if(NOT GOBY_PYTHON_TARGET_PYCONFIG_H_DIR)
+    set(GOBY_PYTHON_TARGET_NOT_FOUND_REASON
+      "the target's pyconfig.h was not found under ${_config_suffixes}; install python3-dev for \
+the target architecture (e.g. python3-dev:arm64)" PARENT_SCOPE)
+    return()
+  endif()
+
+  set(_include_dirs "${GOBY_PYTHON_TARGET_PYTHON_H_DIR}")
+  if(NOT "${GOBY_PYTHON_TARGET_PYCONFIG_H_DIR}" STREQUAL "${GOBY_PYTHON_TARGET_PYTHON_H_DIR}")
+    list(APPEND _include_dirs "${GOBY_PYTHON_TARGET_PYCONFIG_H_DIR}")
+  endif()
+
+  if(NOT GOBY_PYTHON_TARGET_SOABI)
+    if(NOT CMAKE_LIBRARY_ARCHITECTURE)
+      set(GOBY_PYTHON_TARGET_NOT_FOUND_REASON
+        "CMAKE_LIBRARY_ARCHITECTURE is not set, so the extension module suffix cannot be \
+derived; set GOBY_PYTHON_TARGET_SOABI (e.g. cpython-${_major}${_minor}-aarch64-linux-gnu)"
+        PARENT_SCOPE)
+      return()
+    endif()
+    set(GOBY_PYTHON_TARGET_SOABI "cpython-${_major}${_minor}-${CMAKE_LIBRARY_ARCHITECTURE}"
+      CACHE STRING "ABI suffix of the target's extension modules")
+  endif()
+
+  set(GOBY_PYTHON_TARGET_INCLUDE_DIRS "${_include_dirs}"
+    CACHE STRING "Include directories for the target's Python headers")
+  set(GOBY_PYTHON_TARGET_NOT_FOUND_REASON "" PARENT_SCOPE)
+endfunction()
+
+set(GOBY_PYTHON_CROSSCOMPILING FALSE)
+if(CMAKE_CROSSCOMPILING AND NOT CMAKE_CROSSCOMPILING_EMULATOR)
+  set(GOBY_PYTHON_CROSSCOMPILING TRUE)
 endif()
+
+if(NOT GOBY_PYTHON_CROSSCOMPILING)
+  find_package(Python3 COMPONENTS Interpreter Development.Module QUIET)
+  set(GOBY_PYTHON_HOST_EXECUTABLE "${Python3_EXECUTABLE}")
+else()
+  # FindPython would search the target for both, and makes the interpreter a hard error when
+  # cross-compiling without an emulator (CMP0190), so each half is found on its own
+  if(NOT GOBY_PYTHON_HOST_EXECUTABLE)
+    find_program(GOBY_PYTHON_HOST_EXECUTABLE NAMES python3 python
+      NO_CMAKE_FIND_ROOT_PATH
+      DOC "Host Python interpreter that runs the Goby generators when cross-compiling")
+  endif()
+  goby_python_find_target_development()
+endif()
+
+if(GOBY_PYTHON_HOST_EXECUTABLE AND NOT pybind11_DIR)
+  # a pip-installed pybind11 is somewhere CMake has no reason to look; the module knows where
+  execute_process(COMMAND ${GOBY_PYTHON_HOST_EXECUTABLE} -m pybind11 --cmakedir
+    OUTPUT_VARIABLE PYBIND11_PYTHON_CMAKE_DIR
+    RESULT_VARIABLE PYBIND11_PYTHON_CMAKE_DIR_RESULT
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET)
+  if(PYBIND11_PYTHON_CMAKE_DIR_RESULT EQUAL 0 AND IS_DIRECTORY "${PYBIND11_PYTHON_CMAKE_DIR}")
+    set(pybind11_DIR "${PYBIND11_PYTHON_CMAKE_DIR}" CACHE PATH "The directory containing a CMake configuration file for pybind11.")
+  endif()
+endif()
+
+if(GOBY_PYTHON_CROSSCOMPILING)
+  # tells pybind11Config to provide pybind11::headers without searching for Python itself
+  set(PYBIND11_NOPYTHON ON)
+endif()
+find_package(pybind11 QUIET)
 
 # The generator ships with the goby Python package. Prefer the console script; fall back to
 # running the module out of the build or source tree, which is what an uninstalled build needs.
@@ -63,9 +193,9 @@ if(NOT GOBY_GEN_CPP_COMMAND)
   find_program(GOBY_GEN_CPP_EXECUTABLE goby_gen_cpp)
   if(GOBY_GEN_CPP_EXECUTABLE)
     set(GOBY_GEN_CPP_COMMAND ${GOBY_GEN_CPP_EXECUTABLE} CACHE STRING "Command that runs the Goby Python generator")
-  elseif(Python3_EXECUTABLE AND EXISTS "${GOBY_PYTHON_SOURCE_DIR}/goby/gen.py")
+  elseif(GOBY_PYTHON_HOST_EXECUTABLE AND EXISTS "${GOBY_PYTHON_SOURCE_DIR}/goby/gen.py")
     set(GOBY_GEN_CPP_COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${GOBY_PYTHON_SOURCE_DIR}
-        ${Python3_EXECUTABLE} -m goby.gen
+        ${GOBY_PYTHON_HOST_EXECUTABLE} -m goby.gen
         CACHE STRING "Command that runs the Goby Python generator")
   endif()
 endif()
@@ -107,6 +237,10 @@ function(GOBY_ADD_PYTHON_APP)
   endif()
   if(NOT pybind11_FOUND)
     message(FATAL_ERROR "goby_add_python_app(${GAPA_TARGET}) requires pybind11 (pybind11-dev)")
+  endif()
+  if(GOBY_PYTHON_CROSSCOMPILING AND NOT GOBY_PYTHON_TARGET_INCLUDE_DIRS)
+    message(FATAL_ERROR "goby_add_python_app(${GAPA_TARGET}) is cross-compiling but "
+      "${GOBY_PYTHON_TARGET_NOT_FOUND_REASON}")
   endif()
   if(NOT GOBY_GEN_CPP_COMMAND)
     message(FATAL_ERROR
@@ -164,7 +298,20 @@ function(GOBY_ADD_PYTHON_APP)
     COMMENT "Generating Goby Python bindings for ${GAPA_TARGET} from ${GAPA_INTERFACE_YML}"
     VERBATIM)
 
-  pybind11_add_module(${GAPA_TARGET} "${_cpp_out}" ${GAPA_SOURCES})
+  if(GOBY_PYTHON_CROSSCOMPILING)
+    # pybind11_add_module needs the Python that pybind11Config was told not to look for, so the
+    # module is assembled here from pybind11::headers and the target's own headers and suffix
+    add_library(${GAPA_TARGET} MODULE "${_cpp_out}" ${GAPA_SOURCES})
+    target_link_libraries(${GAPA_TARGET} PRIVATE pybind11::headers)
+    target_include_directories(${GAPA_TARGET} SYSTEM PRIVATE ${GOBY_PYTHON_TARGET_INCLUDE_DIRS})
+    set_target_properties(${GAPA_TARGET} PROPERTIES
+      PREFIX ""
+      SUFFIX ".${GOBY_PYTHON_TARGET_SOABI}.so"
+      CXX_VISIBILITY_PRESET hidden
+      VISIBILITY_INLINES_HIDDEN ON)
+  else()
+    pybind11_add_module(${GAPA_TARGET} "${_cpp_out}" ${GAPA_SOURCES})
+  endif()
 
   set_target_properties(${GAPA_TARGET} PROPERTIES
     OUTPUT_NAME "${_module_name}"
@@ -262,12 +409,20 @@ function(GOBY_ADD_PYTHON_APP)
     endif()
 
     get_filename_component(_main "${GAPA_MAIN}" ABSOLUTE)
+
+    # the launcher runs on the target, so a cross build must not bake in the host's interpreter
+    if(GOBY_PYTHON_CROSSCOMPILING)
+      set(_launcher_python "python3")
+    else()
+      set(_launcher_python "${Python3_EXECUTABLE}")
+    endif()
+
     file(GENERATE
       OUTPUT "${_launcher_dir}/${GAPA_TARGET}"
       CONTENT "#!/bin/sh
 PYTHONPATH=\"${_pythonpath}\${PYTHONPATH:+:\$PYTHONPATH}\"
 export PYTHONPATH
-exec \"${Python3_EXECUTABLE}\" \"${_main}\" \"$@\"
+exec \"${_launcher_python}\" \"${_main}\" \"$@\"
 "
       FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
   endif()

--- a/src/doc/markdown/doc250_languages.md
+++ b/src/doc/markdown/doc250_languages.md
@@ -204,6 +204,31 @@ which the generated module imports so that message types can be resolved by name
 
 Goby must be built with `-Dbuild_python=ON`, which requires `pybind11-dev`.
 
+#### Cross-compiling
+
+Two Pythons are involved and they are not the same one: the generators run at build time against
+the *host's* interpreter, while the extension module is loaded by the *target's*, so it is
+compiled against the target's headers and named with the target's ABI suffix. Install
+`python3-dev` for the target architecture (`python3-dev:arm64`, say) and
+`goby_add_python_app()` works under a cross toolchain with nothing else set; it takes the Python
+version from the host and the multiarch triplet from `CMAKE_LIBRARY_ARCHITECTURE`.
+
+Where that guess is wrong, each piece can be set explicitly:
+
+| Variable | |
+|---|---|
+| `GOBY_PYTHON_HOST_EXECUTABLE` | host interpreter that runs the generators |
+| `GOBY_PYTHON_TARGET_VERSION` | target Python version, e.g. `3.12` |
+| `GOBY_PYTHON_TARGET_INCLUDE_DIRS` | the target's `Python.h` and `pyconfig.h` directories |
+| `GOBY_PYTHON_TARGET_SOABI` | extension suffix, e.g. `cpython-312-aarch64-linux-gnu` |
+
+An extension module does not link `libpython` on Unix, so headers and the suffix are all that is
+needed. When the target's architecture-dependent `pyconfig.h` is missing the build stops and says
+so rather than falling back to the host's, which would produce a module for the wrong ABI.
+
+Note that the extension is architecture-dependent even though the application is Python, so it
+belongs in an `Architecture: any` package rather than an `Architecture: all` one.
+
 ### Installation notes
 
 The `goby` Python package is pure Python; all the compiled code lives in the extension module

--- a/src/doc/markdown/doc250_languages.md
+++ b/src/doc/markdown/doc250_languages.md
@@ -183,6 +183,84 @@ Python threads are Python threads: the GIL interleaves them rather than running 
 so they buy independent loop rates and separation of concerns, not throughput. A thread that
 raises prints its traceback and stops the application.
 
+`set_loop_frequency()` changes the rate while the application is running, which is what a
+commanded sample-rate change needs:
+
+```python
+def on_command(self, command: sensor_pb2.Command) -> None:
+    self.set_loop_frequency(command.sample_rate_hertz)
+```
+
+Threads have the same method. Zero stops `loop()` being called without stopping the application
+or thread receiving messages, and an application whose threads are polled faster than it loops
+keeps polling them at `interthread_poll_frequency_hertz`.
+
+### Time and simulation
+
+Under `app { simulation { time { use_sim_time: true warp_factor: 10 } } }` Goby's clocks run ten
+times faster than the wall clock, and every rate Goby schedules -- `loop_frequency_hertz`
+included -- is in that simulated time. `goby.time` is the Python face of `goby::time`, so an
+application that does its own waiting or timestamping stays on the same clock as the rest of the
+system:
+
+```python
+goby.time.sleep(0.5)      # half a simulated second: 50 ms of wall clock at warp 10
+stamp = goby.time.now()   # seconds since the epoch, as SystemClock::now() reports them
+```
+
+`goby.time.monotonic()`, `warp_factor()` and `using_sim_time()` are also available. Outside
+simulation each is the standard library function, so code written against them needs no branch.
+Reading `time.monotonic()` or calling `time.sleep()` directly is the thing to avoid: at warp 10
+it runs ten times slower than everything around it, which looks like a sensor fault rather than a
+timing bug.
+
+### Logging
+
+`goby.glog` writes to `goby::glog`, so a Python application's output lands in the same place as
+every C++ application's, at the verbosity its `app { glog_config { ... } }` asked for:
+
+```python
+goby.glog.verbose("connected to the device")
+goby.glog.warn(f"no reply in {timeout}s")
+```
+
+An application that already uses the standard `logging` module needs no edits beyond installing
+the handler:
+
+```python
+goby.glog.install()
+logging.getLogger(__name__).info("connected to the device")
+```
+
+`WARNING` and above map to Goby's `WARN`, `INFO` to `VERBOSE`, and `DEBUG` and below to
+`DEBUG1`-`DEBUG3`. Nothing maps to `DIE`, which terminates the application rather than describing
+a record; `goby.glog.die()` is there for when that is meant. The logger is configured while the
+application is constructed, so writes from before then -- at module import, say -- are dropped.
+
+### Health
+
+Override `health()` to answer `goby_coroner`, mirroring the C++ `health(ThreadHealth&)`:
+
+```python
+from goby.middleware.protobuf import coroner_pb2
+
+class Driver(SingleThreadApplication):
+    def health(self, health) -> None:
+        if not self.device.responding:
+            health.state = coroner_pb2.HEALTH__FAILED
+            health.error_message = "the I2C device is not answering"
+```
+
+`health` arrives with what Goby filled in -- the application name, thread id and
+`HEALTH__OK` -- and is reported as given back. It crosses the language boundary as serialized
+Protobuf, so an extension this process has no descriptor for survives the round trip and a
+project's own `ThreadHealth` extensions can be set from Python.
+
+Threads override the same method. Their reports are collected as children of the application's,
+as a C++ `MultiThreadApplication` collects its threads', so a thread appears in the coroner's
+report by name. A thread's `health()` runs on the application's thread, so it should read only
+what is safe to read from another thread.
+
 ### Building
 
 `find_package(goby)` provides `goby_add_python_app()`:

--- a/src/middleware/languages/python/application.h
+++ b/src/middleware/languages/python/application.h
@@ -24,7 +24,9 @@
 #ifndef GOBY_MIDDLEWARE_LANGUAGES_PYTHON_APPLICATION_H
 #define GOBY_MIDDLEWARE_LANGUAGES_PYTHON_APPLICATION_H
 
+#include <chrono>    // for microseconds
 #include <csignal>   // for signal, raise, sig_atomic_t
+#include <cstdint>   // for int64_t
 #include <cstdlib>   // for exit
 #include <exception> // for exception_ptr
 #include <iostream>  // for cout
@@ -44,7 +46,10 @@
 #include "goby/middleware/group.h"
 #include "goby/middleware/languages/common/interface.h"
 #include "goby/middleware/marshalling/interface.h"
+#include "goby/middleware/protobuf/coroner.pb.h"
 #include "goby/time.h"
+#include "goby/time/simulation.h"
+#include "goby/util/debug_logger.h"
 
 namespace goby
 {
@@ -159,12 +164,15 @@ template <typename AppBase> class Application : public AppBase
     using AppBase::AppBase;
 
     using Hook = std::function<void()>;
+    /// \brief Takes the serialized ThreadHealth Goby filled in and returns the one Python wrote
+    using HealthHook = std::function<std::string(const std::string&)>;
 
-    void set_hooks(Hook loop, Hook initialize, Hook finalize)
+    void set_hooks(Hook loop, Hook initialize, Hook finalize, HealthHook health)
     {
         loop_ = std::move(loop);
         initialize_ = std::move(initialize);
         finalize_ = std::move(finalize);
+        health_ = std::move(health);
     }
 
   protected:
@@ -172,6 +180,34 @@ template <typename AppBase> class Application : public AppBase
     {
         if (loop_)
             loop_();
+    }
+
+    /// \brief Hands the report goby_coroner asked for to Python, as serialized Protobuf
+    ///
+    /// Serializing round trip rather than a wrapped message: the Python and C++ descriptor pools
+    /// are separate, and this way an extension Python does not know about survives as an unknown
+    /// field instead of being dropped.
+    void health(goby::middleware::protobuf::ThreadHealth& health) override
+    {
+        AppBase::health(health);
+
+        if (!health_)
+            return;
+
+        std::string before;
+        health.SerializeToString(&before);
+
+        std::string after = health_(before);
+        if (after.empty())
+            return;
+
+        goby::middleware::protobuf::ThreadHealth updated;
+        if (updated.ParseFromString(after))
+            health.Swap(&updated);
+        else
+            goby::glog.is_warn() && goby::glog << "Python health() returned a ThreadHealth that "
+                                                  "could not be parsed; keeping the Goby one"
+                                               << std::endl;
     }
 
     // SingleThreadApplication inherits initialize()/finalize() from both Application and Thread.
@@ -199,6 +235,7 @@ template <typename AppBase> class Application : public AppBase
     Hook loop_;
     Hook initialize_;
     Hook finalize_;
+    HealthHook health_;
     bool initialize_called_{false};
     bool finalize_called_{false};
 };
@@ -224,7 +261,14 @@ template <typename App> class ApplicationWrapper
 
         app_ptr_.reset(new App(loop_frequency_hertz));
         app_ptr_->set_hooks([this]() { this->loop(); }, [this]() { this->initialize(); },
-                            [this]() { this->finalize(); });
+                            [this]() { this->finalize(); },
+                            [this](const std::string& serialized) -> std::string
+                            {
+                                // health() is called from the Goby event loop, which runs with
+                                // the GIL released
+                                py::gil_scoped_acquire gil;
+                                return this->health(py::bytes(serialized));
+                            });
     }
 
     virtual ~ApplicationWrapper() = default;
@@ -244,6 +288,12 @@ template <typename App> class ApplicationWrapper
 
     /// \brief Override in Python for cleanup just before the application exits
     virtual void finalize() {}
+
+    /// \brief Override in Python to answer goby_coroner's health request
+    ///
+    /// \param serialized the ThreadHealth Goby filled in
+    /// \return the ThreadHealth to report, or an empty string to keep Goby's unchanged
+    virtual std::string health(py::bytes serialized) { return std::string(serialized); }
 
     /// \brief Reads the command line into the application configuration
     ///
@@ -411,7 +461,52 @@ template <typename App> class ApplicationWrapperTrampoline : public ApplicationW
     void loop() override { PYBIND11_OVERRIDE(void, ApplicationWrapper<App>, loop, ); }
     void initialize() override { PYBIND11_OVERRIDE(void, ApplicationWrapper<App>, initialize, ); }
     void finalize() override { PYBIND11_OVERRIDE(void, ApplicationWrapper<App>, finalize, ); }
+    std::string health(py::bytes serialized) override
+    {
+        PYBIND11_OVERRIDE_NAME(std::string, ApplicationWrapper<App>, "_goby_health", health,
+                               serialized);
+    }
 };
+
+namespace detail
+{
+/// \brief Writes one already-formatted line to goby::glog at the given verbosity
+///
+/// is() both tests the verbosity and opens the message at it, writing the level's prefix and
+/// taking the logger lock, which the endl closes. At DIE that endl terminates the application,
+/// which is why goby.glog maps no logging level onto it.
+///
+/// The GIL is released for the write: the logger lock is process-wide, and a C++ thread holding
+/// it may be waiting on the GIL to run a callback.
+inline void glog_write(int verbosity, const std::string& group, const std::string& text)
+{
+    py::gil_scoped_release release_gil;
+
+    if (!goby::glog.is(static_cast<goby::util::logger::Verbosity>(verbosity)))
+        return;
+
+    if (!group.empty())
+        goby::glog << ::group(group);
+
+    goby::glog << text << std::endl;
+}
+
+/// \brief Whether anything is listening at this verbosity
+///
+/// Deliberately not goby::glog.is(), which opens a message as well as testing it and takes a lock
+/// that only the matching endl releases. This reads the same state that decides it and leaves
+/// nothing behind.
+inline bool glog_is(int verbosity)
+{
+    auto level = static_cast<goby::util::logger::Verbosity>(verbosity);
+    if (level == goby::util::logger::DIE)
+        return true;
+
+    const auto* buf = dynamic_cast<const goby::util::FlexOStreamBuf*>(goby::glog.rdbuf());
+    return buf != nullptr && buf->highest_verbosity() >= level;
+}
+
+} // namespace detail
 
 /// \brief Defines the contents of the generated extension module
 template <typename App>
@@ -452,7 +547,28 @@ inline void define_python_module(py::module_& m, const std::string& app_name)
         .def_static("_configure_from_text", &ApplicationWrapper<App>::configure_from_text,
                     py::arg("config_text"))
         .def_static("_configure_from_serialized",
-                    &ApplicationWrapper<App>::configure_from_serialized, py::arg("config_bytes"));
+                    &ApplicationWrapper<App>::configure_from_serialized, py::arg("config_bytes"))
+        .def("_goby_health", &ApplicationWrapper<App>::health, py::arg("serialized"));
+
+    // Simulation time lives in process-wide statics rather than on the application, and is set
+    // when the configuration is read. goby.time reads it from here so that a Python loop is
+    // scheduled on the same warped clock the C++ loop runs on.
+    m.def("_sim_time",
+          []() {
+              return py::make_tuple(
+                  goby::time::SimulatorSettings::using_sim_time,
+                  goby::time::SimulatorSettings::warp_factor,
+                  static_cast<std::int64_t>(
+                      goby::time::SimulatorSettings::reference_time.time_since_epoch() /
+                      std::chrono::microseconds(1)));
+          });
+
+    m.def("_glog_write", &detail::glog_write, py::arg("verbosity"), py::arg("group"),
+          py::arg("text"));
+    m.def("_glog_is", &detail::glog_is, py::arg("verbosity"));
+    m.def("_glog_add_group",
+          [](const std::string& name, const std::string& description)
+          { goby::glog.add_group(name, goby::util::Colors::nocolor, description); });
 
     m.attr("_GOBY_APPLICATION_NAME") = app_name;
 }

--- a/src/python/README.md
+++ b/src/python/README.md
@@ -38,6 +38,9 @@ if __name__ == "__main__":
 | `goby/__init__.py` | The public API: `run`, `ApplicationMixin`, `Transporter`, the layer and scheme constants. |
 | `goby/_application.py` | The Python side of an application: layer accessors, publish/subscribe, configuration, threads. |
 | `goby/_interthread.py` | The interthread layer, implemented in Python, and the threads that use it. |
+| `goby/_runtime.py` | Holds the extension module the generated module binds, which `goby.time` and `goby.glog` reach C++ through. |
+| `goby/time.py` | Simulation-aware time: `now`, `monotonic`, `sleep`, `warp_factor`. |
+| `goby/glog.py` | The Goby logger, and a `logging.Handler` that routes Python logging into it. |
 | `goby/_schemes.py` | Layer and marshalling scheme constants, mirroring the C++ enumerations. |
 | `goby/gen.py` | Code generator. Reads `interface.yml` and writes the C++ glue plus the Python module that application code imports. Installed as the `goby_gen_cpp` command. |
 | `goby/schema/` | The machine-readable definition of the `interface.yml` format. |
@@ -71,6 +74,22 @@ The interthread layer is implemented in Python, so an interthread message is any
 and an interthread group is any string. The outer layers belong to the C++ application, which
 lives on the main thread; a thread's publications and subscriptions are handed to it and
 delivered back. See `doc250_languages.md` for the details and the costs.
+
+## Time, logging and health
+
+`goby.time` is the Python face of `goby::time`, so an application that waits or timestamps stays
+on the simulated clock under `warp_factor` rather than dropping to the wall clock:
+
+```python
+goby.time.sleep(0.5)      # half a simulated second
+stamp = goby.time.now()
+```
+
+`goby.glog` writes to `goby::glog` at the verbosity `app { glog_config { ... } }` configured, and
+`goby.glog.install()` routes the standard `logging` module there so existing code needs no edits.
+
+`health()` is overridable on applications and threads, answering `goby_coroner` with a
+`ThreadHealth`; extensions survive the round trip through C++. See `doc250_languages.md`.
 
 ## `interface.yml`
 

--- a/src/python/goby/__init__.py
+++ b/src/python/goby/__init__.py
@@ -76,6 +76,7 @@ import pkgutil
 # alongside this package instead of one shadowing the other.
 __path__ = pkgutil.extend_path(__path__, __name__)
 
+from . import glog, time
 from ._application import (
     ApplicationMixin,
     ConfigError,
@@ -84,6 +85,7 @@ from ._application import (
     run,
 )
 from ._interthread import Thread
+from ._runtime import bind as _bind_extension
 from ._schemes import (
     ALL_SCHEMES,
     CSTR,
@@ -120,6 +122,8 @@ __all__ = [
     "Thread",
     "Transporter",
     "__version__",
+    "glog",
     "message_type",
     "run",
+    "time",
 ]

--- a/src/python/goby/_application.py
+++ b/src/python/goby/_application.py
@@ -31,10 +31,10 @@ architecture-independent.
 import functools
 import inspect
 import sys
-import time
 import typing
 
-from . import _interthread
+from . import _interthread, _runtime
+from . import time as goby_time
 from ._schemes import INTERTHREAD, PROTOBUF
 
 
@@ -102,6 +102,23 @@ def _callback_message_type(callback, required=True):
             f"subscribe(group, MessageType, callback)"
         )
     return annotation
+
+
+def _thread_health_type():
+    """The ThreadHealth message type, imported on first use.
+
+    Goby's own .proto files are compiled to Python and installed beside the package, but an
+    application that never answers a health request should not pay for importing them.
+    """
+    global _THREAD_HEALTH
+    if _THREAD_HEALTH is None:
+        from goby.middleware.protobuf import coroner_pb2
+
+        _THREAD_HEALTH = coroner_pb2.ThreadHealth
+    return _THREAD_HEALTH
+
+
+_THREAD_HEALTH = None
 
 
 def _check_message_type(message_type_):
@@ -284,6 +301,53 @@ class ApplicationMixin:
         self._goby_cfg_cached = config
         return config
 
+    @property
+    def loop_frequency_hertz(self):
+        """The rate loop() is called at, in simulated time."""
+        return self._goby_loop_frequency_hertz
+
+    def set_loop_frequency(self, hertz):
+        """Changes the rate loop() is called at, while the application is running.
+
+        For the common case of a commanded sample-rate change::
+
+            def on_command(self, command: sensor_pb2.Command) -> None:
+                self.set_loop_frequency(command.sample_rate_hertz)
+
+        Zero stops loop() being called. The rate is in simulated time, so it means the same thing
+        under warp as it does outside simulation, and an application with threads keeps polling
+        them at ``interthread_poll_frequency_hertz`` however slowly it loops.
+        """
+        hertz = float(hertz)
+        if hertz < 0:
+            raise ValueError(f"loop frequency must not be negative, got {hertz}")
+
+        self._goby_loop_frequency_hertz = hertz
+        self._goby_apply_loop_frequency()
+
+    def health(self, health):
+        """Override to answer goby_coroner's health request.
+
+        Mirrors the C++ ``health(ThreadHealth&)``: fill in ``health``, which arrives with the
+        state Goby set (``HEALTH__OK``) and this application's name and thread id::
+
+            from goby.middleware.protobuf import coroner_pb2
+
+            def health(self, health) -> None:
+                if not self.device.responding:
+                    health.state = coroner_pb2.HEALTH__FAILED
+                    health.error = coroner_pb2.ERROR__DRIVER_FAILED
+
+        Extensions survive the round trip whether or not this process has them compiled in, so an
+        application is free to set the ones its project declares.
+
+        The default reports the health of each running ``goby.Thread`` as a child, which is what a
+        C++ ``MultiThreadApplication`` does.
+        """
+        for runner in self._goby_threads.values():
+            if runner.is_alive():
+                runner.fill_health(health.child.add())
+
     def interthread(self):
         """The interthread transporter."""
         return self._goby_transporter("interthread", INTERTHREAD)
@@ -358,29 +422,54 @@ class ApplicationMixin:
         if period == 0:
             return False
 
-        now = time.monotonic()
+        # the simulated clock, because the period is a simulated one and so is the C++ loop this
+        # rides on: on the wall clock a warped application would loop warp times too slowly
+        now = goby_time.monotonic()
         if now < self._goby_loop_next:
             return False
         self._goby_loop_next = max(now, self._goby_loop_next + period)
         return True
+
+    def _goby_apply_loop_frequency(self):
+        """Sets the C++ loop rate, and gates loop() here when the two differ.
+
+        The C++ loop has to run at least as often as the threads are polled, so when that is
+        faster than the application asked for, the application's own loop() is called on the
+        schedule it asked for rather than on every C++ loop.
+        """
+        wanted = self._goby_loop_frequency_hertz
+        poll = self._goby_interthread_poll_frequency_hertz if self._goby_serviced else 0.0
+
+        self._set_loop_frequency_hertz(max(wanted, poll))
+
+        if poll <= wanted:
+            self._goby_loop_period = None
+            return
+
+        self._goby_loop_period = 1.0 / wanted if wanted > 0 else 0.0
+        self._goby_loop_next = goby_time.monotonic() + self._goby_loop_period
 
     def _goby_service_required(self):
         """Raises the C++ loop rate so the application picks up its threads' work often enough."""
         if self._goby_serviced:
             return
         self._goby_serviced = True
+        self._goby_apply_loop_frequency()
 
-        poll = self._goby_interthread_poll_frequency_hertz
-        if poll <= self._goby_loop_frequency_hertz:
-            return
+    def _goby_health(self, serialized):
+        """Runs health() against the ThreadHealth Goby filled in; called from C++.
 
-        self._set_loop_frequency_hertz(poll)
-        self._goby_loop_period = (
-            1.0 / self._goby_loop_frequency_hertz
-            if self._goby_loop_frequency_hertz > 0
-            else 0.0
-        )
-        self._goby_loop_next = time.monotonic() + self._goby_loop_period
+        Returns the serialized result, or empty to leave Goby's report alone -- which is what an
+        application with no threads and no health() override does, so the common case costs one
+        call and no protobuf work.
+        """
+        if type(self).health is ApplicationMixin.health and not self._goby_threads:
+            return b""
+
+        message = _thread_health_type()()
+        message.ParseFromString(serialized)
+        self.health(message)
+        return message.SerializeToString()
 
     def _goby_thread_failed(self, name, formatted_traceback):
         """Called from a thread that stopped; the application is quit from its own thread."""
@@ -431,6 +520,10 @@ def run(application_class, argv=None, config=None, config_text=None):
             f"class from the module generated from your interface.yml."
         )
 
+    # normally done as the generated module is imported; repeated here so that goby.time and
+    # goby.glog work for an application whose module was written by hand
+    _runtime.bind(extension)
+
     if config is not None and config_text is not None:
         raise TypeError("pass at most one of config= or config_text=")
     if (config is not None or config_text is not None) and argv is not None:
@@ -448,6 +541,10 @@ def run(application_class, argv=None, config=None, config_text=None):
     except ConfigError:
         # Goby has already reported the problem in the same form a C++ application would
         return 1
+
+    # the warp factor is read out of the configuration, so anything goby.time cached from before
+    # that -- from an import, or a previous run in the same process -- is stale
+    goby_time._reset_cache()
 
     application = application_class()
     try:

--- a/src/python/goby/_interthread.py
+++ b/src/python/goby/_interthread.py
@@ -38,9 +38,9 @@ import functools
 import queue
 import sys
 import threading
-import time
 import traceback
 
+from . import time as goby_time
 from ._schemes import INTERTHREAD
 
 _SHUTDOWN = object()
@@ -203,7 +203,29 @@ class Thread:
 
     @property
     def loop_frequency_hertz(self):
+        """The rate loop() is called at, in simulated time."""
         return self._goby_loop_frequency_hertz
+
+    def set_loop_frequency(self, hertz):
+        """Changes the rate loop() is called at, while the thread is running.
+
+        Takes effect on the next loop; zero stops loop() being called without stopping the thread
+        receiving messages.
+        """
+        hertz = float(hertz)
+        if hertz < 0:
+            raise ValueError(f"loop frequency must not be negative, got {hertz}")
+        self._goby_loop_frequency_hertz = hertz
+
+    def health(self, health):
+        """Override to report this thread's health, as the C++ ``Thread::health()`` does.
+
+        ``health`` arrives with this thread's name and ``HEALTH__OK``. It is reported as a child
+        of the application's health, so goby_coroner sees the thread by name.
+
+        Called on the application's thread rather than this one, so read only what is safe to
+        read from another thread.
+        """
 
     def app_name(self):
         return self._goby_app.app_name()
@@ -266,6 +288,9 @@ class ThreadRunner(threading.Thread):
         self._index = index
         self._args = args
         self._kwargs = kwargs
+        # read by the application's thread to report health, so it is published only once the
+        # thread is fully constructed
+        self._thread = None
 
     def run(self):
         thread = None
@@ -276,6 +301,7 @@ class ThreadRunner(threading.Thread):
             finally:
                 _construction.context = None
 
+            self._thread = thread
             thread.initialize()
             self._service(thread)
         except _Shutdown:
@@ -288,26 +314,55 @@ class ThreadRunner(threading.Thread):
                 self._finalize(thread)
 
     def _service(self, thread):
-        period = (
-            1.0 / thread.loop_frequency_hertz if thread.loop_frequency_hertz > 0 else None
-        )
-        if period is None:
-            while True:
-                self.mailbox.service(timeout=None)
+        # simulated time throughout: the loop frequency is a simulated rate, as it is in C++, so
+        # the waits that implement it are converted to wall-clock only where they meet the queue
+        warp = goby_time.warp_factor()
+        next_loop = None
 
-        next_loop = time.monotonic() + period
         while True:
-            self.mailbox.service(timeout=max(0.0, next_loop - time.monotonic()))
-            now = time.monotonic()
+            period = _loop_period(thread)
+            if period is None:
+                # set_loop_frequency(0) leaves the thread receiving messages, so wait for one
+                self.mailbox.service(timeout=None)
+                next_loop = None
+                continue
+
+            if next_loop is None:
+                next_loop = goby_time.monotonic() + period
+
+            wait = max(0.0, next_loop - goby_time.monotonic())
+            self.mailbox.service(timeout=wait / warp)
+
+            now = goby_time.monotonic()
             if now >= next_loop:
                 next_loop = max(now, next_loop + period)
                 thread.loop()
+
+    def fill_health(self, health):
+        """Fills in this thread's ThreadHealth, for the application's health report."""
+        from goby.middleware.protobuf import coroner_pb2
+
+        health.name = self.name
+        health.state = coroner_pb2.HEALTH__OK
+
+        thread = self._thread
+        if thread is not None:
+            thread.health(health)
 
     def _finalize(self, thread):
         try:
             thread.finalize()
         except BaseException:
             self._app._goby_thread_failed(self.name, traceback.format_exc())
+
+
+def _loop_period(thread):
+    """The thread's loop period in simulated seconds, or None when loop() is switched off.
+
+    Read each time round the service loop, so set_loop_frequency() takes effect on the next one.
+    """
+    hertz = thread.loop_frequency_hertz
+    return 1.0 / hertz if hertz > 0 else None
 
 
 def thread_name(thread_class, index):

--- a/src/python/goby/_runtime.py
+++ b/src/python/goby/_runtime.py
@@ -1,0 +1,87 @@
+# Copyright 2026:
+#   GobySoft, LLC (2013-)
+#   Community contributors (see AUTHORS file)
+# File authors:
+#   Toby Schneider <toby@gobysoft.org>
+#
+#
+# This file is part of the Goby Underwater Autonomy Project Libraries
+# ("The Goby Libraries").
+#
+# The Goby Libraries are free software: you can redistribute them and/or modify
+# them under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# The Goby Libraries are distributed in the hope that they will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Goby.  If not, see <http://www.gnu.org/licenses/>.
+
+"""The compiled extension this process is using.
+
+The ``goby`` package is pure Python and architecture-independent; the compiled code lives in the
+extension module generated for each application. ``goby.time`` and ``goby.glog`` need that
+extension, so the generated module hands it over as it is imported, before any application class
+exists.
+"""
+
+import threading
+
+_lock = threading.Lock()
+_extension = None
+_observers = []
+
+
+def bind(extension):
+    """Records the extension module this process is running against.
+
+    Called by the module generated from ``interface.yml``. An application imports exactly one, so
+    a second call with a different extension is a mistake worth reporting rather than a state to
+    support.
+    """
+    global _extension
+
+    with _lock:
+        if _extension is extension:
+            return
+        if _extension is not None:
+            raise RuntimeError(
+                "Two Goby extension modules were imported into one process "
+                f"({_extension.__name__} and {extension.__name__}). A Goby application is built "
+                "from one interface.yml and imports one generated module."
+            )
+        _extension = extension
+        observers = list(_observers)
+
+    for observer in observers:
+        observer(extension)
+
+
+def extension():
+    """The bound extension module, or None when nothing has imported a generated module yet."""
+    return _extension
+
+
+def require(what):
+    """Returns the bound extension, or explains what the caller needed it for."""
+    if _extension is None:
+        raise RuntimeError(
+            f"{what} needs the extension module generated from your interface.yml. Import your "
+            "application's generated module first; goby.run() does this for you."
+        )
+    return _extension
+
+
+def on_bind(observer):
+    """Calls ``observer(extension)`` when the extension is bound, or now if it already is."""
+    with _lock:
+        if _extension is None:
+            _observers.append(observer)
+            return
+        extension_ = _extension
+
+    observer(extension_)

--- a/src/python/goby/gen.py
+++ b/src/python/goby/gen.py
@@ -379,6 +379,10 @@ def generate_python(
         "",
         f"import {module} as _ext",
         "",
+        "# goby.time and goby.glog reach the C++ side through the extension, which is generated",
+        "# per application, so the package is told which one this process is running against",
+        "goby._bind_extension(_ext)",
+        "",
         "APPLICATION_NAME = _ext._GOBY_APPLICATION_NAME",
         "",
     ]

--- a/src/python/goby/glog.py
+++ b/src/python/goby/glog.py
@@ -1,0 +1,195 @@
+# Copyright 2026:
+#   GobySoft, LLC (2013-)
+#   Community contributors (see AUTHORS file)
+# File authors:
+#   Toby Schneider <toby@gobysoft.org>
+#
+#
+# This file is part of the Goby Underwater Autonomy Project Libraries
+# ("The Goby Libraries").
+#
+# The Goby Libraries are free software: you can redistribute them and/or modify
+# them under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# The Goby Libraries are distributed in the hope that they will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Goby.  If not, see <http://www.gnu.org/licenses/>.
+
+"""The Goby logger, ``goby::glog``, from Python.
+
+A Goby application is configured with ``app { glog_config { tty_verbosity: ... } }``, and every
+C++ application's output goes to that one place at that one verbosity. These functions put a
+Python application's output there too::
+
+    import goby
+
+    goby.glog.verbose("connected to the device")
+    goby.glog.warn(f"no reply in {timeout}s")
+
+For an application that already uses the standard ``logging`` module, ``install()`` routes it
+here instead, so nothing else has to change::
+
+    import logging
+
+    goby.glog.install()
+    logging.getLogger(__name__).info("connected to the device")
+
+Levels map onto Goby's verbosities: ``DEBUG`` and below to ``DEBUG1``-``DEBUG3``, ``INFO`` to
+``VERBOSE``, and ``WARNING`` and above to ``WARN``. Nothing maps to ``DIE``, which terminates the
+application rather than describing a record; call ``die()`` deliberately for that.
+
+The logger is configured while the application is constructed, so writes from before then are
+dropped. That covers module import and anything run before ``goby.run()``.
+"""
+
+import logging
+
+from . import _runtime
+
+__all__ = [
+    "DEBUG1",
+    "DEBUG2",
+    "DEBUG3",
+    "DIE",
+    "GlogHandler",
+    "QUIET",
+    "VERBOSE",
+    "WARN",
+    "add_group",
+    "debug1",
+    "debug2",
+    "debug3",
+    "die",
+    "install",
+    "is_enabled",
+    "verbose",
+    "warn",
+    "write",
+]
+
+# goby::util::logger::Verbosity
+DIE = -1
+QUIET = 0
+WARN = 1
+VERBOSE = 2
+DEBUG1 = 4
+DEBUG2 = 5
+DEBUG3 = 6
+
+_LOGGING_TO_VERBOSITY = (
+    (logging.WARNING, WARN),
+    (logging.INFO, VERBOSE),
+    (logging.DEBUG, DEBUG1),
+)
+
+
+def verbosity_for(level):
+    """The Goby verbosity a ``logging`` level maps onto."""
+    for threshold, verbosity in _LOGGING_TO_VERBOSITY:
+        if level >= threshold:
+            return verbosity
+    # a level below DEBUG is asking for more detail, which is what DEBUG2 and DEBUG3 are for
+    return DEBUG2 if level >= logging.DEBUG // 2 else DEBUG3
+
+
+def write(verbosity, text, group=""):
+    """Writes one line at ``verbosity``, optionally into a named group."""
+    extension = _runtime.extension()
+    if extension is None:
+        return
+    extension._glog_write(int(verbosity), str(group), str(text))
+
+
+def is_enabled(verbosity):
+    """Whether anything is listening at ``verbosity``.
+
+    Worth checking before building an expensive message, as ``goby::glog.is()`` is in C++.
+    """
+    extension = _runtime.extension()
+    if extension is None:
+        return False
+    return extension._glog_is(int(verbosity))
+
+
+def add_group(name, description=""):
+    """Declares a log group, as ``goby::glog.add_group()`` does.
+
+    A group must be declared before it is written to.
+    """
+    extension = _runtime.require("goby.glog.add_group()")
+    extension._glog_add_group(str(name), str(description))
+
+
+def warn(text, group=""):
+    """Writes a warning."""
+    write(WARN, text, group)
+
+
+def verbose(text, group=""):
+    """Writes at the default verbosity."""
+    write(VERBOSE, text, group)
+
+
+def debug1(text, group=""):
+    write(DEBUG1, text, group)
+
+
+def debug2(text, group=""):
+    write(DEBUG2, text, group)
+
+
+def debug3(text, group=""):
+    write(DEBUG3, text, group)
+
+
+def die(text, group=""):
+    """Writes the message and terminates the application, as ``goby::glog`` does at DIE."""
+    extension = _runtime.require("goby.glog.die()")
+    extension._glog_write(int(DIE), str(group), str(text))
+
+
+class GlogHandler(logging.Handler):
+    """A ``logging`` handler that writes to ``goby::glog``.
+
+    :param group: log group to write into; it must have been declared with ``add_group()``
+    """
+
+    def __init__(self, group=""):
+        super().__init__()
+        self.group = group
+
+    def emit(self, record):
+        try:
+            write(verbosity_for(record.levelno), self.format(record), self.group)
+        except Exception:  # noqa: BLE001 - a logging handler must not raise into its caller
+            self.handleError(record)
+
+
+def install(logger=None, level=logging.DEBUG, group="", replace=True):
+    """Routes the standard ``logging`` module to the Goby logger.
+
+    :param logger: the logger to attach to; the root logger by default
+    :param level: the level below which records are dropped before reaching Goby. The default
+        passes everything and lets ``glog_config`` decide, which is the point of the bridge.
+    :param group: log group to write into
+    :param replace: remove any handlers already attached, so records are not also printed
+        straight to the terminal outside Goby's formatting
+    :return: the installed handler
+    """
+    logger = logging.getLogger() if logger is None else logger
+
+    if replace:
+        for existing in list(logger.handlers):
+            logger.removeHandler(existing)
+
+    handler = GlogHandler(group)
+    handler.setLevel(level)
+    logger.addHandler(handler)
+    logger.setLevel(min(logger.level, level) if logger.level else level)
+    return handler

--- a/src/python/goby/time.py
+++ b/src/python/goby/time.py
@@ -1,0 +1,124 @@
+# Copyright 2026:
+#   GobySoft, LLC (2013-)
+#   Community contributors (see AUTHORS file)
+# File authors:
+#   Toby Schneider <toby@gobysoft.org>
+#
+#
+# This file is part of the Goby Underwater Autonomy Project Libraries
+# ("The Goby Libraries").
+#
+# The Goby Libraries are free software: you can redistribute them and/or modify
+# them under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# The Goby Libraries are distributed in the hope that they will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Goby.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Simulation-aware time, mirroring ``goby::time``.
+
+Under ``app { simulation { time { use_sim_time: true warp_factor: 10 } } }`` the C++ clocks run
+ten times faster than the wall clock, and everything Goby schedules -- loop rates, timeouts --
+is expressed in that simulated time. An application that reads ``time.monotonic()`` or calls
+``time.sleep()`` directly is on the wall clock, so at warp 10 it runs ten times slower than the
+rest of the system.
+
+Use these in place of the standard library's::
+
+    import goby
+
+    goby.time.sleep(0.5)           # half a simulated second
+    stamp = goby.time.now()        # seconds since the epoch, on the simulated clock
+
+``goby.run()`` and ``loop_frequency_hertz`` are already on this clock; this module is for an
+application that does its own waiting or timestamping.
+
+Outside simulation every function here is the standard library function, so code written against
+it needs no branch.
+"""
+
+import time as _time
+
+from . import _runtime
+
+__all__ = [
+    "monotonic",
+    "now",
+    "sleep",
+    "using_sim_time",
+    "warp_factor",
+]
+
+# (using_sim_time, warp_factor, reference_microtime), read from the extension on first use.
+# Goby reads it out of the configuration, so it is fixed by the time an application runs.
+_settings = None
+
+
+def _read_settings():
+    global _settings
+
+    if _settings is None:
+        extension = _runtime.extension()
+        if extension is None:
+            # nothing has been configured, so nothing is warped
+            return (False, 1, 0)
+        _settings = tuple(extension._sim_time())
+    return _settings
+
+
+def _reset_cache():
+    """Forgets the cached settings; for tests, which configure more than once per process."""
+    global _settings
+    _settings = None
+
+
+def using_sim_time():
+    """Whether this application was configured to run on a simulated clock."""
+    return bool(_read_settings()[0])
+
+
+def warp_factor():
+    """How much faster than the wall clock the simulated clock runs; 1 outside simulation."""
+    using, warp, _ = _read_settings()
+    return warp if using and warp > 0 else 1
+
+
+def now():
+    """Seconds since the UNIX epoch on the simulated clock, mirroring ``SystemClock::now()``.
+
+    Outside simulation this is ``time.time()``.
+    """
+    using, warp, reference_microtime = _read_settings()
+    real = _time.time()
+    if not using:
+        return real
+
+    # t_sim = (t - t0) * w + t0, as SystemClock::warp() computes it
+    reference = reference_microtime / 1e6
+    return (real - reference) * warp + reference
+
+
+def monotonic():
+    """A monotonic clock in simulated seconds, mirroring ``SteadyClock::now()``.
+
+    Use it for measuring simulated durations; unlike ``now()`` it is unaffected by changes to the
+    system clock. Outside simulation this is ``time.monotonic()``.
+    """
+    return _time.monotonic() * warp_factor()
+
+
+def sleep(seconds):
+    """Sleeps for ``seconds`` of simulated time.
+
+    At warp 10, ``sleep(1)`` returns after a tenth of a wall-clock second, so a driver polling its
+    device keeps pace with the simulation rather than falling behind it.
+    """
+    if seconds <= 0:
+        return
+    _time.sleep(seconds / warp_factor())

--- a/src/python/tests/test_glog.py
+++ b/src/python/tests/test_glog.py
@@ -1,0 +1,192 @@
+"""Unit tests for goby.glog, the bridge to the Goby logger.
+
+goby::glog itself is C++, so these tests stand in for the extension and check what would be
+handed to it: the verbosity a record maps onto, and that a handler never raises into the code
+that logged. The end-to-end path -- that this actually reaches the Goby log file -- is covered by
+the compiled test application.
+
+Run with `python3 -m unittest discover -s tests` from src/python, or through CTest as the
+goby_test_python_unit test.
+"""
+
+import logging
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import goby  # noqa: E402
+from goby import _runtime  # noqa: E402
+
+
+class FakeExtension:
+    """The generated extension, reduced to the glog entry points."""
+
+    __name__ = "_fake_goby"
+
+    def __init__(self, enabled_at=goby.glog.DEBUG3):
+        self.written = []
+        self.groups = []
+        self.enabled_at = enabled_at
+
+    def _glog_write(self, verbosity, group, text):
+        self.written.append((verbosity, group, text))
+
+    def _glog_is(self, verbosity):
+        return verbosity <= self.enabled_at
+
+    def _glog_add_group(self, name, description):
+        self.groups.append((name, description))
+
+
+class GlogTestCase(unittest.TestCase):
+    def setUp(self):
+        self.original = _runtime._extension
+        self.extension = FakeExtension()
+        _runtime._extension = self.extension
+        self.addCleanup(self._restore)
+
+    def _restore(self):
+        _runtime._extension = self.original
+
+
+class VerbosityMappingTest(unittest.TestCase):
+    def test_warning_and_above_are_warnings(self):
+        for level in (logging.WARNING, logging.ERROR, logging.CRITICAL):
+            self.assertEqual(goby.glog.verbosity_for(level), goby.glog.WARN)
+
+    def test_info_is_the_default_verbosity(self):
+        self.assertEqual(goby.glog.verbosity_for(logging.INFO), goby.glog.VERBOSE)
+
+    def test_debug_is_the_first_debug_level(self):
+        self.assertEqual(goby.glog.verbosity_for(logging.DEBUG), goby.glog.DEBUG1)
+
+    def test_below_debug_asks_for_more_not_less(self):
+        self.assertEqual(goby.glog.verbosity_for(logging.DEBUG - 1), goby.glog.DEBUG2)
+        self.assertEqual(goby.glog.verbosity_for(1), goby.glog.DEBUG3)
+
+    def test_nothing_maps_to_die(self):
+        # writing at DIE terminates the application, which no log record should be able to do
+        for level in range(0, 60):
+            self.assertNotEqual(goby.glog.verbosity_for(level), goby.glog.DIE)
+
+
+class WriteTest(GlogTestCase):
+    def test_each_level_writes_at_its_verbosity(self):
+        goby.glog.warn("w")
+        goby.glog.verbose("v")
+        goby.glog.debug1("d1")
+        goby.glog.debug2("d2")
+        goby.glog.debug3("d3")
+
+        self.assertEqual(
+            [(verbosity, text) for verbosity, _, text in self.extension.written],
+            [
+                (goby.glog.WARN, "w"),
+                (goby.glog.VERBOSE, "v"),
+                (goby.glog.DEBUG1, "d1"),
+                (goby.glog.DEBUG2, "d2"),
+                (goby.glog.DEBUG3, "d3"),
+            ],
+        )
+
+    def test_a_group_is_passed_through(self):
+        goby.glog.verbose("text", group="driver")
+
+        self.assertEqual(self.extension.written, [(goby.glog.VERBOSE, "driver", "text")])
+
+    def test_is_enabled_asks_the_logger(self):
+        self.extension.enabled_at = goby.glog.WARN
+
+        self.assertTrue(goby.glog.is_enabled(goby.glog.WARN))
+        self.assertFalse(goby.glog.is_enabled(goby.glog.DEBUG1))
+
+    def test_add_group_is_declared(self):
+        goby.glog.add_group("driver", "the sensor driver")
+
+        self.assertEqual(self.extension.groups, [("driver", "the sensor driver")])
+
+
+class UnboundTest(unittest.TestCase):
+    """Before a generated module is imported there is nothing to write to."""
+
+    def setUp(self):
+        self.original = _runtime._extension
+        _runtime._extension = None
+        self.addCleanup(self._restore)
+
+    def _restore(self):
+        _runtime._extension = self.original
+
+    def test_writing_is_dropped_rather_than_raising(self):
+        # module-level logging happens before the application is constructed; it should not be
+        # the thing that stops the application starting
+        goby.glog.warn("nowhere to go")
+        self.assertFalse(goby.glog.is_enabled(goby.glog.WARN))
+
+    def test_add_group_explains_what_is_missing(self):
+        with self.assertRaisesRegex(RuntimeError, "interface.yml"):
+            goby.glog.add_group("driver")
+
+
+class HandlerTest(GlogTestCase):
+    def setUp(self):
+        super().setUp()
+        self.logger = logging.getLogger("goby.tests.handler")
+        self.logger.handlers = []
+        self.logger.propagate = False
+
+    def test_records_reach_glog_at_the_mapped_verbosity(self):
+        goby.glog.install(self.logger)
+
+        self.logger.info("connected")
+        self.logger.warning("no reply")
+
+        self.assertEqual(
+            [(verbosity, text) for verbosity, _, text in self.extension.written],
+            [(goby.glog.VERBOSE, "connected"), (goby.glog.WARN, "no reply")],
+        )
+
+    def test_formatting_is_applied(self):
+        goby.glog.install(self.logger)
+
+        self.logger.info("depth %.1f m", 12.34)
+
+        self.assertEqual(self.extension.written[0][2], "depth 12.3 m")
+
+    def test_install_replaces_existing_handlers(self):
+        self.logger.addHandler(logging.StreamHandler())
+        goby.glog.install(self.logger)
+
+        self.assertEqual(len(self.logger.handlers), 1)
+        self.assertIsInstance(self.logger.handlers[0], goby.glog.GlogHandler)
+
+    def test_install_can_keep_existing_handlers(self):
+        existing = logging.StreamHandler()
+        self.logger.addHandler(existing)
+        goby.glog.install(self.logger, replace=False)
+
+        self.assertIn(existing, self.logger.handlers)
+        self.assertEqual(len(self.logger.handlers), 2)
+
+    def test_a_group_is_carried_by_the_handler(self):
+        goby.glog.install(self.logger, group="driver")
+
+        self.logger.info("text")
+
+        self.assertEqual(self.extension.written[0][1], "driver")
+
+    def test_a_failing_write_does_not_raise_into_the_caller(self):
+        def explode(*args):
+            raise RuntimeError("glog is unhappy")
+
+        self.extension._glog_write = explode
+        handler = goby.glog.install(self.logger)
+        handler.handleError = lambda record: None
+
+        self.logger.info("this must not propagate")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/src/python/tests/test_interthread.py
+++ b/src/python/tests/test_interthread.py
@@ -20,9 +20,21 @@ import unittest
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 import goby  # noqa: E402
-from goby import _interthread  # noqa: E402
+from goby import _interthread, _runtime  # noqa: E402
 
 TIMEOUT = 5
+
+
+class FakeExtension:
+    """The generated extension, reduced to the simulation settings goby.time reads."""
+
+    __name__ = "_fake_goby"
+
+    def __init__(self, using_sim_time, warp_factor, reference_microtime=0):
+        self._settings = (using_sim_time, warp_factor, reference_microtime)
+
+    def _sim_time(self):
+        return self._settings
 
 
 class Message:
@@ -51,7 +63,9 @@ class FakeBase:
     """The compiled _ApplicationBase, reduced to what the Python side calls."""
 
     def __init__(self, loop_frequency_hertz=0):
-        self.loop_frequency_hertz = float(loop_frequency_hertz)
+        # the rate the C++ loop runs at, which is not the rate the application's loop() is
+        # called at once threads raise it
+        self.cxx_loop_frequency_hertz = float(loop_frequency_hertz)
         self.published = []
         self.subscriptions = []
         self.quit_values = []
@@ -63,7 +77,7 @@ class FakeBase:
         self.subscriptions.append((int(layer), type_name, int(scheme), group, callback))
 
     def _set_loop_frequency_hertz(self, loop_frequency_hertz):
-        self.loop_frequency_hertz = float(loop_frequency_hertz)
+        self.cxx_loop_frequency_hertz = float(loop_frequency_hertz)
 
     def quit(self, return_value=0):
         self.quit_values.append(return_value)
@@ -498,20 +512,20 @@ class LoopRateTest(unittest.TestCase):
 
     def test_the_rate_is_untouched_without_threads(self):
         app = FakeApp(loop_frequency_hertz=1)
-        self.assertEqual(app.loop_frequency_hertz, 1)
+        self.assertEqual(app.cxx_loop_frequency_hertz, 1)
 
     def test_a_slower_application_is_polled_at_the_poll_rate(self):
         app = FakeApp(loop_frequency_hertz=1, interthread_poll_frequency_hertz=20)
         app.launch_thread(self.Idle)
 
-        self.assertEqual(app.loop_frequency_hertz, 20)
+        self.assertEqual(app.cxx_loop_frequency_hertz, 20)
         app._goby_join_all_threads()
 
     def test_a_faster_application_is_left_alone(self):
         app = FakeApp(loop_frequency_hertz=50, interthread_poll_frequency_hertz=10)
         app.launch_thread(self.Idle)
 
-        self.assertEqual(app.loop_frequency_hertz, 50)
+        self.assertEqual(app.cxx_loop_frequency_hertz, 50)
         self.assertTrue(app._goby_loop_due())
         app._goby_join_all_threads()
 
@@ -541,7 +555,7 @@ class LoopRateTest(unittest.TestCase):
         app = FakeApp(loop_frequency_hertz=0, interthread_poll_frequency_hertz=10)
         app.launch_thread(self.Idle)
 
-        self.assertEqual(app.loop_frequency_hertz, 10)
+        self.assertEqual(app.cxx_loop_frequency_hertz, 10)
         self.assertFalse(app._goby_loop_due())
         app.loop()
         app._goby_join_all_threads()
@@ -552,12 +566,259 @@ class LoopRateTest(unittest.TestCase):
         app = FakeApp(loop_frequency_hertz=0, interthread_poll_frequency_hertz=10)
         app.interthread().subscribe("group", lambda message: None)
 
-        self.assertEqual(app.loop_frequency_hertz, 10)
+        self.assertEqual(app.cxx_loop_frequency_hertz, 10)
 
     def test_a_missing_loop_override_is_still_reported(self):
         app = FakeApp(loop_frequency_hertz=10)
         with self.assertRaisesRegex(RuntimeError, "loop\\(\\) must be overridden"):
             app.loop()
+
+
+class WarpedLoopTest(unittest.TestCase):
+    """Under warp the C++ loop runs faster in wall-clock terms, and so must the Python gate.
+
+    Scheduling loop() on time.monotonic() while riding a warped C++ loop is the bug this covers:
+    it made a 10 Hz loop fire at an effective 1 Hz under warp 10.
+    """
+
+    def setUp(self):
+        self.original_bus = _interthread.bus
+        _interthread.bus = _interthread.Bus()
+        self.original_extension = _runtime._extension
+        self.addCleanup(self._restore)
+
+    def _restore(self):
+        _interthread.bus = self.original_bus
+        _runtime._extension = self.original_extension
+        goby.time._reset_cache()
+
+    def _warp(self, factor):
+        _runtime._extension = FakeExtension(True, factor)
+        goby.time._reset_cache()
+
+    class Idle(goby.Thread):
+        pass
+
+    def _count_loops(self, wall_seconds=0.3):
+        calls = []
+
+        class Counting(FakeApp):
+            def loop(self):
+                calls.append(None)
+
+        app = Counting(loop_frequency_hertz=10, interthread_poll_frequency_hertz=1000)
+        app.launch_thread(self.Idle)
+
+        deadline = time.monotonic() + wall_seconds
+        while time.monotonic() < deadline:
+            app.loop()
+            time.sleep(0.001)
+        app._goby_join_all_threads()
+        return len(calls)
+
+    def test_unwarped_a_10hz_loop_fires_about_10_times_a_second(self):
+        self._warp(1)
+        self.assertLessEqual(self._count_loops(), 8)
+
+    def test_warped_it_keeps_its_rate_in_simulated_time(self):
+        self._warp(10)
+        # 0.3 wall seconds is 3 simulated seconds, so a 10 Hz loop is due about 30 times
+        self.assertGreater(self._count_loops(), 12)
+
+
+class SetLoopFrequencyTest(unittest.TestCase):
+    """The public rate change, which has to keep cooperating with the thread poll rate."""
+
+    def setUp(self):
+        self.original_bus = _interthread.bus
+        _interthread.bus = _interthread.Bus()
+
+    def tearDown(self):
+        _interthread.bus = self.original_bus
+
+    class Idle(goby.Thread):
+        pass
+
+    def test_the_rate_reaches_the_cxx_side(self):
+        app = FakeApp(loop_frequency_hertz=1)
+        app.set_loop_frequency(25)
+
+        self.assertEqual(app.loop_frequency_hertz, 25)
+        self.assertEqual(app.cxx_loop_frequency_hertz, 25)
+
+    def test_slowing_below_the_poll_rate_keeps_polling(self):
+        app = FakeApp(loop_frequency_hertz=50, interthread_poll_frequency_hertz=10)
+        app.launch_thread(self.Idle)
+        app.set_loop_frequency(1)
+
+        # the application loops at 1 Hz, but its threads are still picked up at 10
+        self.assertEqual(app.loop_frequency_hertz, 1)
+        self.assertEqual(app.cxx_loop_frequency_hertz, 10)
+        app._goby_join_all_threads()
+
+    def test_speeding_past_the_poll_rate_raises_the_cxx_rate(self):
+        app = FakeApp(loop_frequency_hertz=1, interthread_poll_frequency_hertz=10)
+        app.launch_thread(self.Idle)
+        app.set_loop_frequency(100)
+
+        self.assertEqual(app.cxx_loop_frequency_hertz, 100)
+        # no gating is needed once the application is the faster of the two
+        self.assertTrue(app._goby_loop_due())
+        app._goby_join_all_threads()
+
+    def test_zero_stops_loop_without_stopping_the_threads(self):
+        app = FakeApp(loop_frequency_hertz=10, interthread_poll_frequency_hertz=10)
+        app.launch_thread(self.Idle)
+        app.set_loop_frequency(0)
+
+        self.assertEqual(app.cxx_loop_frequency_hertz, 10)
+        self.assertFalse(app._goby_loop_due())
+        app._goby_join_all_threads()
+
+    def test_a_negative_rate_is_rejected(self):
+        app = FakeApp()
+        with self.assertRaisesRegex(ValueError, "negative"):
+            app.set_loop_frequency(-1)
+
+    def test_a_thread_rate_takes_effect_on_the_next_loop(self):
+        loops = []
+
+        class Counting(goby.Thread):
+            def __init__(self):
+                super().__init__(loop_frequency_hertz=1000)
+
+            def loop(self):
+                loops.append(self.loop_frequency_hertz)
+                if len(loops) == 1:
+                    self.set_loop_frequency(500)
+
+        app = FakeApp()
+        app.launch_thread(Counting)
+
+        deadline = time.monotonic() + TIMEOUT
+        while len(loops) < 2 and time.monotonic() < deadline:
+            time.sleep(0.005)
+        app._goby_join_all_threads()
+
+        self.assertGreaterEqual(len(loops), 2)
+        self.assertEqual(loops[0], 1000)
+        self.assertEqual(loops[1], 500)
+
+
+class HealthTest(unittest.TestCase):
+    """The report goby_coroner asks for, which arrives as serialized Protobuf from C++."""
+
+    def setUp(self):
+        try:
+            from goby.middleware.protobuf import coroner_pb2
+        except ImportError as error:
+            # naming the import that failed: coroner_pb2 pulls in dccl, whose extension module
+            # is built for one interpreter, so running under another skips this silently
+            self.skipTest(f"goby.middleware.protobuf.coroner_pb2 is not importable: {error}")
+        self.coroner_pb2 = coroner_pb2
+        self.original_bus = _interthread.bus
+        _interthread.bus = _interthread.Bus()
+
+    def tearDown(self):
+        _interthread.bus = self.original_bus
+
+    def _goby_report(self, name="fake_app"):
+        """What Goby hands Python: the report it already filled in."""
+        health = self.coroner_pb2.ThreadHealth()
+        health.name = name
+        health.state = self.coroner_pb2.HEALTH__OK
+        return health.SerializeToString()
+
+    class Idle(goby.Thread):
+        pass
+
+    def test_an_application_with_nothing_to_add_is_not_charged_for_it(self):
+        app = FakeApp()
+
+        # empty means "keep what Goby filled in", so no protobuf work happens on either side
+        self.assertEqual(app._goby_health(self._goby_report()), b"")
+
+    def test_an_override_is_called_with_what_goby_filled_in(self):
+        seen = []
+
+        class Reporting(FakeApp):
+            def health(self, health):
+                seen.append((health.name, health.state))
+
+        app = Reporting()
+        app._goby_health(self._goby_report("driver"))
+
+        self.assertEqual(seen, [("driver", self.coroner_pb2.HEALTH__OK)])
+
+    def test_what_the_override_sets_is_returned(self):
+        class Failing(FakeApp):
+            def health(self, health):
+                health.state = self.coroner_pb2_ref.HEALTH__FAILED
+                health.error_message = "the device is not answering"
+
+        Failing.coroner_pb2_ref = self.coroner_pb2
+        app = Failing()
+
+        updated = self.coroner_pb2.ThreadHealth()
+        updated.ParseFromString(app._goby_health(self._goby_report()))
+
+        self.assertEqual(updated.state, self.coroner_pb2.HEALTH__FAILED)
+        self.assertEqual(updated.error_message, "the device is not answering")
+
+    def test_an_extension_this_process_does_not_know_survives(self):
+        # ThreadHealth reserves 1000 and up for projects; an application built without those
+        # descriptors must not drop them on the way through
+        report = self.coroner_pb2.ThreadHealth()
+        report.name = "driver"
+        report.state = self.coroner_pb2.HEALTH__OK
+        serialized = report.SerializeToString()
+        # field 1000, varint, value 7 -- an extension no descriptor here knows about
+        serialized += b"\xc0\x3e\x07"
+
+        class Reporting(FakeApp):
+            def health(self, health):
+                health.error_message = "still here"
+
+        app = Reporting()
+        returned = app._goby_health(serialized)
+
+        self.assertIn(b"\xc0\x3e\x07", returned)
+
+    def test_running_threads_are_reported_as_children(self):
+        app = FakeApp()
+        app.launch_thread(self.Idle)
+        app.launch_thread(self.Idle, index=2)
+
+        updated = self.coroner_pb2.ThreadHealth()
+        updated.ParseFromString(app._goby_health(self._goby_report()))
+        app._goby_join_all_threads()
+
+        # the name is the thread class's qualified name, as goby.Thread reports it elsewhere
+        self.assertEqual(
+            sorted(child.name for child in updated.child),
+            ["HealthTest.Idle", "HealthTest.Idle/2"],
+        )
+        for child in updated.child:
+            self.assertEqual(child.state, self.coroner_pb2.HEALTH__OK)
+
+    def test_a_thread_can_report_its_own_state(self):
+        coroner_pb2 = self.coroner_pb2
+
+        class Unhappy(goby.Thread):
+            def health(self, health):
+                health.state = coroner_pb2.HEALTH__DEGRADED
+                health.error_message = "I2C timeout"
+
+        app = FakeApp()
+        app.launch_thread(Unhappy)
+
+        updated = self.coroner_pb2.ThreadHealth()
+        updated.ParseFromString(app._goby_health(self._goby_report()))
+        app._goby_join_all_threads()
+
+        self.assertEqual(len(updated.child), 1)
+        self.assertEqual(updated.child[0].state, coroner_pb2.HEALTH__DEGRADED)
+        self.assertEqual(updated.child[0].error_message, "I2C timeout")
 
 
 if __name__ == "__main__":

--- a/src/python/tests/test_time.py
+++ b/src/python/tests/test_time.py
@@ -1,0 +1,138 @@
+"""Unit tests for goby.time, the simulation-aware clock.
+
+The warp factor normally comes from the compiled extension, which reads it out of the application
+configuration. These tests stand in for the extension so that the arithmetic can be checked
+without building one: what matters is that a warped clock runs warp times faster than the wall
+clock and that the conversion matches SystemClock::warp() in C++.
+
+Run with `python3 -m unittest discover -s tests` from src/python, or through CTest as the
+goby_test_python_unit test.
+"""
+
+import os
+import sys
+import time as wall
+import types
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import goby  # noqa: E402
+from goby import _runtime  # noqa: E402
+
+
+class FakeExtension(types.SimpleNamespace):
+    """The generated extension, reduced to the simulation settings goby.time reads."""
+
+    def __init__(self, using_sim_time, warp_factor, reference_microtime=0):
+        super().__init__(__name__="_fake_goby")
+        self._settings = (using_sim_time, warp_factor, reference_microtime)
+
+    def _sim_time(self):
+        return self._settings
+
+
+class SimTimeTest(unittest.TestCase):
+    def setUp(self):
+        # _runtime.bind() deliberately refuses a second extension, so the module state is
+        # replaced directly rather than through the public call
+        self.original = _runtime._extension
+        self.addCleanup(self._restore)
+
+    def _restore(self):
+        _runtime._extension = self.original
+        goby.time._reset_cache()
+
+    def _bind(self, extension):
+        _runtime._extension = extension
+        goby.time._reset_cache()
+
+    def test_no_extension_is_real_time(self):
+        self._bind(None)
+
+        self.assertFalse(goby.time.using_sim_time())
+        self.assertEqual(goby.time.warp_factor(), 1)
+
+    def test_outside_simulation_nothing_is_warped(self):
+        self._bind(FakeExtension(False, 10))
+
+        self.assertFalse(goby.time.using_sim_time())
+        self.assertEqual(goby.time.warp_factor(), 1)
+        self.assertAlmostEqual(goby.time.now(), wall.time(), delta=1.0)
+
+    def test_warp_factor_is_reported(self):
+        self._bind(FakeExtension(True, 10))
+
+        self.assertTrue(goby.time.using_sim_time())
+        self.assertEqual(goby.time.warp_factor(), 10)
+
+    def test_a_warp_factor_of_zero_does_not_divide_by_zero(self):
+        # warp_factor is an int in C++ and defaults to 1; a configuration setting it to 0 would
+        # otherwise make every period infinite
+        self._bind(FakeExtension(True, 0))
+
+        self.assertEqual(goby.time.warp_factor(), 1)
+        goby.time.sleep(0.001)
+
+    def test_monotonic_runs_warp_times_faster(self):
+        self._bind(FakeExtension(True, 10))
+
+        started = goby.time.monotonic()
+        wall.sleep(0.05)
+        elapsed = goby.time.monotonic() - started
+
+        # 0.05 wall seconds is half a simulated second at warp 10
+        self.assertGreater(elapsed, 0.25)
+
+    def test_now_matches_the_cxx_warp_formula(self):
+        # t_sim = (t - t0) * w + t0, as SystemClock::warp() computes it
+        reference = wall.time() - 100.0
+        self._bind(FakeExtension(True, 4, int(reference * 1e6)))
+
+        real = wall.time()
+        expected = (real - reference) * 4 + reference
+
+        self.assertAlmostEqual(goby.time.now(), expected, delta=0.5)
+
+    def test_now_is_ahead_of_the_wall_clock_under_warp(self):
+        reference = wall.time() - 10.0
+        self._bind(FakeExtension(True, 10, int(reference * 1e6)))
+
+        self.assertGreater(goby.time.now(), wall.time())
+
+    def test_sleep_is_divided_by_the_warp_factor(self):
+        self._bind(FakeExtension(True, 10))
+
+        started = wall.monotonic()
+        goby.time.sleep(0.2)
+        slept = wall.monotonic() - started
+
+        # a fifth of a simulated second is a fiftieth of a wall-clock one
+        self.assertLess(slept, 0.15)
+        self.assertGreater(slept, 0.005)
+
+    def test_sleep_of_zero_returns(self):
+        self._bind(FakeExtension(True, 10))
+        goby.time.sleep(0)
+        goby.time.sleep(-1)
+
+    def test_settings_are_read_once(self):
+        extension = FakeExtension(True, 10)
+        reads = []
+        original = extension._sim_time
+
+        def counting():
+            reads.append(None)
+            return original()
+
+        extension._sim_time = counting
+        self._bind(extension)
+
+        for _ in range(5):
+            goby.time.warp_factor()
+
+        self.assertEqual(len(reads), 1)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/src/test/python/test_app.py
+++ b/src/test/python/test_app.py
@@ -201,5 +201,126 @@ class SubscribeApiTest(unittest.TestCase):
             _callback_message_type(callback)
 
 
+class ExtensionBindingTest(unittest.TestCase):
+    """goby.time and goby.glog reach C++ through the extension the generated module binds."""
+
+    def test_importing_the_generated_module_binds_the_extension(self):
+        from goby import _runtime
+
+        self.assertIs(_runtime.extension(), app_module._ext)
+
+    def test_a_second_extension_is_refused(self):
+        from goby import _runtime
+
+        class Other:
+            __name__ = "_other_goby"
+
+        with self.assertRaisesRegex(RuntimeError, "one generated module"):
+            _runtime.bind(Other())
+
+
+class SimTimeTest(unittest.TestCase):
+    """The warp factor the C++ side read out of the configuration, as goby.time sees it."""
+
+    # goby::middleware::detail::configure_simulation_time() applies simulation settings when the
+    # configuration asks for them and otherwise leaves them alone, because an application
+    # configures once. So a process that has read one warped configuration stays warped, and the
+    # unwarped default is checked in the unit tests rather than here.
+
+    def setUp(self):
+        self.base = app_module.SingleThreadApplication._goby_ext._ApplicationBase
+        self.addCleanup(goby.time._reset_cache)
+
+    def test_the_configured_warp_factor_reaches_python(self):
+        self.base._configure_from_text(
+            "app { simulation { time { use_sim_time: true warp_factor: 10 } } }"
+        )
+        goby.time._reset_cache()
+
+        self.assertTrue(goby.time.using_sim_time())
+        self.assertEqual(goby.time.warp_factor(), 10)
+
+    def test_sleep_is_scaled_by_the_warp_factor(self):
+        import time as wall
+
+        self.base._configure_from_text(
+            "app { simulation { time { use_sim_time: true warp_factor: 20 } } }"
+        )
+        goby.time._reset_cache()
+
+        started = wall.monotonic()
+        goby.time.sleep(1.0)
+        slept = wall.monotonic() - started
+
+        # one simulated second at warp 20 is a twentieth of a wall-clock second
+        self.assertLess(slept, 0.5)
+
+    def test_monotonic_runs_at_the_configured_warp(self):
+        import time as wall
+
+        self.base._configure_from_text(
+            "app { simulation { time { use_sim_time: true warp_factor: 10 } } }"
+        )
+        goby.time._reset_cache()
+
+        started = goby.time.monotonic()
+        wall.sleep(0.05)
+        elapsed = goby.time.monotonic() - started
+
+        # what schedules loop(): 0.05 wall seconds is half a simulated second at warp 10
+        self.assertGreater(elapsed, 0.25)
+
+
+class GlogTest(unittest.TestCase):
+    """The bridge into goby::glog. The logger is configured when an application is built, so
+    these check the call reaches C++ rather than what lands in the log."""
+
+    def test_is_enabled_answers_from_cxx(self):
+        self.assertIn(goby.glog.is_enabled(goby.glog.WARN), (True, False))
+
+    def test_writing_before_an_application_exists_is_harmless(self):
+        goby.glog.warn("no application has been constructed yet")
+        goby.glog.verbose("nor here")
+
+    def test_a_group_can_be_declared(self):
+        goby.glog.add_group("test_group", "a group declared by the test")
+        goby.glog.verbose("into the group", group="test_group")
+
+    def test_logging_records_reach_glog(self):
+        import logging
+
+        logger = logging.getLogger("goby.test.python.glog")
+        logger.propagate = False
+        goby.glog.install(logger)
+        try:
+            logger.info("through the handler")
+            logger.warning("and a warning")
+        finally:
+            logger.handlers = []
+
+
+class ApiSurfaceTest(unittest.TestCase):
+    """What the generated base class offers. Constructing one needs a portal and a running
+    gobyd, so the behaviour behind these is tested against a stand-in base in the unit tests."""
+
+    def test_health_is_overridable_and_wired_to_cxx(self):
+        base = app_module.SingleThreadApplication
+        self.assertTrue(callable(base.health))
+        # the name the C++ trampoline looks up, which is what makes an override reachable
+        self.assertTrue(callable(base._goby_health))
+        self.assertIn("_goby_health", dir(base._goby_ext._ApplicationBase))
+
+    def test_the_loop_rate_can_be_changed(self):
+        base = app_module.SingleThreadApplication
+        self.assertTrue(callable(base.set_loop_frequency))
+        self.assertIsInstance(base.loop_frequency_hertz, property)
+        # the private C++ setter it drives, which threads also share
+        self.assertIn("_set_loop_frequency_hertz", dir(base._goby_ext._ApplicationBase))
+
+    def test_threads_have_the_same_two(self):
+        self.assertTrue(callable(app_module.Thread.health))
+        self.assertTrue(callable(app_module.Thread.set_loop_frequency))
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
Acts on five of the eight points in the jaiabot `task/3.y/goby-native-python` feedback — the ones that block or complicate porting the six Python sensor drivers off `jaiabot_udp_gateway`.

Three commits: the cross-build, the four runtime-API additions (which share one mechanism — the generated module binds its extension to the `goby` package as it is imported, so `goby.time` and `goby.glog` can reach C++ without an application instance), and a fix found by actually cross-compiling.

## 1. Cross-compiling (feedback #1, option b)

`GobyPython.cmake` skipped `find_package(Python3)` outright when `CMAKE_CROSSCOMPILING` was set without an emulator, so `goby_add_python_app()` could not run there at all.

Two Pythons are involved and they are not the same one. The generators (`goby_gen_cpp`, `protoc --python_out`) run at build time and need the **host's** interpreter; the extension is loaded by the **target's**, so it is compiled against the target's headers and named with the target's ABI suffix. Each is now found separately, and the module is built from `pybind11::headers` rather than `pybind11_add_module()`, which needs the Python search `PYBIND11_NOPYTHON` turns off. The generated launcher runs plain `python3` rather than the host's absolute path.

An extension module does not link `libpython` on Unix, so headers and the suffix are all that is needed. The version is chosen by what the **target** has — each candidate is accepted only when both `Python.h` and a matching architecture-dependent `pyconfig.h` are present — and the triplet comes from `CMAKE_LIBRARY_ARCHITECTURE`. Each piece is overridable (`GOBY_PYTHON_HOST_EXECUTABLE`, `GOBY_PYTHON_TARGET_VERSION`, `GOBY_PYTHON_TARGET_INCLUDE_DIRS`, `GOBY_PYTHON_TARGET_SOABI`). Installing `python3-dev:arm64` should be enough.

A missing architecture-dependent `pyconfig.h` **stops the build** rather than falling back to the shared `python3.X/pyconfig.h`, which belongs to the host and would silently produce a module for the wrong ABI.

This does not make the extension architecture-independent — `jaiabot-python` still cannot be `Architecture: all`. That was only ever true of feedback #1 option (a), which you asked me not to implement.

## 2. Warp-aware time (feedback #2)

`ApplicationMixin._goby_loop_due()` scheduled the user's `loop()` on `time.monotonic()` while riding a C++ loop that *is* warp-scaled, so under `warp_factor: 10` a 10 Hz loop fired at an effective 1 Hz. `ThreadRunner` had the same bug. Both now schedule on the simulated clock.

`goby.time` gives an application the same clock for its own waiting and timestamping:

```python
goby.time.sleep(0.5)      # half a simulated second: 50 ms of wall clock at warp 10
stamp = goby.time.now()   # as SystemClock::now() reports it
```

`monotonic()`, `warp_factor()` and `using_sim_time()` are also there. Outside simulation each is the standard library function, so driver code needs no branch. `now()` implements the same `t_sim = (t - t0) * w + t0` that `SystemClock::warp()` does, and there is a test pinning them together.

## 3. health() (feedback #3)

Overridable on applications and threads:

```python
def health(self, health) -> None:
    if not self.device.responding:
        health.state = coroner_pb2.HEALTH__FAILED
        health.error_message = "the I2C device is not answering"
```

It crosses the boundary as serialized Protobuf rather than a wrapped message, because the two descriptor pools are separate — so a `jaiabot_thread` extension that this process has no descriptor for survives the round trip as an unknown field instead of being dropped. There is a test that asserts exactly that. Python threads are reported as children, as a C++ `MultiThreadApplication` reports its own.

An application that neither overrides `health()` nor launches threads returns empty and Goby keeps its own report, so the common case costs one call and no protobuf work.

## 4. glog bridge (feedback #4)

```python
goby.glog.verbose("connected to the device")
goby.glog.warn(f"no reply in {timeout}s")
```

and, for code that already uses `logging`, the handler you asked for so nothing else changes:

```python
goby.glog.install()
logging.getLogger(__name__).info("connected to the device")
```

`WARNING` and above map to `WARN`, `INFO` to `VERBOSE`, `DEBUG` and below to `DEBUG1`-`DEBUG3`. **Nothing maps to `DIE`** — writing at that level terminates the application, which no log record should be able to do by accident; `goby.glog.die()` is there for when it is meant.

Two things worth noting in the C++: `goby::glog.is()` both tests the verbosity *and* opens the message at it, writing the prefix and taking the logger lock that the `endl` releases — so `is_enabled()` reads `FlexOStreamBuf::highest_verbosity()` directly rather than calling `is()`, which would take a lock nothing releases. The write releases the GIL, since the logger lock is process-wide and a C++ thread holding it may be waiting on the GIL.

## 5. Runtime loop-rate control (feedback #6)

`set_loop_frequency()` on applications and threads, for the commanded sample-rate change `IMUCommand.CONFIGURE` needs. It keeps the C++ loop running at least as fast as the threads are polled and gates the application's own `loop()` to the rate it asked for, so slowing the application below `interthread_poll_frequency_hertz` no longer starves its threads.

## Not implemented, as requested

#1 (runtime-registered interface, no compiled extension), #5 (stock config type), #7 (shared declarations across interface files).

## Deferred: units helpers (#8) — a plan

Not implemented; here is what I would do, for a separate change.

`set_pressure_raw_with_units()` comes from the `(dccl.field).units` options that `protobuf_generate_cpp_dccl` turns into generated C++ accessors. Python's `protoc --python_out` has no equivalent, but the options are on the field descriptor at runtime, so a helper can read them without any generator change:

```python
goby.units.set(msg, "pressure_raw", 1013.25, "millibar")
value = goby.units.get(msg, "pressure_raw", "dbar")
```

Sketch:

1. **Read the declaration.** `msg.DESCRIPTOR.fields_by_name["pressure_raw"].GetOptions().Extensions[option_extensions_pb2.field]` gives the `units` submessage — `base_dimensions` (e.g. `"LT^-2M^-1"`), `derived_dimensions` (`"pressure"`), `system`, `prefix` and `unit`. That is the same source the C++ accessors are generated from, so the two sides cannot drift.
2. **Convert.** `pint` is the obvious backend and is already packaged everywhere (`python3-pint`), but it would be the `goby` package's first non-protobuf runtime dependency — so I would put it behind an extra (`pip install goby3[units]`) and raise a clear error when a conversion is asked for without it, the way `jsonschema` is optional for `interface.yml` validation today.
3. **Fail loudly on a mismatch.** Converting between incompatible dimensions, or setting a field that declares no units, should raise rather than silently pass the number through — the whole point is catching the class of bug the gateway's fixup was compensating for.
4. **Scope.** Scalar fields first; repeated fields and `Timestamp`-style conversions only if something needs them.

Worth saying plainly: for the Bar30 case in the plan this helper is not what unblocks you. The driver already reads millibar and Celsius, the `.proto` declares millibar and Celsius, and the gateway's `set_pressure_raw_with_units()` applies no scaling — so deleting that call and setting the fields directly is correct today, with or without `goby.units`. The helper is worth having as a guard against the next field whose declared unit is not the one the sensor reports.

## Testing

**Native.** `goby_test_python_unit` (108 tests) covers the warp arithmetic against the C++ formula, a 10 Hz loop keeping its rate under warp 10, the `ThreadHealth` round trip preserving an unknown extension, thread children, and the `logging` level mapping. `goby_test_python_app` (35) runs against the compiled extension — the binding, the configured warp factor reaching `goby.time`, the glog entry points, the API surface. `goby_test_julia_app` unchanged. All passing.

**Cross-compiled, for real.** An `aarch64-linux-gnu` toolchain plus arm64 `libgoby3-dev` and `python3-dev` from `packages.gobysoft.org` and `ports.ubuntu.com`, laid out the way `dpkg-buildpackage -a arm64` lays them out — multiarch on one filesystem, no sysroot — and then the goby3-examples Python publisher and subscriber built through `goby_add_python_app()`:

```
_basic_python_publisher_goby.cpython-312-aarch64-linux-gnu.so:
  ELF 64-bit LSB shared object, ARM aarch64, version 1 (GNU/Linux), dynamically linked
  NEEDED  libgoby_zeromq.so.30, libgoby.so.30, libzmq.so.5, libprotobuf.so.32, libdccl.so.31
```

Host `goby_gen_cpp` and `protoc --python_out` ran, the glue compiled with the cross compiler, the suffix is the target's, and the launcher runs plain `python3`.

That run is what found the third commit: the host here is Python 3.11 and the target 3.12, so preferring the host's version looked for `aarch64-linux-gnu/python3.11/pyconfig.h` and stopped. It stopped with a diagnostic rather than building against the host's header — the safety property held — but the version is now chosen from what the target actually has.

The detection was also checked against a pinned version the target lacks, and a triplet with no Python headers at all; both report what they looked for.